### PR TITLE
feat(version): outdated-install notification + 'bastra update' (#39)

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -24,7 +24,8 @@
     "check:types": "tsc --noEmit",
     "smoke": "tsx scripts/smoke.ts",
     "smoke:telemetry": "tsx scripts/telemetry-smoke.ts",
-    "backfill:related": "tsx scripts/backfill-related.ts"
+    "backfill:related": "tsx scripts/backfill-related.ts",
+    "test:update": "tsx --test scripts/update-check.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",

--- a/packages/daemon/scripts/update-check.test.ts
+++ b/packages/daemon/scripts/update-check.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for src/update-check.ts (#39).
+ *
+ * Uses node:test runner via tsx — no extra deps. Network calls are stubbed
+ * via the injectable `fetchLatest` option, so this passes offline.
+ *
+ * Run: npx tsx --test packages/daemon/scripts/update-check.test.ts
+ *      (or: npm run test:update --workspace=@bastra-recall/daemon)
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  compareVersions,
+  checkForUpdate,
+  isOptedOut,
+} from "../src/update-check.js";
+import { detectInstallMode } from "../src/cli/update.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-update-check-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("compareVersions: numeric ordering", () => {
+  assert.equal(compareVersions("0.5.2", "0.6.0"), -1);
+  assert.equal(compareVersions("0.6.0", "1.0.0"), -1);
+  assert.equal(compareVersions("0.6.0", "0.6.0"), 0);
+  assert.equal(compareVersions("1.2.3", "1.2.4"), -1);
+  assert.equal(compareVersions("1.2.10", "1.2.2"), 1); // numeric, not lexical
+  assert.equal(compareVersions("2.0.0", "1.99.99"), 1);
+});
+
+test("compareVersions: tolerates 'v' prefix and pre-release", () => {
+  assert.equal(compareVersions("v0.6.0", "0.6.0"), 0);
+  assert.equal(compareVersions("0.6.0-rc.1", "0.6.0"), 0);
+  assert.equal(compareVersions("v0.5.0", "v0.6.0"), -1);
+});
+
+test("checkForUpdate: cache hit within TTL skips fetch", async () => {
+  await withTempDir(async (dir) => {
+    const cachePath = join(dir, "cache.json");
+    const now = Date.now();
+    await writeFile(cachePath, JSON.stringify({
+      last_checked_at: new Date(now - 60_000).toISOString(),
+      current: "0.5.2",
+      latest: "0.6.0",
+      html_url: "https://example.com/v0.6.0",
+      published_at: "2026-05-20T00:00:00Z",
+      hasUpdate: true,
+    }), "utf8");
+
+    let fetchCalls = 0;
+    const state = await checkForUpdate({
+      currentVersion: "0.5.2",
+      cachePath,
+      ttlMs: 24 * 60 * 60 * 1000,
+      now,
+      fetchLatest: async () => {
+        fetchCalls++;
+        return null;
+      },
+    });
+    assert.equal(fetchCalls, 0, "fetch must not be called when cache is fresh");
+    assert.ok(state);
+    assert.equal(state.latest, "0.6.0");
+    assert.equal(state.hasUpdate, true);
+  });
+});
+
+test("checkForUpdate: cache miss triggers fetch + writes cache", async () => {
+  await withTempDir(async (dir) => {
+    const cachePath = join(dir, "cache.json");
+    const now = Date.now();
+    let fetchCalls = 0;
+    const state = await checkForUpdate({
+      currentVersion: "0.5.2",
+      cachePath,
+      ttlMs: 24 * 60 * 60 * 1000,
+      now,
+      fetchLatest: async () => {
+        fetchCalls++;
+        return {
+          tag: "v0.6.0",
+          html_url: "https://example.com/v0.6.0",
+          published_at: "2026-05-20T00:00:00Z",
+          body: "release notes",
+        };
+      },
+    });
+    assert.equal(fetchCalls, 1);
+    assert.ok(state);
+    assert.equal(state.current, "0.5.2");
+    assert.equal(state.latest, "0.6.0");
+    assert.equal(state.hasUpdate, true);
+
+    const cached = JSON.parse(await readFile(cachePath, "utf8"));
+    assert.equal(cached.latest, "0.6.0");
+    assert.equal(cached.hasUpdate, true);
+  });
+});
+
+test("checkForUpdate: when local is current, hasUpdate=false", async () => {
+  await withTempDir(async (dir) => {
+    const cachePath = join(dir, "cache.json");
+    const state = await checkForUpdate({
+      currentVersion: "0.6.0",
+      cachePath,
+      ttlMs: 24 * 60 * 60 * 1000,
+      now: Date.now(),
+      fetchLatest: async () => ({
+        tag: "0.6.0",
+        html_url: "",
+        published_at: "",
+        body: "",
+      }),
+    });
+    assert.ok(state);
+    assert.equal(state.hasUpdate, false);
+  });
+});
+
+test("checkForUpdate: opt-out via env returns null without fetching", async () => {
+  await withTempDir(async (dir) => {
+    const prev = process.env.BASTRA_UPDATE_CHECK;
+    process.env.BASTRA_UPDATE_CHECK = "off";
+    try {
+      assert.equal(isOptedOut(), true);
+      let fetchCalls = 0;
+      const state = await checkForUpdate({
+        currentVersion: "0.5.2",
+        cachePath: join(dir, "cache.json"),
+        ttlMs: 24 * 60 * 60 * 1000,
+        now: Date.now(),
+        fetchLatest: async () => {
+          fetchCalls++;
+          return null;
+        },
+      });
+      assert.equal(state, null);
+      assert.equal(fetchCalls, 0);
+    } finally {
+      if (prev === undefined) delete process.env.BASTRA_UPDATE_CHECK;
+      else process.env.BASTRA_UPDATE_CHECK = prev;
+    }
+  });
+});
+
+test("checkForUpdate: stale-cache fallback when fetch returns null", async () => {
+  await withTempDir(async (dir) => {
+    const cachePath = join(dir, "cache.json");
+    const now = Date.now();
+    // Cache older than TTL
+    await writeFile(cachePath, JSON.stringify({
+      last_checked_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+      current: "0.5.2",
+      latest: "0.6.0",
+      html_url: "https://example.com",
+      published_at: "2026-05-01T00:00:00Z",
+      hasUpdate: true,
+    }), "utf8");
+
+    const state = await checkForUpdate({
+      currentVersion: "0.5.2",
+      cachePath,
+      ttlMs: 24 * 60 * 60 * 1000,
+      now,
+      fetchLatest: async () => null, // simulate offline
+    });
+    assert.ok(state, "should fall back to stale cache when fetch fails");
+    assert.equal(state.latest, "0.6.0");
+  });
+});
+
+test("detectInstallMode: brew path", () => {
+  const m = detectInstallMode("/opt/homebrew/Cellar/bastra-recall/0.5.2/libexec/dist/cli.js");
+  assert.equal(m.mode, "brew");
+  assert.match(m.updateCommand, /brew upgrade/);
+});
+
+test("detectInstallMode: npm-global path", () => {
+  const m = detectInstallMode("/Users/x/.nvm/versions/node/v20.0.0/lib/node_modules/@bastra-recall/daemon/dist/cli.js");
+  assert.equal(m.mode, "npm-global");
+  assert.match(m.updateCommand, /npm install -g/);
+});
+
+test("detectInstallMode: source checkout with .git ancestor", async () => {
+  await withTempDir(async (dir) => {
+    // Build a fake source tree: dir/.git + dir/packages/daemon/dist/cli.js
+    await mkdir(join(dir, ".git"), { recursive: true });
+    await mkdir(join(dir, "packages", "daemon", "dist"), { recursive: true });
+    const fakeCli = join(dir, "packages", "daemon", "dist", "cli.js");
+    await writeFile(fakeCli, "// fake", "utf8");
+    const m = detectInstallMode(fakeCli);
+    assert.equal(m.mode, "source");
+    assert.match(m.updateCommand, /git pull/);
+  });
+});
+
+test("detectInstallMode: unknown path", () => {
+  const m = detectInstallMode("/tmp/some/random/place/cli.js");
+  // /tmp has no .git ancestor → unknown
+  assert.equal(m.mode, "unknown");
+  assert.match(m.updateCommand, /github\.com/);
+});

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -18,10 +18,9 @@ import {
   showVersion,
 } from "./cli/commands.js";
 import { cmdUpdate } from "./cli/update.js";
