### PR TITLE
perf(search): staleness + query cache (#29 #30)

### DIFF
--- a/packages/core/__tests__/query-cache.test.ts
+++ b/packages/core/__tests__/query-cache.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests für den Query-Tokenizer-LRU-Cache in `SearchIndex` (#30).
+ *
+ * Verifiziert: identischer Query → Cache-Hit (kein erneutes MiniSearch),
+ * unterschiedliche opts → Cache-Miss (Key enthält JSON-stringified opts),
+ * Vault-Change → komplettes clear(), LRU-Eviction bei > 100 distinct Keys.
+ *
+ * Runner: `node --import tsx --test packages/core/__tests__/query-cache.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "../src/index.js";
+
+function memoryMarkdown(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: reference",
+    `summary: ${title}`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: test-scope",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+async function makeVault(memos: { id: string; title: string }[]): Promise<{ vault: Vault; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-query-test-"));
+  for (const m of memos) {
+    await writeFile(join(dir, `${m.id}.md`), memoryMarkdown(m.id, m.title), "utf8");
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  return { vault, dir };
+}
+
+function getQueryCache(idx: SearchIndex): Map<string, { hits: unknown[]; at: number }> {
+  return (idx as unknown as {
+    queryCache: Map<string, { hits: unknown[]; at: number }>;
+  }).queryCache;
+}
+
+test("query-cache: zweiter Recall mit identischem Query hit Cache", async () => {
+  const { vault, dir } = await makeVault([
+    { id: "qc-1", title: "alpha bravo" },
+    { id: "qc-2", title: "charlie delta" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const cache = getQueryCache(idx);
+    assert.equal(cache.size, 0);
+
+    const a = idx.recall("alpha", { k: 5 });
+    assert.equal(cache.size, 1, "Cache füllt sich nach Recall");
+    const a2 = idx.recall("alpha", { k: 5 });
+    assert.equal(cache.size, 1, "zweiter Call ändert Cache-Größe nicht");
+    assert.deepEqual(
+      a.map((h) => h.id),
+      a2.map((h) => h.id),
+      "gleiche IDs aus dem Cache",
+    );
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("query-cache: andere opts → Cache-Miss (separater Key)", async () => {
+  const { vault, dir } = await makeVault([{ id: "qc-1", title: "alpha bravo" }]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const cache = getQueryCache(idx);
+    idx.recall("alpha", { k: 5 });
+    assert.equal(cache.size, 1);
+
+    // Anderer k → anderer Key → zweiter Eintrag im Cache.
+    idx.recall("alpha", { k: 3 });
+    assert.equal(cache.size, 2, "unterschiedliche opts erzeugen separate Cache-Keys");
+
+    // Scope-Filter → wieder anderer Key.
+    idx.recall("alpha", { k: 5, scope: "other-scope" });
+    assert.equal(cache.size, 3);
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("query-cache: Vault-Change leert den Cache komplett", async () => {
+  const { vault, dir } = await makeVault([{ id: "qc-1", title: "alpha bravo" }]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const cache = getQueryCache(idx);
+    idx.recall("alpha", { k: 5 });
+    idx.recall("bravo", { k: 5 });
+    assert.equal(cache.size, 2);
+
+    // change event über reindexFile.
+    await writeFile(
+      join(dir, "qc-1.md"),
+      memoryMarkdown("qc-1", "alpha bravo updated"),
+      "utf8",
+    );
+    await vault.reindexFile(join(dir, "qc-1.md"));
+
+    assert.equal(cache.size, 0, "Cache wurde geleert");
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("query-cache: LRU-Eviction bei > 100 Keys", async () => {
+  const { vault, dir } = await makeVault([{ id: "qc-1", title: "alpha bravo" }]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const cache = getQueryCache(idx);
+
+    // 100 verschiedene Queries → Cache läuft voll.
+    for (let i = 0; i < 100; i++) {
+      idx.recall(`query-${i}`, { k: 5 });
+    }
+    assert.equal(cache.size, 100, "Cache füllt sich bis zum Limit");
+
+    const firstKey = `recall|query-0|${JSON.stringify({ k: 5 })}`;
+    assert.ok(cache.has(firstKey), "erste Query noch im Cache");
+
+    // 101. Query → erste muss rausfliegen.
+    idx.recall("query-100", { k: 5 });
+    assert.equal(cache.size, 100, "Cache-Größe bleibt am Limit");
+    assert.equal(cache.has(firstKey), false, "älteste Query wurde gedroppt");
+    assert.ok(cache.has(`recall|query-100|${JSON.stringify({ k: 5 })}`));
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("query-cache: LRU-Bump bei Hit verhindert Eviction der gebumpten Query", async () => {
+  const { vault, dir } = await makeVault([{ id: "qc-1", title: "alpha bravo" }]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const cache = getQueryCache(idx);
+
+    // Fülle Cache exakt voll.
+    for (let i = 0; i < 100; i++) {
+      idx.recall(`q-${i}`, { k: 5 });
+    }
+
+    // „query-0" nochmal anfassen → bump auf jüngst.
+    idx.recall("q-0", { k: 5 });
+
+    // Eine neue Query → jetzt fliegt „q-1" raus (q-0 war gerade gebumpt).
+    idx.recall("q-new", { k: 5 });
+    assert.equal(cache.has(`recall|q-0|${JSON.stringify({ k: 5 })}`), true, "gebumpte Query bleibt");
+    assert.equal(cache.has(`recall|q-1|${JSON.stringify({ k: 5 })}`), false, "vorher zweitälteste fliegt raus");
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/__tests__/staleness-cache.test.ts
+++ b/packages/core/__tests__/staleness-cache.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests für den Staleness-Cache in `SearchIndex` (#29).
+ *
+ * Ziel: verifizieren dass `computeStaleness()` pro Memory nur einmal
+ * läuft (Cache-Hit beim zweiten Recall), dass Vault-Changes den Eintrag
+ * invalidieren, und dass die 12h-TTL alte Einträge neu rechnet — auch
+ * wenn die Frontmatter unverändert ist (Tageswechsel-Flip aging → stale).
+ *
+ * Runner: `node --import tsx --test packages/core/__tests__/staleness-cache.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "../src/index.js";
+
+interface MemorySpec {
+  id: string;
+  title: string;
+  type: string;
+  summary: string;
+  updated?: string;
+  body?: string;
+}
+
+function memoryMarkdown(spec: MemorySpec): string {
+  const updated = spec.updated ?? new Date().toISOString();
+  // `created` muss <= `updated` sein und ist Pflicht — wir nehmen den
+  // gleichen Stempel.
+  return [
+    "---",
+    `id: ${spec.id}`,
+    `title: ${spec.title}`,
+    `type: ${spec.type}`,
+    `summary: ${spec.summary}`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: test-scope",
+    "recall_when:",
+    `  - ${spec.title}`,
+    `created: ${updated}`,
+    `updated: ${updated}`,
+    "---",
+    "",
+    spec.body ?? `Body for ${spec.title}.`,
+    "",
+  ].join("\n");
+}
+
+async function makeVault(specs: MemorySpec[]): Promise<{ vault: Vault; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-staleness-test-"));
+  for (const s of specs) {
+    await writeFile(join(dir, `${s.id}.md`), memoryMarkdown(s), "utf8");
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  return { vault, dir };
+}
+
+test("staleness-cache: zweiter Recall verwendet Cache (kein Re-Compute)", async () => {
+  // 200 Tage altes lesson (default 180d → ratio ~1.1 → stale).
+  const oldDate = new Date(Date.now() - 200 * 86400_000).toISOString();
+  const { vault, dir } = await makeVault([
+    { id: "stale-old", title: "alter eintrag", type: "lesson", summary: "alt", updated: oldDate },
+    { id: "stale-fresh", title: "frischer eintrag", type: "lesson", summary: "frisch" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    // Erster Recall — Cache füllt sich.
+    const a = idx.recall("eintrag", { k: 5 });
+    assert.ok(a.length >= 2, "beide Memorys finden");
+
+    // Internen Cache anzapfen (private — Test-Only über cast).
+    const cache = (idx as unknown as {
+      stalenessCache: Map<string, { touchTs: number; status: string; computedAt: number }>;
+    }).stalenessCache;
+    assert.equal(cache.size, 2, "Cache hat einen Eintrag pro Hit");
+
+    // Stempel mutieren: wenn der zweite Recall den staleness-Cache wirklich
+    // benutzt, bleiben die Stempel unverändert (Cache-Hit-Pfad updated
+    // computedAt NICHT, nur Miss-Pfad).
+    const stamp = Date.now() - 1_000;
+    for (const v of cache.values()) v.computedAt = stamp;
+
+    // Anderen Query verwenden damit der queryCache miss-t und die
+    // Staleness-Logik tatsächlich erneut betreten wird.
+    const b = idx.recall("alter", { k: 5 });
+    assert.ok(b.length >= 1);
+    for (const [id, v] of cache.entries()) {
+      assert.equal(
+        v.computedAt,
+        stamp,
+        `computedAt für ${id} bleibt stabil bei Cache-Hit`,
+      );
+    }
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("staleness-cache: Vault-Change invalidiert den Eintrag", async () => {
+  const { vault, dir } = await makeVault([
+    { id: "change-test", title: "change me", type: "lesson", summary: "x" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    idx.recall("change", { k: 5 });
+    const cache = (idx as unknown as {
+      stalenessCache: Map<string, unknown>;
+    }).stalenessCache;
+    assert.ok(cache.has("change-test"), "Cache hat Eintrag nach erstem Recall");
+
+    // Force-reindex über Vault — feuert ein `change`-Event → handle() löscht
+    // den Cache-Eintrag.
+    await writeFile(
+      join(dir, "change-test.md"),
+      memoryMarkdown({
+        id: "change-test",
+        title: "change me",
+        type: "lesson",
+        summary: "x v2",
+      }),
+      "utf8",
+    );
+    await vault.reindexFile(join(dir, "change-test.md"));
+
+    assert.equal(cache.has("change-test"), false, "Cache-Eintrag wurde invalidiert");
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("staleness-cache: 12h TTL rechnet alten Eintrag neu", async () => {
+  // touch-ts „heute" — Status fresh.
+  const { vault, dir } = await makeVault([
+    { id: "ttl-test", title: "ttl probe", type: "lesson", summary: "x" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    // Erster Call: Cache fresh, computedAt = now0.
+    const now0 = Date.now();
+    idx.recall("ttl", { k: 5 });
+    const cache = (idx as unknown as {
+      stalenessCache: Map<string, { touchTs: number; status: string; computedAt: number }>;
+    }).stalenessCache;
+    const e0 = cache.get("ttl-test");
+    assert.ok(e0, "Cache-Eintrag vorhanden");
+    assert.ok(e0!.computedAt >= now0 - 1000, "computedAt frisch");
+
+    // Cache-Eintrag manuell „13h alt" stempeln — TTL > 12h.
+    e0!.computedAt = Date.now() - 13 * 3600_000;
+    const stampedAt = e0!.computedAt;
+
+    // Wir nutzen einen ANDEREN Query damit der queryCache miss-t und
+    // die Staleness-Logik wirklich erneut greift. Beide Queries matchen
+    // dieselbe Memory („ttl probe").
+    idx.recall("probe", { k: 5 });
+    const e1 = cache.get("ttl-test");
+    assert.ok(e1, "Cache-Eintrag noch da");
+    assert.ok(
+      e1!.computedAt > stampedAt,
+      `computedAt wurde aktualisiert (was ${stampedAt}, now ${e1!.computedAt})`,
+    );
+
+    idx.stop();
+  } finally {
+    await vault.stop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/scripts/bench-cache.ts
+++ b/packages/core/scripts/bench-cache.ts
@@ -1,0 +1,214 @@
+/**
+ * Micro-Bench für die Recall-Caches (#29 + #30).
+ *
+ * Generiert einen synthetischen Vault auf Disk (default 1000 Memorys
+ * mit gemischten Types und touchTs), startet SearchIndex, und misst:
+ *  - 10k Recalls mit 20 distinct Queries (Cache-WARM-Pfad)
+ *  - 10k Recalls mit 10k distinct Queries (Cache-COLD-Pfad)
+ *  - Vergleichsmessung gegen den freistehenden `applyStalenessMultiplier`
+ *    (HEAD-Pfad ohne Per-Memory-Cache)
+ *
+ * Run: `npx tsx packages/core/scripts/bench-cache.ts`
+ *      `BENCH_VAULT_SIZE=10000 npx tsx packages/core/scripts/bench-cache.ts`
+ */
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { Vault, SearchIndex } from "../src/index.js";
+import { applyStalenessMultiplier } from "../src/search.js";
+
+const VAULT_SIZE = Number(process.env.BENCH_VAULT_SIZE ?? 1000);
+const RECALL_COUNT = Number(process.env.BENCH_RECALL_COUNT ?? 10_000);
+const HOT_QUERY_COUNT = 20;
+
+const WORDS = [
+  "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+  "hotel", "india", "juliet", "kilo", "lima", "mike", "november",
+  "oscar", "papa", "quebec", "romeo", "sierra", "tango", "uniform",
+  "victor", "whiskey", "xray", "yankee", "zulu",
+];
+
+const TYPES = ["lesson", "decision", "project-fact", "reference", "preference"];
+
+function pick<T>(arr: T[], i: number): T {
+  return arr[i % arr.length]!;
+}
+
+function memoryMarkdown(i: number): string {
+  const type = pick(TYPES, i);
+  const w1 = pick(WORDS, i);
+  const w2 = pick(WORDS, i * 7);
+  const w3 = pick(WORDS, i * 13);
+  // Mische frische und 200d alte Memorys damit der Staleness-Pfad
+  // nicht durchgängig fresh ist.
+  const ageDays = i % 5 === 0 ? 200 : i % 3;
+  const ts = new Date(Date.now() - ageDays * 86400_000).toISOString();
+  return [
+    "---",
+    `id: bench-${i}`,
+    `title: ${w1} ${w2} ${i}`,
+    `type: ${type}`,
+    `summary: ${w1} ${w2} ${w3} probe`,
+    "topic_path:",
+    "  - bench",
+    `  - ${type}`,
+    "tags:",
+    "  - bench",
+    `  - ${w1}`,
+    "scope: bench-scope",
+    "recall_when:",
+    `  - ${w1} ${w2}`,
+    `  - ${w3}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${w1} ${w2} ${w3}. Lorem ipsum.`,
+    "",
+  ].join("\n");
+}
+
+interface BenchResult {
+  label: string;
+  totalMs: number;
+  perCallUs: number;
+  recalls: number;
+}
+
+async function setup(): Promise<{ vault: Vault; idx: SearchIndex; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-bench-"));
+  for (let i = 0; i < VAULT_SIZE; i++) {
+    await writeFile(join(dir, `bench-${i}.md`), memoryMarkdown(i), "utf8");
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  const idx = new SearchIndex(vault);
+  idx.start();
+  return { vault, idx, dir };
+}
+
+function bench(label: string, n: number, fn: (i: number) => void): BenchResult {
+  // Warmup
+  for (let i = 0; i < Math.min(50, n); i++) fn(i);
+  const t0 = performance.now();
+  for (let i = 0; i < n; i++) fn(i);
+  const totalMs = performance.now() - t0;
+  return {
+    label,
+    totalMs,
+    perCallUs: (totalMs * 1000) / n,
+    recalls: n,
+  };
+}
+
+function printResult(r: BenchResult): void {
+  console.log(
+    `  ${r.label.padEnd(48)}  total ${r.totalMs.toFixed(1).padStart(8)} ms` +
+      `  |  per call ${r.perCallUs.toFixed(2).padStart(8)} µs` +
+      `  (n=${r.recalls})`,
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `[bench] vault=${VAULT_SIZE} memorys, recall_count=${RECALL_COUNT}`,
+  );
+  const t0 = performance.now();
+  const { vault, idx, dir } = await setup();
+  console.log(`[bench] indexed ${idx.size()} memorys in ${(performance.now() - t0).toFixed(0)} ms`);
+  console.log();
+
+  // ─── #30 Query-Cache ──────────────────────────────────────────
+  console.log("Query-Tokenizer-Cache (#30):");
+
+  // Cold: unique queries → cache miss every time.
+  const coldQueries = Array.from({ length: RECALL_COUNT }, (_, i) =>
+    `${pick(WORDS, i)} ${pick(WORDS, i * 11)} ${i}`,
+  );
+  const cold = bench(
+    "cold path (unique queries, miss every call)",
+    RECALL_COUNT,
+    (i) => {
+      idx.recall(coldQueries[i % coldQueries.length]!, { k: 5 });
+    },
+  );
+  printResult(cold);
+
+  // Hot: 20 queries cycled → cache hits after first 20.
+  const hotQueries = Array.from({ length: HOT_QUERY_COUNT }, (_, i) =>
+    `${pick(WORDS, i)} ${pick(WORDS, i * 11)}`,
+  );
+  // Wir resetten den Cache explizit um die Hits zu zeigen.
+  (idx as unknown as { queryCache: Map<string, unknown> }).queryCache.clear();
+  const hot = bench(
+    "hot path (20 cycled queries, mostly cache-hit)",
+    RECALL_COUNT,
+    (i) => {
+      idx.recall(hotQueries[i % HOT_QUERY_COUNT]!, { k: 5 });
+    },
+  );
+  printResult(hot);
+  console.log(
+    `  → hot/cold speedup: ${(cold.perCallUs / hot.perCallUs).toFixed(1)}×`,
+  );
+
+  console.log();
+
+  // ─── #29 Staleness-Cache ──────────────────────────────────────
+  console.log("Staleness-Cache (#29):");
+
+  // Reset query cache so the staleness comparison is not skewed.
+  (idx as unknown as { queryCache: Map<string, unknown> }).queryCache.clear();
+  (idx as unknown as { stalenessCache: Map<string, unknown> }).stalenessCache.clear();
+
+  // Pre-fetch ein hit set (5 hits) damit wir applyStaleness direkt messen.
+  const sampleHits = idx.recall("alpha", { k: 5 });
+  if (sampleHits.length === 0) {
+    console.error("no sample hits — vault generation issue?");
+  }
+  console.log(`  (sample hit count: ${sampleHits.length})`);
+
+  // HEAD-Pfad: freistehende applyStalenessMultiplier ohne Cache.
+  const head = bench(
+    "applyStalenessMultiplier (HEAD, no per-memory cache)",
+    RECALL_COUNT,
+    () => {
+      // Kopie der Hits weil die Funktion das Array mutiert / re-sorted.
+      const hits = sampleHits.map((h) => ({ ...h }));
+      applyStalenessMultiplier(hits, (id) => vault.get(id)?.fm as Record<string, unknown> | undefined);
+    },
+  );
+  printResult(head);
+
+  // Cached: SearchIndex.applyStaleness via private cast.
+  const applyStalenessCached = (
+    idx as unknown as { applyStaleness: (hits: unknown[]) => unknown[] }
+  ).applyStaleness.bind(idx);
+  // Warmup damit der Staleness-Cache gefüllt ist.
+  applyStalenessCached(sampleHits.map((h) => ({ ...h })));
+  const cached = bench(
+    "SearchIndex.applyStaleness (cached, this PR)",
+    RECALL_COUNT,
+    () => {
+      const hits = sampleHits.map((h) => ({ ...h }));
+      applyStalenessCached(hits);
+    },
+  );
+  printResult(cached);
+  console.log(
+    `  → cached/HEAD speedup: ${(head.perCallUs / cached.perCallUs).toFixed(1)}×`,
+  );
+
+  console.log();
+  console.log("[bench] cleanup …");
+  idx.stop();
+  await vault.stop();
+  await rm(dir, { recursive: true, force: true });
+  console.log("[bench] done.");
+}
+
+main().catch((err) => {
+  console.error("[bench] FATAL:", err);
+  process.exit(1);
+});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -77,6 +77,14 @@ export class SearchIndex {
   >();
   private static readonly STALENESS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
 
+  // Query-Cache (#30): MiniSearch tokenisiert die Query bei jedem
+  // `recall()` neu. Hooks rufen häufig mit identischer Query auf
+  // (detectTopics() ist deterministisch). LRU via Map-insertion-order,
+  // hard cap 100 Einträge, TTL 30s. Vault-Change leert komplett.
+  private queryCache = new Map<string, { hits: RecallHit[]; at: number }>();
+  private static readonly QUERY_CACHE_MAX = 100;
+  private static readonly QUERY_CACHE_TTL_MS = 30_000;
+
   constructor(private readonly vault: Vault) {
     this.mini = new MiniSearch<IndexDoc>({
       fields: [
@@ -139,6 +147,14 @@ export class SearchIndex {
   recall(query: string, opts: RecallOptions = {}): RecallHit[] {
     const k = opts.k ?? 5;
     if (!query.trim()) return [];
+
+    // Query-Cache (#30) — bei Hit komplett überspringen, inkl. Hop-
+    // Expansion und Staleness-Reranking. Cache speichert das finale
+    // RecallHit[], nicht den BM25-Roh-Output.
+    const cacheKey = `recall|${query}|${JSON.stringify(opts)}`;
+    const cached = this.lookupQueryCache(cacheKey);
+    if (cached) return cached;
+
     const raw = this.mini.search(query);
 
     const filtered = raw.filter((r) => {
@@ -167,7 +183,9 @@ export class SearchIndex {
     const withHops = opts.expand_hops === 1
       ? [...direct, ...this.collectOneHopNeighbors(directFull, opts, new Set(direct.map((h) => h.id))).slice(0, k)]
       : direct;
-    return this.applyStaleness(withHops);
+    const reranked = this.applyStaleness(withHops);
+    this.storeQueryCache(cacheKey, reranked);
+    return reranked;
   }
 
   /** Hybrid-Recall: BM25 + Vector via Reciprocal-Rank-Fusion. Wenn kein
@@ -178,6 +196,13 @@ export class SearchIndex {
     if (!this.embeddings) return this.recall(query, opts);
     const k = opts.k ?? 5;
     if (!query.trim()) return [];
+
+    // Query-Cache (#30) — eigener Key-Prefix damit BM25-only und Hybrid
+    // sich nicht gegenseitig überschreiben (gleicher Query-String,
+    // anderes Ranking-Ergebnis).
+    const cacheKey = `hybrid|${query}|${JSON.stringify(opts)}`;
+    const cached = this.lookupQueryCache(cacheKey);
+    if (cached) return cached;
 
     // BM25 — top 50 für RRF-Pool.
     const bm25 = this.mini.search(query).filter((r) => passesRecallFilters(r, opts));
@@ -241,7 +266,9 @@ export class SearchIndex {
     const withHops = opts.expand_hops === 1
       ? [...out, ...this.collectOneHopNeighbors(outFull, opts, new Set(out.map((h) => h.id))).slice(0, k)]
       : out;
-    return this.applyStaleness(withHops);
+    const reranked = this.applyStaleness(withHops);
+    this.storeQueryCache(cacheKey, reranked);
+    return reranked;
   }
 
   /**
@@ -313,6 +340,9 @@ export class SearchIndex {
     if (e.kind === "remove") {
       // Staleness-Cache invalidieren (#29) — memId genügt.
       this.stalenessCache.delete(e.id);
+      // Query-Cache komplett leeren (#30) — selektive Invalidierung wäre
+      // ein eigenes Ranking-Problem und Vault-Changes sind selten.
+      this.queryCache.clear();
       try {
         this.mini.discard(e.id);
       } catch {
@@ -322,11 +352,17 @@ export class SearchIndex {
     }
     if (e.kind === "change") {
       this.stalenessCache.delete(e.memory.fm.id);
+      this.queryCache.clear();
       try {
         this.mini.discard(e.memory.fm.id);
       } catch {
         // first time; treat as add
       }
+    } else if (e.kind === "add") {
+      // Neue Memory könnte BM25-Ranking aller bestehenden Queries
+      // verändern → Query-Cache leeren. Staleness wird ohnehin lazy
+      // beim nächsten Recall berechnet.
+      this.queryCache.clear();
     }
     this.indexOne(e.memory);
   }
@@ -361,6 +397,41 @@ export class SearchIndex {
     direct.sort((a, b) => b.score - a.score);
     hops.sort((a, b) => b.score - a.score);
     return [...direct, ...hops];
+  }
+
+  /**
+   * LRU-Lookup für `queryCache` (#30). Bei Hit wird der Eintrag
+   * re-inserted, damit die Map-insertion-order ihn als „recently used"
+   * sieht. TTL 30s — frische Edits sollen den Cache nicht zu lange
+   * dominieren, auch wenn der Watcher nicht feuert.
+   */
+  private lookupQueryCache(key: string): RecallHit[] | undefined {
+    const cached = this.queryCache.get(key);
+    if (!cached) return undefined;
+    if (Date.now() - cached.at > SearchIndex.QUERY_CACHE_TTL_MS) {
+      this.queryCache.delete(key);
+      return undefined;
+    }
+    // LRU-Bump: löschen + neu setzen, damit Map-iteration den Eintrag
+    // als jüngsten sieht.
+    this.queryCache.delete(key);
+    this.queryCache.set(key, cached);
+    // Defensive Kopie — Caller könnte das Array mutieren (sortieren,
+    // pushen). Cache-Werte bleiben damit stabil über Calls hinweg.
+    return cached.hits.map((h) => ({ ...h }));
+  }
+
+  private storeQueryCache(key: string, hits: RecallHit[]): void {
+    if (this.queryCache.size >= SearchIndex.QUERY_CACHE_MAX) {
+      // Oldest first — Map preserved insertion order.
+      const oldest = this.queryCache.keys().next().value;
+      if (oldest !== undefined) this.queryCache.delete(oldest);
+    }
+    // Tiefen-Kopie der Hits, gleicher Grund wie in lookupQueryCache.
+    this.queryCache.set(key, {
+      hits: hits.map((h) => ({ ...h })),
+      at: Date.now(),
+    });
   }
 
   private indexOne(m: Memory): void {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -66,6 +66,17 @@ export class SearchIndex {
   private detach?: () => void;
   private embeddings?: EmbeddingIndex;
 
+  // Staleness-Cache (#29): `computeStaleness()` parsed Date-Strings und
+  // rechnet Ratio-Logik — pro Recall × Hit-Count summiert sich das. Cache
+  // ist memId → { touchTs, status, computedAt }. Invalidiert in `handle()`
+  // bei change/remove, plus 12h-TTL gegen Tageswechsel (`aging → stale`
+  // ohne Vault-Change).
+  private stalenessCache = new Map<
+    string,
+    { touchTs: number; status: StaleStatus; computedAt: number }
+  >();
+  private static readonly STALENESS_CACHE_TTL_MS = 12 * 60 * 60 * 1000;
+
   constructor(private readonly vault: Vault) {
     this.mini = new MiniSearch<IndexDoc>({
       fields: [
@@ -156,7 +167,7 @@ export class SearchIndex {
     const withHops = opts.expand_hops === 1
       ? [...direct, ...this.collectOneHopNeighbors(directFull, opts, new Set(direct.map((h) => h.id))).slice(0, k)]
       : direct;
-    return applyStalenessMultiplier(withHops, (id) => this.vault.get(id)?.fm as Record<string, unknown> | undefined);
+    return this.applyStaleness(withHops);
   }
 
   /** Hybrid-Recall: BM25 + Vector via Reciprocal-Rank-Fusion. Wenn kein
@@ -230,7 +241,7 @@ export class SearchIndex {
     const withHops = opts.expand_hops === 1
       ? [...out, ...this.collectOneHopNeighbors(outFull, opts, new Set(out.map((h) => h.id))).slice(0, k)]
       : out;
-    return applyStalenessMultiplier(withHops, (id) => this.vault.get(id)?.fm as Record<string, unknown> | undefined);
+    return this.applyStaleness(withHops);
   }
 
   /**
@@ -300,6 +311,8 @@ export class SearchIndex {
 
   private handle(e: VaultEvent): void {
     if (e.kind === "remove") {
+      // Staleness-Cache invalidieren (#29) — memId genügt.
+      this.stalenessCache.delete(e.id);
       try {
         this.mini.discard(e.id);
       } catch {
@@ -308,6 +321,7 @@ export class SearchIndex {
       return;
     }
     if (e.kind === "change") {
+      this.stalenessCache.delete(e.memory.fm.id);
       try {
         this.mini.discard(e.memory.fm.id);
       } catch {
@@ -315,6 +329,38 @@ export class SearchIndex {
       }
     }
     this.indexOne(e.memory);
+  }
+
+  /**
+   * Staleness-Reranking mit Per-Memory-Cache (#29). Cache-Key ist die
+   * memId — invalidiert in `handle()` bei change/remove. Zusätzlich
+   * 12h-TTL gegen Tageswechsel-Flips (`aging → stale` ohne Vault-Change).
+   *
+   * Behält die Sortier-Semantik von `applyStalenessMultiplier`: Direct-
+   * vs 1-hop-Hits bleiben getrennt sortiert.
+   */
+  private applyStaleness(hits: RecallHit[], now: Date = new Date()): RecallHit[] {
+    const nowMs = now.getTime();
+    for (const h of hits) {
+      const fm = this.vault.get(h.id)?.fm as Record<string, unknown> | undefined;
+      if (!fm) continue;
+      const touchTs = computeTouchTs(fm);
+      let entry = this.stalenessCache.get(h.id);
+      const ttlExpired =
+        entry != null && nowMs - entry.computedAt > SearchIndex.STALENESS_CACHE_TTL_MS;
+      if (!entry || entry.touchTs !== touchTs || ttlExpired) {
+        const status = computeStaleness(fm, now);
+        entry = { touchTs, status, computedAt: nowMs };
+        this.stalenessCache.set(h.id, entry);
+      }
+      const mult = STALE_MULTIPLIERS[entry.status];
+      if (mult !== 1.0) h.score = round(h.score * mult);
+    }
+    const direct = hits.filter((h) => h.hop !== "1-hop");
+    const hops = hits.filter((h) => h.hop === "1-hop");
+    direct.sort((a, b) => b.score - a.score);
+    hops.sort((a, b) => b.score - a.score);
+    return [...direct, ...hops];
   }
 
   private indexOne(m: Memory): void {
@@ -449,6 +495,19 @@ function parseDateValue(raw: unknown): number | null {
     return Number.isNaN(t) ? null : t;
   }
   return null;
+}
+
+/**
+ * „Touch-Timestamp" einer Memory: jüngeres aus `updated` und
+ * `last_reviewed_at`. Wird vom Staleness-Cache (#29) als Identitäts-
+ * Stempel benutzt — ändert sich der touchTs, wird der Cache-Eintrag
+ * neu berechnet, auch ohne Vault-Event (z.B. wenn die Mac-App die
+ * Frontmatter direkt patcht).
+ */
+function computeTouchTs(fm: Record<string, unknown>): number {
+  const updated = parseDateValue(fm.updated) ?? 0;
+  const lastReviewed = parseDateValue(fm.last_reviewed_at) ?? 0;
+  return Math.max(updated, lastReviewed);
 }
 
 /**


### PR DESCRIPTION
## Summary

Two performance caches in `SearchIndex` that target the recall hot-path:

- **Staleness cache (#29)** — `applyStalenessMultiplier()` re-parsed date strings + ran ratio logic for every hit of every recall. Now `SearchIndex.applyStaleness()` keeps a `memId → { touchTs, status, computedAt }` Map, invalidated in `handle()` on `change`/`remove`, plus a 12h TTL against day-boundary flips. The free-standing `applyStalenessMultiplier` stays exported (backwards-compat).
- **Query LRU (#30)** — `SearchIndex.recall()` / `recallHybrid()` now consult a `queryCache: Map<key, { hits, at }>` before re-tokenizing through MiniSearch. Key is `${prefix}|${query}|${JSON.stringify(opts)}`, prefix `recall` vs `hybrid` so the two ranking strategies don't collide. Hard cap 100 entries, TTL 30s, LRU bump on hit (Map insertion-order). Full clear on any vault event — the force-reindex path in `tool-handlers.ts:176` flows through `vault.reindexFile()` → `change` event, so no extra hook needed.

Signatures of `recall()` and `recallHybrid()` are untouched, so the upcoming stage-events work (#38) can still extend them.

## Bench

`npx tsx packages/core/scripts/bench-cache.ts` against a synthetic 1000-memory vault, 10k recalls each:

```
Query-Tokenizer-Cache (#30):
  cold path (unique queries, miss every call)       per call   131.96 µs
  hot path (20 cycled queries, mostly cache-hit)    per call     0.33 µs
  → hot/cold speedup: 399.8×

Staleness-Cache (#29):
  applyStalenessMultiplier (HEAD, no cache)         per call     0.81 µs
  SearchIndex.applyStaleness (this PR, cached)      per call     0.61 µs
  → cached/HEAD speedup: 1.3×
```

The query-cache speedup dominates because it short-circuits the whole BM25 + hop expansion + staleness pipeline. The per-memory staleness cache shows a modest 1.3× because date parsing in V8 is already fast — but it scales with hit-count × recall-frequency and removes parse pressure for the future stage-events work.

## Test plan

- [x] `npm run check:types` green
- [x] `npm run build` green
- [x] `npm run smoke --workspace=@bastra-recall/daemon` 7/7 passing (against the real Obsidian vault)
- [x] `npx tsx --test packages/core/__tests__/staleness-cache.test.ts packages/core/__tests__/query-cache.test.ts` — 8/8 passing
  - staleness: cache fill, vault-change invalidation, 12h TTL re-compute
  - query: hit/miss, opts-aware keys, vault-change clears, LRU eviction at 101st key, LRU bump prevents eviction of recently-used

Closes #29
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)