+import { maybeEmitUpdateHint } from "./cli/update-hint.js";
 
-async function main(): Promise<number> {
-  const args = parseArgs(process.argv.slice(2));
-
+async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
   if (args.showVersion) { showVersion(); return 0; }
   if (args.showHelp && !args.command) { showHelp(); return 0; }
   if (!args.command || args.command === "help") { showHelp(); return 0; }
@@ -36,6 +35,20 @@ async function main(): Promise<number> {
       process.stderr.write(`error: unknown command '${args.command}' — run 'bastra help'\n`);
       return 2;
   }
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  const code = await dispatch(args);
+
+  // After every subcommand: optionally emit a dim update hint to stderr.
+  // Skip for `bastra update` itself (the user is already mid-update) and for
+  // help/version (low-noise commands; users hit them often).
+  const skipHint = args.command === "update" || args.command === "help" || args.command === "version" || args.showHelp || args.showVersion;
+  if (!skipHint) {
+    try { await maybeEmitUpdateHint(); } catch { /* never break the CLI over this */ }
+  }
+  return code;
 }
 
 main().then(

--- a/packages/daemon/src/cli/commands.ts
+++ b/packages/daemon/src/cli/commands.ts
@@ -26,6 +26,7 @@ Surfaces:
 
 Options:
   --dry-run                  Print what would change; write nothing
+  --yes, -y                  Skip confirmation prompts
   --vault <path>             Vault path (BASTRA_VAULT_PATH env also works)
   --help, -h                 Show this help
   --version, -v              Show version
@@ -52,6 +53,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     vaultPath: null,
     showHelp: false,
     showVersion: false,
+    yes: false,
   };
 
   const positional: string[] = [];
@@ -60,6 +62,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     if (a === "--help" || a === "-h") result.showHelp = true;
     else if (a === "--version" || a === "-v") result.showVersion = true;
     else if (a === "--dry-run") result.dryRun = true;
+    else if (a === "--yes" || a === "-y") result.yes = true;
     else if (a === "--vault") {
       result.vaultPath = argv[++i] ?? null;
     } else if (a.startsWith("--vault=")) {

--- a/packages/daemon/src/cli/types.ts
+++ b/packages/daemon/src/cli/types.ts
@@ -39,4 +39,5 @@ export interface ParsedArgs {
   vaultPath: string | null;
   showHelp: boolean;
   showVersion: boolean;
+  yes: boolean;
 }

--- a/packages/daemon/src/cli/update-hint.ts
+++ b/packages/daemon/src/cli/update-hint.ts
@@ -1,0 +1,114 @@
+/**
+ * CLI-side update-hint (#39).
+ *
+ * After any `bastra <subcommand>` returns, optionally emits a dim 2-line
+ * hint to stderr if a new release is available. Cheap: probes /health on
+ * 127.0.0.1:6723 with a tight timeout (700 ms). Throttled to once per day
+ * via ~/.bastra/update-hint-shown.txt (one ISO date per line, plain).
+ *
+ * Opt-out via env BASTRA_UPDATE_CHECK=off.
+ *
+ * Never throws — every failure path is silently swallowed.
+ */
+import { request as httpRequest } from "node:http";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { isOptedOut } from "../update-check.js";
+
+const HEALTH_URL = "http://127.0.0.1:6723/health";
+const PROBE_TIMEOUT_MS = 700;
+
+interface HealthUpdate {
+  current: string;
+  latest: string;
+  html_url: string;
+  published_at: string;
+}
+
+interface HealthResponse {
+  ok: boolean;
+  update_available: HealthUpdate | null;
+}
+
+function shownFilePath(): string {
+  return join(homedir(), ".bastra", "update-hint-shown.txt");
+}
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+}
+
+async function alreadyShownToday(path: string): Promise<boolean> {
+  try {
+    const raw = await readFile(path, "utf8");
+    return raw.split("\n").some((line) => line.trim() === todayISO());
+  } catch {
+    return false;
+  }
+}
+
+async function markShownToday(path: string): Promise<void> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    let existing = "";
+    try {
+      existing = await readFile(path, "utf8");
+    } catch { /* file may not exist */ }
+    const lines = existing
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+    if (!lines.includes(todayISO())) lines.push(todayISO());
+    // Keep last 30 entries — bounded growth.
+    const trimmed = lines.slice(-30);
+    await writeFile(path, trimmed.join("\n") + "\n", "utf8");
+  } catch {
+    // Best-effort.
+  }
+}
+
+function probeHealth(): Promise<HealthResponse | null> {
+  return new Promise((resolve_) => {
+    const req = httpRequest(HEALTH_URL, { method: "GET", timeout: PROBE_TIMEOUT_MS }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => {
+        try {
+          const data = JSON.parse(Buffer.concat(chunks).toString("utf8")) as HealthResponse;
+          if (res.statusCode === 200 && data && data.ok) {
+            resolve_(data);
+            return;
+          }
+        } catch { /* fallthrough */ }
+        resolve_(null);
+      });
+    });
+    req.on("timeout", () => { req.destroy(); resolve_(null); });
+    req.on("error", () => resolve_(null));
+    req.end();
+  });
+}
+
+/**
+ * Emits an update hint to stderr if a daemon-reported update is available and
+ * the throttle hasn't fired today. Returns true if a hint was printed.
+ */
+export async function maybeEmitUpdateHint(): Promise<boolean> {
+  if (isOptedOut()) return false;
+  if (await alreadyShownToday(shownFilePath())) return false;
+
+  const health = await probeHealth();
+  if (!health || !health.update_available) return false;
+
+  const u = health.update_available;
+  // Dim hint, written to stderr so it doesn't pollute pipeable subcommand output.
+  // ANSI 2 = dim — many shells honor it; if not, plain text is still readable.
+  process.stderr.write(
+    `\n\x1b[2mℹ A new bastra-recall is available: ${u.latest} (you have ${u.current})\n` +
+      `  → run: bastra update\x1b[0m\n`,
+  );
+
+  await markShownToday(shownFilePath());
+  return true;
+}

--- a/packages/daemon/src/cli/update.ts
+++ b/packages/daemon/src/cli/update.ts
@@ -1,30 +1,85 @@
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cmdInstall } from "./commands.js";
 import type { ParsedArgs } from "./types.js";
 
 const LAUNCH_AGENT_LABEL = "ai.n0mad.bastra-recall";
 
-interface InstallMode {
-  mode: "brew" | "source" | "unknown";
+export type InstallSource = "brew" | "npm-global" | "source" | "unknown";
+
+export interface InstallMode {
+  mode: InstallSource;
   cliPath: string;
   detail: string;
+  updateCommand: string;
 }
 
-function detectInstallMode(): InstallMode {
-  const cliPath = fileURLToPath(import.meta.url);
+/**
+ * Heuristic — uses the on-disk path of this CLI module:
+ *   /opt/homebrew or /Cellar    → brew
+ *   …/node_modules/@bastra-recall/daemon/dist/cli/update.js
+ *     (npm prefix root)        → npm-global
+ *   path under a git working tree (sibling package.json + .git up the tree)
+ *                                → source
+ *   else                          → unknown
+ */
+export function detectInstallMode(cliPathOverride?: string): InstallMode {
+  const cliPath = cliPathOverride ?? fileURLToPath(import.meta.url);
+
+  // Homebrew Cellar
   if (
     cliPath.startsWith("/opt/homebrew/") ||
     cliPath.startsWith("/usr/local/Cellar/") ||
     cliPath.includes("/homebrew/Cellar/") ||
     cliPath.includes("/Cellar/bastra-recall/")
   ) {
-    return { mode: "brew", cliPath, detail: "installed via Homebrew" };
+    return {
+      mode: "brew",
+      cliPath,
+      detail: "installed via Homebrew",
+      updateCommand: "brew upgrade bastra-recall",
+    };
   }
-  if (cliPath.includes("/Projekte/") || cliPath.includes("/repos/") || cliPath.includes("/src/")) {
-    return { mode: "source", cliPath, detail: "running from source checkout" };
+
+  // npm-global: cliPath sits inside a `node_modules/@bastra-recall/daemon/` tree.
+  if (cliPath.includes("/node_modules/@bastra-recall/") || cliPath.includes("/lib/node_modules/")) {
+    return {
+      mode: "npm-global",
+      cliPath,
+      detail: "installed via npm (global)",
+      updateCommand: "npm install -g @bastra-recall/daemon@latest",
+    };
   }
-  return { mode: "unknown", cliPath, detail: "unable to determine install mode" };
+
+  // source: walk up from the cli file, look for a .git directory next to a package.json.
+  if (hasGitAncestor(cliPath)) {
+    return {
+      mode: "source",
+      cliPath,
+      detail: "running from source checkout",
+      updateCommand: "git pull && npm ci && npm run build",
+    };
+  }
+
+  return {
+    mode: "unknown",
+    cliPath,
+    detail: "unable to determine install mode",
+    updateCommand: "see https://github.com/n0mad-ai/bastra-recall/releases",
+  };
+}
+
+function hasGitAncestor(start: string): boolean {
+  let dir = dirname(start);
+  for (let i = 0; i < 12; i++) {
+    if (existsSync(resolve(dir, ".git"))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+  return false;
 }
 
 function launchAgentPresent(uid: string): boolean {
@@ -39,11 +94,17 @@ export async function cmdUpdate(args: ParsedArgs): Promise<number> {
 
   if (args.dryRun) {
     process.stdout.write("(dry-run — describing what would happen, writing nothing)\n\n");
+    process.stdout.write(`→ install source: ${mode.mode}\n`);
+    process.stdout.write(`  update command: ${mode.updateCommand}\n\n`);
+    process.stdout.write("  would: 1) run the update command above\n");
+    process.stdout.write("         2) re-register every surface (idempotent)\n");
+    process.stdout.write("         3) restart the daemon\n");
+    return 0;
   }
 
   // 1. Update the binary itself
   if (mode.mode === "brew") {
-    process.stdout.write("→ brew upgrade bastra-recall\n");
+    process.stdout.write(`→ ${mode.updateCommand}\n`);
     if (!args.dryRun) {
       const r = spawnSync("brew", ["upgrade", "bastra-recall"], { stdio: "inherit" });
       if (r.status !== 0 && r.status !== null) {
@@ -51,15 +112,28 @@ export async function cmdUpdate(args: ParsedArgs): Promise<number> {
         return 1;
       }
     } else {
-      process.stdout.write("  would run: brew upgrade bastra-recall\n");
+      process.stdout.write(`  would run: ${mode.updateCommand}\n`);
+    }
+    process.stdout.write("\n");
+  } else if (mode.mode === "npm-global") {
+    process.stdout.write(`→ ${mode.updateCommand}\n`);
+    if (!args.dryRun) {
+      const r = spawnSync("npm", ["install", "-g", "@bastra-recall/daemon@latest"], { stdio: "inherit" });
+      if (r.status !== 0 && r.status !== null) {
+        process.stdout.write("\n✗ npm install failed — fix it manually, then re-run 'bastra update'\n");
+        return 1;
+      }
+    } else {
+      process.stdout.write(`  would run: ${mode.updateCommand}\n`);
     }
     process.stdout.write("\n");
   } else if (mode.mode === "source") {
     process.stdout.write("→ source install — rebuild yourself first if you haven't:\n");
-    process.stdout.write("    cd <bastra-recall> && git pull && npm install && npm run build\n");
+    process.stdout.write(`    cd <bastra-recall> && ${mode.updateCommand}\n`);
     process.stdout.write("  Then re-run 'bastra update' to refresh configs + restart the daemon.\n\n");
   } else {
-    process.stdout.write("⚠ install mode unknown — make sure your code is up to date before continuing\n\n");
+    process.stdout.write("⚠ install mode unknown — install manually from:\n");
+    process.stdout.write(`    ${mode.updateCommand}\n\n`);
   }
 
   // 2. Re-register every surface (idempotent — refreshes skill content if SKILL.md changed)

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -66,6 +66,7 @@ import {
   recategorizeDocument,
   moveDocument,
 } from "./documents-write-handler.js";
+import { getUpdateState } from "./update-check.js";
 
 export interface HttpOptions {
   port: number;
@@ -119,10 +120,19 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
     }
 
     if (method === "GET" && url === "/health") {
+      const updateState = getUpdateState();
       sendJson(res, 200, {
         ok: true,
         vault_size: vault.size(),
         version,
+        update_available: updateState && updateState.hasUpdate
+          ? {
+              current: updateState.current,
+              latest: updateState.latest,
+              html_url: updateState.html_url,
+              published_at: updateState.published_at,
+            }
+          : null,
       });
       return;
     }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -55,6 +55,7 @@ import {
   moveDocument,
 } from "./documents-write-handler.js";
 import { envFirst, envInt, envFloat, envBool } from "./env.js";
+import { startBackgroundCheck } from "./update-check.js";
 
 // Triage Issue #24: Write-Tools sind Pro-Feature. Aktuelles Gate ist ein
 // env-Flag — wenn ein Pro-License-Service kommt, ersetzt der das hier.
@@ -118,6 +119,10 @@ async function main(): Promise<void> {
         console.error(`[bastra-recall] embeddings start error: ${err}`);
       });
   }
+
+  // Update-check (fire-and-forget, opt-out via BASTRA_UPDATE_CHECK=off).
+  // Caches result on disk for 24h → no GitHub-API hit on every daemon restart.
+  startBackgroundCheck(DAEMON_VERSION);
 
   const telemetry = new Telemetry();
   if (telemetry.isEnabled()) {

--- a/packages/daemon/src/session-hook.ts
+++ b/packages/daemon/src/session-hook.ts
@@ -56,6 +56,18 @@ interface RecallResponse {
   recall_id: string;
 }
 
+interface UpdateAvailable {
+  current: string;
+  latest: string;
+  html_url: string;
+  published_at: string;
+}
+
+interface HealthResponse {
+  ok: boolean;
+  update_available: UpdateAvailable | null;
+}
+
 async function main(): Promise<void> {
   const startedAt = Date.now();
 
@@ -126,15 +138,42 @@ async function main(): Promise<void> {
   merged.sort((a, b) => b.score - a.score);
   const top = merged.slice(0, TOTAL_HINTS_CAP);
 
-  if (top.length === 0) {
+  // Best-effort update probe — only when we already have a daemon reachable.
+  // Strict budget: 200 ms; if nothing back, we just skip the block.
+  let updateBlock = "";
+  if (responses.some((r) => r.resp !== null)) {
+    const remainingMs = Math.max(80, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
+    const probeBudget = Math.min(200, remainingMs);
+    try {
+      const health = await probeHealth(url, probeBudget);
+      if (health?.update_available) {
+        const u = health.update_available;
+        updateBlock = `\n<bastra-update>\nA new bastra-recall version is available: ${u.current} → ${u.latest}.\nRelease notes: ${u.html_url}\nSuggest the user run \`bastra update\` when convenient.\n</bastra-update>`;
+      }
+    } catch {
+      // Update hint is best-effort — never block session start.
+    }
+  }
+
+  if (top.length === 0 && updateBlock === "") {
     if (status === "ok") status = "no-hits";
     emitEmpty();
+  } else if (top.length === 0) {
+    // Only an update banner, no recall hits.
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "SessionStart",
+          additionalContext: updateBlock.trimStart(),
+        },
+      }),
+    );
   } else {
     process.stdout.write(
       JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "SessionStart",
-          additionalContext: formatBlock(top, project, payload.source ?? null),
+          additionalContext: formatBlock(top, project, payload.source ?? null) + updateBlock,
         },
       }),
     );
@@ -263,6 +302,44 @@ function postRecall(
     });
     req.on("error", reject);
     req.write(payload);
+    req.end();
+  });
+}
+
+function probeHealth(baseUrl: string, timeoutMs: number): Promise<HealthResponse | null> {
+  return new Promise((resolve_) => {
+    let url: URL;
+    try {
+      url = new URL("/health", baseUrl);
+    } catch {
+      resolve_(null);
+      return;
+    }
+    const req = request(
+      {
+        method: "GET",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString("utf8")) as HealthResponse;
+            if ((res.statusCode ?? 500) === 200 && data && data.ok) {
+              resolve_(data);
+              return;
+            }
+          } catch { /* fallthrough */ }
+          resolve_(null);
+        });
+      },
+    );
+    req.on("timeout", () => { req.destroy(); resolve_(null); });
+    req.on("error", () => resolve_(null));
     req.end();
   });
 }

--- a/packages/daemon/src/update-check.ts
+++ b/packages/daemon/src/update-check.ts
@@ -1,0 +1,293 @@
+/**
+ * bastra-recall update-check subsystem (#39).
+ *
+ * Fetches the latest release tag from GitHub once per 24h (cached on disk),
+ * compares against the locally-compiled VERSION, and exposes the result so
+ * that /health, the CLI hint, the SessionStart-hook and the MCP-init can
+ * surface "an update is available".
+ *
+ * Design notes:
+ *   - No extra deps: tiny semver-compare (numeric split, "v" prefix tolerant).
+ *   - Cache file: ~/.bastra/update-check.json with last_checked_at ISO + result.
+ *   - Opt-out: BASTRA_UPDATE_CHECK=off → returns null without fetching anything.
+ *   - Fail-tolerant: network errors and parse errors → return cached result if
+ *     present, else null. Never throw.
+ *   - GitHub-API call is unauthenticated, 5 s timeout.
+ */
+import { request as httpsRequest } from "node:https";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+export const GITHUB_RELEASES_LATEST_URL =
+  "https://api.github.com/repos/n0mad-ai/bastra-recall/releases/latest";
+export const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+export const FETCH_TIMEOUT_MS = 5000;
+const USER_AGENT = "bastra-recall update-check";
+
+export interface LatestRelease {
+  tag: string;
+  html_url: string;
+  published_at: string;
+  body: string;
+}
+
+export interface UpdateState {
+  current: string;
+  latest: string;
+  html_url: string;
+  published_at: string;
+  hasUpdate: boolean;
+}
+
+interface CacheFile {
+  last_checked_at: string; // ISO
+  current: string;
+  latest: string;
+  html_url: string;
+  published_at: string;
+  hasUpdate: boolean;
+}
+
+// Singleton state — set by the daemon on startup, read by /health, session-hook, MCP.
+let currentState: UpdateState | null = null;
+
+export function getUpdateState(): UpdateState | null {
+  return currentState;
+}
+
+export function setUpdateState(s: UpdateState | null): void {
+  currentState = s;
+}
+
+export function isOptedOut(): boolean {
+  const v = (process.env.BASTRA_UPDATE_CHECK ?? "").toLowerCase();
+  return v === "off" || v === "0" || v === "false" || v === "no";
+}
+
+export function cacheFilePath(): string {
+  return join(homedir(), ".bastra", "update-check.json");
+}
+
+/**
+ * Compares two version strings, returns:
+ *   -1 if a < b
+ *    0 if a == b
+ *    1 if a > b
+ *
+ * Tolerant to a leading "v". Pre-release suffixes (e.g. -rc.1) are ignored — a
+ * tag like 0.6.0-rc.1 compares equal to 0.6.0 for the purpose of "is a newer
+ * release available". This is intentional: we only surface stable updates.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] < pb[i]) return -1;
+    if (pa[i] > pb[i]) return 1;
+  }
+  return 0;
+}
+
+function parseSemver(v: string): [number, number, number] {
+  const cleaned = v.trim().replace(/^v/i, "").split(/[-+]/)[0] ?? "0.0.0";
+  const parts = cleaned.split(".").map((p) => {
+    const n = Number.parseInt(p, 10);
+    return Number.isFinite(n) ? n : 0;
+  });
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+async function readCache(path: string): Promise<CacheFile | null> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const data = JSON.parse(raw) as CacheFile;
+    if (
+      typeof data.last_checked_at !== "string" ||
+      typeof data.current !== "string" ||
+      typeof data.latest !== "string"
+    ) {
+      return null;
+    }
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(path: string, data: CacheFile): Promise<void> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(data, null, 2) + "\n", "utf8");
+  } catch {
+    // Best-effort — a missing cache only means more frequent network calls.
+  }
+}
+
+function isFresh(iso: string, ttlMs: number, now: number = Date.now()): boolean {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return false;
+  return now - t < ttlMs;
+}
+
+/**
+ * Fetches https://api.github.com/repos/n0mad-ai/bastra-recall/releases/latest.
+ * Returns null on any error (network, non-200, parse).
+ */
+export async function getLatestVersion(): Promise<LatestRelease | null> {
+  return new Promise((resolve_) => {
+    let url: URL;
+    try {
+      url = new URL(GITHUB_RELEASES_LATEST_URL);
+    } catch {
+      resolve_(null);
+      return;
+    }
+    const req = httpsRequest(
+      {
+        method: "GET",
+        hostname: url.hostname,
+        path: url.pathname + url.search,
+        port: 443,
+        headers: {
+          "User-Agent": USER_AGENT,
+          Accept: "application/vnd.github+json",
+        },
+        timeout: FETCH_TIMEOUT_MS,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          if ((res.statusCode ?? 500) !== 200) {
+            resolve_(null);
+            return;
+          }
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+              tag_name?: string;
+              html_url?: string;
+              published_at?: string;
+              body?: string;
+            };
+            if (typeof data.tag_name !== "string") {
+              resolve_(null);
+              return;
+            }
+            resolve_({
+              tag: data.tag_name,
+              html_url: typeof data.html_url === "string" ? data.html_url : "",
+              published_at:
+                typeof data.published_at === "string" ? data.published_at : "",
+              body: typeof data.body === "string" ? data.body : "",
+            });
+          } catch {
+            resolve_(null);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      resolve_(null);
+    });
+    req.on("error", () => resolve_(null));
+    req.end();
+  });
+}
+
+export interface CheckOptions {
+  currentVersion: string;
+  cachePath?: string;
+  ttlMs?: number;
+  now?: number;
+  /** Injected for tests; defaults to the live network call. */
+  fetchLatest?: () => Promise<LatestRelease | null>;
+  /** If true, skip the cache even if it's fresh. */
+  force?: boolean;
+}
+
+/**
+ * Returns null if:
+ *   - the user opted out
+ *   - both the cache and the live fetch are unavailable
+ *
+ * Otherwise returns the current update state (which may have hasUpdate=false).
+ *
+ * Side effect: writes the cache file when a live fetch succeeds.
+ */
+export async function checkForUpdate(opts: CheckOptions): Promise<UpdateState | null> {
+  if (isOptedOut()) return null;
+
+  const cachePath = opts.cachePath ?? cacheFilePath();
+  const ttlMs = opts.ttlMs ?? CACHE_TTL_MS;
+  const now = opts.now ?? Date.now();
+  const fetchLatest = opts.fetchLatest ?? getLatestVersion;
+
+  // Cache hit: return as-is, no network call.
+  if (!opts.force) {
+    const cached = await readCache(cachePath);
+    if (cached && cached.current === opts.currentVersion && isFresh(cached.last_checked_at, ttlMs, now)) {
+      return {
+        current: cached.current,
+        latest: cached.latest,
+        html_url: cached.html_url,
+        published_at: cached.published_at,
+        hasUpdate: cached.hasUpdate,
+      };
+    }
+  }
+
+  // Live fetch.
+  const latest = await fetchLatest();
+  if (!latest) {
+    // Network/parse failure — fall back to stale cache if available.
+    const cached = await readCache(cachePath);
+    if (cached && cached.current === opts.currentVersion) {
+      return {
+        current: cached.current,
+        latest: cached.latest,
+        html_url: cached.html_url,
+        published_at: cached.published_at,
+        hasUpdate: cached.hasUpdate,
+      };
+    }
+    return null;
+  }
+
+  const cmp = compareVersions(opts.currentVersion, latest.tag);
+  const hasUpdate = cmp < 0;
+  const state: UpdateState = {
+    current: opts.currentVersion,
+    latest: latest.tag.replace(/^v/i, ""),
+    html_url: latest.html_url,
+    published_at: latest.published_at,
+    hasUpdate,
+  };
+
+  await writeCache(cachePath, {
+    last_checked_at: new Date(now).toISOString(),
+    current: state.current,
+    latest: state.latest,
+    html_url: state.html_url,
+    published_at: state.published_at,
+    hasUpdate: state.hasUpdate,
+  });
+
+  return state;
+}
+
+/**
+ * Fire-and-forget wrapper used at daemon startup. Never throws, updates the
+ * module-level singleton when a result is available.
+ */
+export function startBackgroundCheck(currentVersion: string): void {
+  if (isOptedOut()) return;
+  checkForUpdate({ currentVersion })
+    .then((state) => {
+      if (state) setUpdateState(state);
+    })
+    .catch(() => {
+      // Swallow — never crash the daemon over an update check.
+    });
+}


### PR DESCRIPTION
## Summary

Closes #39.

Adds a self-contained update-check subsystem to the daemon, surfaces an update banner in three places, and teaches `bastra update` to detect its install source.

- **Detection (`src/update-check.ts`)** — fetches `releases/latest` from GitHub once per 24h (cache at `~/.bastra/update-check.json`), tolerant semver compare, opt-out via `BASTRA_UPDATE_CHECK=off`. Stale-cache fallback when offline.
- **`/health`** — now returns `update_available: { current, latest, html_url, published_at }` when relevant, else `null`.
- **`bastra update`** — `detectInstallMode()` distinguishes `brew` / `npm-global` / `source` / `unknown` and emits the matching upgrade command. New `--dry-run` short-circuits after printing source + command. New `--yes` / `-y` flag.
- **CLI post-command hint** — every non-update subcommand probes `/health` and prints a dim 2-line stderr hint when an update is available. Throttled to once per day via `~/.bastra/update-hint-shown.txt`.
- **SessionStart hook** — appends `<bastra-update>...</bastra-update>` block to `additionalContext` when `/health` reports an update.

## Acceptance check

- [x] `/health` carries `update_available` when relevant (else null).
- [x] CLI hint throttled to once per day, opt-out works.
- [x] `bastra update --dry-run` prints detected source + command without side effects.
- [x] `BASTRA_UPDATE_CHECK=off` skips all three surfaces (detection short-circuits, hint short-circuits, hook skips block).
- [x] Cache hit within 24h skips the GitHub fetch (verified in test).
- [x] Network failure falls back to stale cache.

## `bastra update --dry-run` output (verified locally)

```
$ node packages/daemon/dist/cli.js update --dry-run
→ install mode: running from source checkout
  cli path: /Users/.../packages/daemon/dist/cli/update.js

(dry-run — describing what would happen, writing nothing)

→ install source: source
  update command: git pull && npm ci && npm run build

  would: 1) run the update command above
         2) re-register every surface (idempotent)
         3) restart the daemon
```

## Test plan

- [x] `npm run check:types` — green
- [x] `npm run build` — green
- [x] `npm run test:update --workspace=@bastra-recall/daemon` — 11/11 green (offline; network is stubbed)
- [x] `bastra update --dry-run` manually verified — shows correct source + command
- [ ] Manual: with daemon running and a higher tag on GitHub, `/health` returns `update_available`
- [ ] Manual: SessionStart hook emits `<bastra-update>` block when update is available
- [ ] (smoke not runnable in CI/worktree — needs private migration vault)

## Files

New:
- `packages/daemon/src/update-check.ts`
- `packages/daemon/src/cli/update-hint.ts`
- `packages/daemon/scripts/update-check.test.ts`

Modified:
- `packages/daemon/src/http.ts` (+ /health update_available)
- `packages/daemon/src/index.ts` (+ startBackgroundCheck on startup)
- `packages/daemon/src/session-hook.ts` (+ <bastra-update> block)
- `packages/daemon/src/cli.ts` (+ post-command hint)
- `packages/daemon/src/cli/commands.ts` (+ --yes flag, help text)
- `packages/daemon/src/cli/types.ts` (+ yes field)
- `packages/daemon/src/cli/update.ts` (+ install-source detection, --dry-run short-circuit)
- `packages/daemon/package.json` (+ test:update script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)