### PR TITLE
feat(hook): UserPromptSubmit + TodoWrite reflex hooks (#33 #36)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,84 @@
+# Claude Code hooks for bastra-recall
+
+bastra-recall ships **four** Claude-Code hook CLIs. They all read a Claude
+Code hook payload from stdin, optionally call the daemon's `/hook/recall`
+endpoint, and emit an `additionalContext` block (or `{}`) on stdout. Every
+hook has a hard wall-clock budget (`BASTRA_HOOK_TIMEOUT_MS`, default 250 ms,
+500 ms for SessionStart) and fails silently if the daemon is unreachable.
+
+| Bin name                          | Event             | Trigger                  | Purpose                                                   |
+| --------------------------------- | ----------------- | ------------------------ | --------------------------------------------------------- |
+| `bastra-recall-session-hook`      | `SessionStart`    | every fresh session      | Preload user-preferences + active project context         |
+| `bastra-recall-hook`              | `PreToolUse`      | `Write`/`Edit`/`MultiEdit`/`NotebookEdit` | Topic-aware recall before file mutations |
+| `bastra-recall-prompt-hook`       | `UserPromptSubmit`| every user message       | Lookup-mode reflex (Issue #33)                            |
+| `bastra-recall-todo-hook`         | `PreToolUse`      | `TodoWrite`              | Topology recall before multi-step plans (Issue #36)       |
+
+## Activation snippet for `~/.claude/settings.json`
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "command": "bastra-recall-session-hook" }
+    ],
+    "UserPromptSubmit": [
+      { "command": "bastra-recall-prompt-hook" }
+    ],
+    "PreToolUse": [
+      { "matcher": "Write|Edit|MultiEdit|NotebookEdit", "command": "bastra-recall-hook" },
+      { "matcher": "TodoWrite", "command": "bastra-recall-todo-hook" }
+    ]
+  }
+}
+```
+
+The bins are installed by `npm install -g @bastra-recall/daemon` (or via the
+Bastra Mac app's "install Claude Code hooks" action).
+
+## Per-hook behavior
+
+### `bastra-recall-prompt-hook` (Issue #33)
+
+Detects retrieval prompts via DE + EN regex (e.g. `^such|finde|wo (ist|sind)`
+/ `^find|search|where (is|are)`). On a match:
+
+- POSTs the prompt verbatim to `/hook/recall` with `k=5`, score-floor `50`.
+- Emits a `<recall-hints surface="claude-code" trigger="prompt-lookup">`
+  block with an explicit "Use bastra-recall:recall (and find_document if
+  pdf-likely) BEFORE conversation_search / web_search" instruction.
+
+Non-retrieval prompts emit `{}` by default. Set
+`BASTRA_PROMPT_HOOK_MODE=all` to also recall on generic prompts (only
+score ≥ 100 hits surface — much higher noise gate).
+
+Telemetry event: `prompt_hook_call` (`detected_mode`, `prompt_chars`, `hint_count`, …).
+
+### `bastra-recall-todo-hook` (Issue #36)
+
+Fires only on `PreToolUse` + `tool_name === "TodoWrite"`. Pulls the first
+1–2 todo `content` strings as the query spine, plus the top-3 lowercased
+tokens that appear in ≥ 2 todos as topic words. Stopwords (DE + EN) and
+short tokens (< 3 chars) are filtered.
+
+- POSTs to `/hook/recall` with `type=project-fact`, `k=5`, score-floor `50`.
+- Skips silently (`{}`) when confidence is low (< 2 topic words AND query
+  length < 10 chars).
+- Emits a `<recall-hints surface="claude-code" trigger="todo-plan"
+  topics="…">` block with a "Before starting these todos, load the
+  project-facts above to understand current file layout / past decisions"
+  instruction.
+
+Telemetry event: `todo_hook_call` (`topic`, `todo_count`, `hit_count`, …).
+
+## Environment overrides
+
+| Env var                       | Default          | What it does                                                  |
+| ----------------------------- | ---------------- | ------------------------------------------------------------- |
+| `BASTRA_HTTP_URL`             | _none_           | Full daemon base URL (overrides host+port)                    |
+| `BASTRA_HTTP_PORT`            | `6723`           | Daemon port on `127.0.0.1`                                    |
+| `BASTRA_HOOK_TIMEOUT_MS`      | `250` / `500`    | Wall-clock budget for the hook (incl. network round-trip)     |
+| `BASTRA_PROMPT_HOOK_MODE`     | `retrieval-only` | `retrieval-only` or `all` — only the prompt-hook reads this   |
+| `BASTRA_TELEMETRY`            | `on`             | `off` to disable JSONL telemetry writes                       |
+| `BASTRA_LOG_PATH`             | `~/.bastra/logs` | Telemetry log directory                                       |
+
+All `BASTRA_*` vars accept a legacy `NEXUS_*` fallback for migration.

--- a/packages/daemon/__tests__/prompt-hook.test.ts
+++ b/packages/daemon/__tests__/prompt-hook.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for prompt-hook.ts (Issue #33).
+ *
+ * Strategy: unit-test the pure helpers (detectRetrieval, extractPrompt,
+ * formatHintBlock) directly, then run an end-to-end test by spawning the
+ * hook via tsx against a mock daemon HTTP server.
+ */
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectRetrieval,
+  extractPrompt,
+  formatHintBlock,
+  type RecallHit,
+} from "../src/prompt-hook.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = resolve(__dirname, "..", "src", "prompt-hook.ts");
+
+// ─── Pure unit tests ─────────────────────────────────────────────────────
+
+test("detectRetrieval — DE triggers match", () => {
+  const cases = [
+    "such mal meinen Strafzettel",
+    "Suche nach Rechnungen von 2024",
+    "finde alle PDFs zum Mietvertrag",
+    "wo ist meine Steuererklärung?",
+    "wo sind die Notizen vom Meeting?",
+    "wann war der letzte Arzttermin?",
+    "wann hatte ich Urlaub im Juli?",
+    "wieviel habe ich für Strom bezahlt?",
+    "wie viel Miete im März?",
+    "was habe ich zum Architekt gesagt?",
+    "Was hab ich gestern gemacht?",
+    "was war der Stand bei der Steuer?",
+  ];
+  for (const c of cases) {
+    assert.equal(detectRetrieval(c), true, `expected retrieval match for: ${c}`);
+  }
+});
+
+test("detectRetrieval — EN triggers match", () => {
+  const cases = [
+    "find the parking ticket pdf",
+    "search invoices from last quarter",
+    "where is the lease agreement?",
+    "where are the meeting notes?",
+    "when was the last vet visit?",
+    "when did I sign the contract?",
+    "how much did I spend on rent?",
+    "what did I tell the architect?",
+    "what was the status on the tax filing?",
+  ];
+  for (const c of cases) {
+    assert.equal(detectRetrieval(c), true, `expected retrieval match for: ${c}`);
+  }
+});
+
+test("detectRetrieval — non-retrieval prompts skip", () => {
+  const cases = [
+    "bitte schreib mir einen Hook",
+    "implement a UserPromptSubmit handler",
+    "lass uns über das design reden",
+    "refactor the daemon",
+    "thanks!",
+    "",
+    "   ",
+    "ok",
+    "go ahead",
+    "machen wir das so",
+  ];
+  for (const c of cases) {
+    assert.equal(detectRetrieval(c), false, `expected NO retrieval match for: ${c}`);
+  }
+});
+
+test("extractPrompt — prefers payload.prompt", () => {
+  assert.equal(extractPrompt({ prompt: "hello", user_message: "ignored" }), "hello");
+});
+
+test("extractPrompt — falls back to user_message", () => {
+  assert.equal(extractPrompt({ user_message: "fallback" }), "fallback");
+});
+
+test("extractPrompt — empty/missing returns null", () => {
+  assert.equal(extractPrompt({}), null);
+  assert.equal(extractPrompt({ prompt: "" }), null);
+  assert.equal(extractPrompt({ prompt: "   " }), null);
+});
+
+test("formatHintBlock — retrieval mode includes lookup instruction", () => {
+  const hits: RecallHit[] = [
+    {
+      id: "test-memory",
+      title: "Test",
+      type: "lesson",
+      scope: "user",
+      summary: "Summary of the lesson",
+      score: 120,
+    },
+  ];
+  const block = formatHintBlock(hits, "myproject", "retrieval");
+  assert.match(block, /<recall-hints surface="claude-code" trigger="prompt-lookup"/);
+  assert.match(block, /project="myproject"/);
+  assert.match(block, /LOOKUP \/ retrieval query/);
+  assert.match(block, /bastra-recall:recall.*BEFORE conversation_search/i);
+  assert.match(block, /test-memory/);
+  assert.match(block, /<\/recall-hints>/);
+});
+
+test("formatHintBlock — separates REQUIRED vs OPTIONAL by score", () => {
+  const hits: RecallHit[] = [
+    { id: "high", title: "H", type: "lesson", scope: "user", summary: "high", score: 150 },
+    { id: "mid", title: "M", type: "lesson", scope: "user", summary: "mid", score: 70 },
+  ];
+  const block = formatHintBlock(hits, null, "retrieval");
+  const requiredIdx = block.indexOf("REQUIRED");
+  const optionalIdx = block.indexOf("OPTIONAL");
+  assert.ok(requiredIdx >= 0, "REQUIRED section missing");
+  assert.ok(optionalIdx > requiredIdx, "OPTIONAL must come after REQUIRED");
+  assert.ok(block.indexOf("high") < block.indexOf("mid"));
+});
+
+// ─── Integration test via mock daemon ────────────────────────────────────
+
+function startMockDaemon(handler: (req: IncomingMessage, res: ServerResponse) => void) {
+  const server = createServer(handler);
+  return new Promise<{ port: number; close: () => Promise<void> }>((ok) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      ok({
+        port,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+function runHook(
+  payload: object,
+  env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((ok, ko) => {
+    const child = spawn("npx", ["tsx", HOOK_PATH], {
+      env: { ...process.env, ...env, BASTRA_TELEMETRY: "off" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", ko);
+    child.on("close", (code) => ok({ stdout, stderr, code: code ?? -1 }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+test("integration — retrieval prompt yields recall-hints block", async () => {
+  let received: { url: string | undefined; body: unknown } | null = null;
+  const daemon = await startMockDaemon((req, res) => {
+    let body = "";
+    req.on("data", (c: Buffer) => (body += c.toString()));
+    req.on("end", () => {
+      received = { url: req.url, body: JSON.parse(body) };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          hits: [
+            {
+              id: "parkticket-2025",
+              title: "Strafzettel März 2025",
+              type: "project-fact",
+              scope: "personal",
+              summary: "Parkverstoß Berlin Mitte, 35€, bezahlt 2025-03-12.",
+              score: 142,
+            },
+          ],
+          vault_size: 100,
+          latency_ms: 12,
+          recall_id: "test-recall",
+        }),
+      );
+    });
+  });
+
+  try {
+    const { stdout } = await runHook(
+      {
+        hook_event_name: "UserPromptSubmit",
+        prompt: "such mal meinen Strafzettel",
+        cwd: process.cwd(),
+      },
+      { BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}` },
+    );
+
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: { additionalContext?: string; hookEventName?: string };
+    };
+    assert.ok(parsed.hookSpecificOutput, "hook should emit hookSpecificOutput");
+    assert.equal(parsed.hookSpecificOutput?.hookEventName, "UserPromptSubmit");
+    const ctx = parsed.hookSpecificOutput?.additionalContext ?? "";
+    assert.match(ctx, /parkticket-2025/);
+    assert.match(ctx, /trigger="prompt-lookup"/);
+    assert.match(ctx, /BEFORE conversation_search/);
+
+    assert.ok(received, "mock daemon should have received request");
+    const r = received as { url: string | undefined; body: { query: string; k: number } };
+    assert.equal(r.url, "/hook/recall");
+    assert.equal(r.body.query, "such mal meinen Strafzettel");
+    assert.equal(r.body.k, 5);
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("integration — non-retrieval prompt emits empty object", async () => {
+  let hit = false;
+  const daemon = await startMockDaemon((_req, res) => {
+    hit = true;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end('{"hits":[],"vault_size":0,"latency_ms":1,"recall_id":"x"}');
+  });
+  try {
+    const { stdout } = await runHook(
+      {
+        hook_event_name: "UserPromptSubmit",
+        prompt: "lass uns das implementieren",
+        cwd: process.cwd(),
+      },
+      { BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}` },
+    );
+    assert.equal(stdout.trim(), "{}");
+    assert.equal(hit, false, "daemon must not be called when no retrieval signal");
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("integration — wrong hook_event_name emits empty object", async () => {
+  const daemon = await startMockDaemon((_req, res) => {
+    res.writeHead(200);
+    res.end("{}");
+  });
+  try {
+    const { stdout } = await runHook(
+      { hook_event_name: "PreToolUse", prompt: "such mal meinen Strafzettel" },
+      { BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}` },
+    );
+    assert.equal(stdout.trim(), "{}");
+  } finally {
+    await daemon.close();
+  }
+});

--- a/packages/daemon/__tests__/todo-hook.test.ts
+++ b/packages/daemon/__tests__/todo-hook.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for todo-hook.ts (Issue #36).
+ *
+ * Strategy: unit-test the pure helpers (extractTopicsFromTodos,
+ * isLowConfidence, formatHintBlock) directly, then end-to-end against a
+ * mock daemon HTTP server.
+ */
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractTopicsFromTodos,
+  isLowConfidence,
+  formatHintBlock,
+  type RecallHit,
+} from "../src/todo-hook.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = resolve(__dirname, "..", "src", "todo-hook.ts");
+
+// ─── Pure unit tests ─────────────────────────────────────────────────────
+
+test("extractTopicsFromTodos — picks topic words that appear in >=2 todos", () => {
+  const todos = [
+    { content: "Refactor the bastra-recall daemon hook pipeline", status: "pending" },
+    { content: "Update bastra-recall daemon telemetry events", status: "pending" },
+    { content: "Document the new daemon hook config", status: "pending" },
+  ];
+  const ex = extractTopicsFromTodos(todos);
+  // "daemon" appears in all 3, "bastra-recall" + "hook" each in 2.
+  assert.ok(ex.topics.includes("daemon"), `topics: ${ex.topics.join(",")}`);
+  assert.ok(ex.topics.includes("hook"), `topics: ${ex.topics.join(",")}`);
+  assert.equal(ex.todoCount, 3);
+  assert.ok(ex.query.length > 0);
+  // Query should start with the topics
+  assert.ok(ex.query.startsWith(ex.topics.join(" ")));
+});
+
+test("extractTopicsFromTodos — handles missing/empty payload", () => {
+  assert.deepEqual(extractTopicsFromTodos(undefined), {
+    query: "",
+    topics: [],
+    todoCount: 0,
+  });
+  assert.deepEqual(extractTopicsFromTodos([]), {
+    query: "",
+    topics: [],
+    todoCount: 0,
+  });
+  const onlyEmptyContent = extractTopicsFromTodos([{ content: "" }, { content: "" }]);
+  assert.equal(onlyEmptyContent.query, "");
+  assert.equal(onlyEmptyContent.topics.length, 0);
+});
+
+test("extractTopicsFromTodos — filters stopwords and short words", () => {
+  const todos = [
+    { content: "fix the and or but if then for to of in" },
+    { content: "fix the and or but if then for to of in" },
+  ];
+  const ex = extractTopicsFromTodos(todos);
+  // "fix" is stopword too; everything else is < 3 chars or stopword.
+  assert.equal(ex.topics.length, 0);
+});
+
+test("isLowConfidence — triggers when no topics and short query", () => {
+  assert.equal(isLowConfidence({ query: "hi", topics: [], todoCount: 1 }), true);
+  assert.equal(isLowConfidence({ query: "", topics: [], todoCount: 0 }), true);
+});
+
+test("isLowConfidence — passes with >=2 topics", () => {
+  assert.equal(
+    isLowConfidence({ query: "x", topics: ["alpha", "beta"], todoCount: 2 }),
+    false,
+  );
+});
+
+test("isLowConfidence — passes with long query even if no topics", () => {
+  assert.equal(
+    isLowConfidence({
+      query: "implement a complete user-prompt-submit hook end to end",
+      topics: [],
+      todoCount: 1,
+    }),
+    false,
+  );
+});
+
+test("formatHintBlock — emits todo-plan trigger + load instruction", () => {
+  const hits: RecallHit[] = [
+    {
+      id: "bastra-projekt-ubersicht-master",
+      title: "Bastra Projekt Übersicht",
+      type: "project-fact",
+      scope: "bastra-recall",
+      summary: "Master entry covering the whole project.",
+      score: 130,
+    },
+  ];
+  const block = formatHintBlock(hits, "bastra-recall", ["daemon", "hook"]);
+  assert.match(block, /<recall-hints surface="claude-code" trigger="todo-plan"/);
+  assert.match(block, /project="bastra-recall"/);
+  assert.match(block, /topics="daemon,hook"/);
+  assert.match(block, /Before starting these todos, load the project-facts/);
+  assert.match(block, /bastra-projekt-ubersicht-master/);
+});
+
+// ─── Integration test via mock daemon ────────────────────────────────────
+
+function startMockDaemon(handler: (req: IncomingMessage, res: ServerResponse) => void) {
+  const server = createServer(handler);
+  return new Promise<{ port: number; close: () => Promise<void> }>((ok) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      ok({
+        port,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+function runHook(
+  payload: object,
+  env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((ok, ko) => {
+    const child = spawn("npx", ["tsx", HOOK_PATH], {
+      env: { ...process.env, ...env, BASTRA_TELEMETRY: "off" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", ko);
+    child.on("close", (code) => ok({ stdout, stderr, code: code ?? -1 }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+test("integration — TodoWrite with topical todos yields hints + type=project-fact filter", async () => {
+  let received: { url: string | undefined; body: { type?: string; query?: string } } | null =
+    null;
+  const daemon = await startMockDaemon((req, res) => {
+    let body = "";
+    req.on("data", (c: Buffer) => (body += c.toString()));
+    req.on("end", () => {
+      received = { url: req.url, body: JSON.parse(body) };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          hits: [
+            {
+              id: "bastra-projekt-ubersicht-master",
+              title: "Bastra Projekt Übersicht",
+              type: "project-fact",
+              scope: "bastra-recall",
+              summary: "Master entry.",
+              score: 135,
+            },
+          ],
+          vault_size: 100,
+          latency_ms: 10,
+          recall_id: "test",
+        }),
+      );
+    });
+  });
+
+  try {
+    const { stdout } = await runHook(
+      {
+        hook_event_name: "PreToolUse",
+        tool_name: "TodoWrite",
+        cwd: process.cwd(),
+        tool_input: {
+          todos: [
+            { content: "Implement bastra-recall daemon hook for TodoWrite", status: "pending" },
+            { content: "Wire up bastra-recall daemon telemetry", status: "pending" },
+            { content: "Test the daemon hook pipeline", status: "pending" },
+          ],
+        },
+      },
+      { BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}` },
+    );
+
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: { additionalContext?: string; hookEventName?: string };
+    };
+    assert.ok(parsed.hookSpecificOutput, "hook should emit hookSpecificOutput");
+    assert.equal(parsed.hookSpecificOutput?.hookEventName, "PreToolUse");
+    const ctx = parsed.hookSpecificOutput?.additionalContext ?? "";
+    assert.match(ctx, /trigger="todo-plan"/);
+    assert.match(ctx, /bastra-projekt-ubersicht-master/);
+
+    assert.ok(received, "mock daemon should have been called");
+    const r = received as { url: string | undefined; body: { type?: string; query?: string } };
+    assert.equal(r.url, "/hook/recall");
+    assert.equal(r.body.type, "project-fact", "must filter by type=project-fact");
+    assert.match(r.body.query ?? "", /daemon/);
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("integration — low-confidence todos emit empty object", async () => {
+  let hit = false;
+  const daemon = await startMockDaemon((_req, res) => {
+    hit = true;
+    res.writeHead(200);
+    res.end('{"hits":[],"vault_size":0,"latency_ms":1,"recall_id":"x"}');
+  });
+  try {
+    const { stdout } = await runHook(
+      {
+        hook_event_name: "PreToolUse",
+        tool_name: "TodoWrite",
+        tool_input: { todos: [{ content: "ok", status: "pending" }] },
+      },
+      { BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}` },
+    );
+    assert.equal(stdout.trim(), "{}");
+    assert.equal(hit, false, "daemon must not be called for low-confidence todos");
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("integration — wrong tool_name emits empty object", async () => {
+  const daemon = await startMockDaemon((_req, res) => {
+    res.writeHead(200);
+    res.end("{}");
+  });
+  try {
+    const { stdout } = await runHook(
+      {
+        hook_event_name: "PreToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: "/tmp/x.ts" },
+      },
+      { BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}` },
+    );
+    assert.equal(stdout.trim(), "{}");
+  } finally {
+    await daemon.close();
+  }
+});

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -14,14 +14,17 @@
     "bastra-recall-mcp": "./dist/mcp-forwarder.js",
     "bastra-recall-bridge": "./dist/bridge.js",
     "bastra-recall-hook": "./dist/hook.js",
-    "bastra-recall-session-hook": "./dist/session-hook.js"
+    "bastra-recall-session-hook": "./dist/session-hook.js",
+    "bastra-recall-prompt-hook": "./dist/prompt-hook.js",
+    "bastra-recall-todo-hook": "./dist/todo-hook.js"
   },
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc && chmod +x dist/index.js dist/mcp-forwarder.js dist/bridge.js dist/hook.js dist/session-hook.js dist/cli.js",
+    "build": "tsc && chmod +x dist/index.js dist/mcp-forwarder.js dist/bridge.js dist/hook.js dist/session-hook.js dist/prompt-hook.js dist/todo-hook.js dist/cli.js",
     "start": "node dist/index.js",
     "check:types": "tsc --noEmit",
+    "test": "tsx --test __tests__/**/*.test.ts",
     "smoke": "tsx scripts/smoke.ts",
     "smoke:telemetry": "tsx scripts/telemetry-smoke.ts",
     "backfill:related": "tsx scripts/backfill-related.ts"

--- a/packages/daemon/src/prompt-hook.ts
+++ b/packages/daemon/src/prompt-hook.ts
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * bastra-recall prompt hook — UserPromptSubmit reflex layer (Issue #33).
+ *
+ * Pipeline:
+ *   stdin (JSON Claude-Code hook payload)
+ *     -> filter to hook_event_name === "UserPromptSubmit"
+ *     -> extract user prompt from payload.prompt / payload.user_message
+ *     -> detect retrieval mode -> "retrieval" | "none" (default) | "generic" (env-opt-in)
+ *     -> if retrieval/generic: POST 127.0.0.1:BASTRA_HTTP_PORT/hook/recall  (k=5, score-floor 50)
+ *     -> emit <recall-hints surface="claude-code" trigger="prompt-lookup"> with
+ *        explicit "use bastra-recall:recall BEFORE conversation_search" instruction
+ *     -> otherwise: emit `{}`
+ *
+ * Why a separate file (not added to hook.ts):
+ *   - hook.ts is under heavy refactor in a parallel PR; this hook ships as
+ *     its own CLI entry (`bastra-recall-prompt-hook`) to avoid merge friction.
+ *   - Helpers (postRecall/emitEmpty/telemetry/readStdin) are intentionally
+ *     copied — not imported — for the same reason.
+ */
+import { detectProject } from "@bastra-recall/core";
+import { request } from "node:http";
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { envFirst, envInt } from "./env.js";
+import { defaultLogDir } from "./telemetry.js";
+
+const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 250, "NEXUS_HOOK_TIMEOUT_MS");
+const DEFAULT_PORT = 6723;
+const HOOK_VERSION = "0.2.0";
+const SCORE_FLOOR = 50; // higher than PreToolUse: prompts rarely match recall_when exactly
+const MUST_LOAD_SCORE = 100;
+
+/** "retrieval-only" (default) or "all" (also recall on non-lookup prompts, score-gated to MUST_LOAD_SCORE). */
+type PromptHookMode = "retrieval-only" | "all";
+const HOOK_MODE: PromptHookMode =
+  (envFirst("BASTRA_PROMPT_HOOK_MODE") as PromptHookMode | undefined) ?? "retrieval-only";
+
+export interface ClaudeHookPayload {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  /** primary surface in Claude Code docs */
+  prompt?: string;
+  /** legacy / alternative key seen in some Claude-Code payload variants */
+  user_message?: string;
+}
+
+export interface RecallHit {
+  id: string;
+  title: string;
+  type: string;
+  scope: string;
+  summary: string;
+  score: number;
+}
+
+interface RecallResponse {
+  hits: RecallHit[];
+  vault_size: number;
+  latency_ms: number;
+  recall_id: string;
+}
+
+export type DetectedMode = "retrieval" | "none" | "generic";
+
+// DE + EN retrieval triggers — match the spec in Issue #33.
+const RETRIEVAL_DE = /^\s*(such|finde|wo (ist|sind)|wann (war|hatte)|wieviel|wie viel|was hab(e ich)?|was war)/i;
+const RETRIEVAL_EN = /^\s*(find|search|where (is|are)|when (was|did)|how much|what (did|was))/i;
+
+export function detectRetrieval(prompt: string): boolean {
+  const trimmed = prompt.trim();
+  if (trimmed.length === 0) return false;
+  return RETRIEVAL_DE.test(trimmed) || RETRIEVAL_EN.test(trimmed);
+}
+
+export function extractPrompt(payload: ClaudeHookPayload): string | null {
+  const raw =
+    typeof payload.prompt === "string"
+      ? payload.prompt
+      : typeof payload.user_message === "string"
+        ? payload.user_message
+        : null;
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+
+  const raw = await readStdin();
+  let payload: ClaudeHookPayload;
+  try {
+    payload = JSON.parse(raw) as ClaudeHookPayload;
+  } catch {
+    return emitEmpty();
+  }
+
+  if (payload.hook_event_name !== "UserPromptSubmit") return emitEmpty();
+
+  const prompt = extractPrompt(payload);
+  if (!prompt) return emitEmpty();
+
+  const isRetrieval = detectRetrieval(prompt);
+  let detectedMode: DetectedMode;
+  if (isRetrieval) {
+    detectedMode = "retrieval";
+  } else if (HOOK_MODE === "all") {
+    detectedMode = "generic";
+  } else {
+    detectedMode = "none";
+  }
+
+  if (detectedMode === "none") {
+    emitEmpty();
+    await writeTelemetry({
+      detected_mode: "none",
+      prompt_chars: prompt.length,
+      daemon_url: null,
+      daemon_reachable: false,
+      hint_count: 0,
+      top_score: null,
+      latency_ms_total: Date.now() - startedAt,
+      status: "ok",
+      error: null,
+    });
+    return;
+  }
+
+  const project = detectProject(payload.cwd ?? process.cwd());
+  const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
+  const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? String(DEFAULT_PORT);
+  const url = httpURL ?? `http://127.0.0.1:${httpPort}`;
+  const remainingMs = Math.max(50, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
+
+  // For "generic" mode we only show top-tier hits, so request fewer (k=3).
+  const k = detectedMode === "retrieval" ? 5 : 3;
+  // In "generic" mode bump the score floor to MUST_LOAD_SCORE — only show
+  // very strong matches to avoid noise on every single prompt.
+  const effectiveFloor = detectedMode === "generic" ? MUST_LOAD_SCORE : SCORE_FLOOR;
+
+  let resp: RecallResponse | null = null;
+  let status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" = "ok";
+  let errMsg: string | null = null;
+  try {
+    resp = await postRecall(
+      url,
+      { query: prompt, project, k, tool_name: "UserPromptSubmit" },
+      remainingMs,
+    );
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ECONNREFUSED" || e.code === "ENOTFOUND" || e.code === "EHOSTUNREACH") {
+      status = "daemon-unreachable";
+    } else if (e.message === "timeout") {
+      status = "timeout";
+    } else {
+      status = "error";
+      errMsg = e.message ?? String(err);
+    }
+  }
+
+  const filtered: RecallHit[] = [];
+  if (resp && Array.isArray(resp.hits)) {
+    for (const h of resp.hits) {
+      if (h.score < effectiveFloor) continue;
+      filtered.push(h);
+    }
+  }
+  if (resp && filtered.length === 0) status = "no-hits";
+
+  if (filtered.length === 0) {
+    emitEmpty();
+  } else {
+    const block = formatHintBlock(filtered, project, detectedMode);
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          additionalContext: block,
+        },
+      }),
+    );
+  }
+
+  await writeTelemetry({
+    detected_mode: detectedMode,
+    prompt_chars: prompt.length,
+    daemon_url: url,
+    daemon_reachable: resp !== null,
+    hint_count: filtered.length,
+    top_score: resp?.hits?.[0]?.score ?? null,
+    latency_ms_total: Date.now() - startedAt,
+    status,
+    error: errMsg,
+  });
+}
+
+function emitEmpty(): void {
+  process.stdout.write("{}");
+}
+
+function formatHintLine(h: RecallHit): string {
+  const summary = h.summary.length > 220 ? h.summary.slice(0, 217) + "…" : h.summary;
+  return `- ${h.id} (${h.type}, score ${Math.round(h.score)}): ${summary}`;
+}
+
+export function formatHintBlock(hits: RecallHit[], project: string | null, mode: DetectedMode): string {
+  const projAttr = project ? ` project="${escapeAttr(project)}"` : "";
+  const head = `<recall-hints surface="claude-code" trigger="prompt-lookup"${projAttr}>`;
+  const tail = `</recall-hints>`;
+
+  const required = hits.filter((h) => h.score >= MUST_LOAD_SCORE);
+  const optional = hits.filter((h) => h.score < MUST_LOAD_SCORE);
+  const sections: string[] = [];
+
+  if (mode === "retrieval") {
+    sections.push(
+      `The user prompt looks like a LOOKUP / retrieval query. ` +
+        `Use bastra-recall:recall (and find_document if pdf-likely) BEFORE conversation_search / web_search. ` +
+        `Pre-recalled candidates for this prompt:`,
+    );
+  } else {
+    sections.push(
+      `Pre-recall surfaced strong matches (score >=${MUST_LOAD_SCORE}) for this prompt. ` +
+        `Load them via bastra-recall:load_memory before answering.`,
+    );
+  }
+
+  if (required.length > 0) {
+    sections.push("");
+    sections.push(
+      `REQUIRED — load_memory(id) for EACH of these before responding. ` +
+        `Score >=${MUST_LOAD_SCORE} = strong match:`,
+    );
+    for (const h of required) sections.push(formatHintLine(h));
+  }
+
+  if (optional.length > 0) {
+    if (required.length > 0) sections.push("");
+    sections.push(
+      `OPTIONAL (score ${SCORE_FLOOR}–${MUST_LOAD_SCORE - 1}) — load only if title/summary directly relates:`,
+    );
+    for (const h of optional) sections.push(formatHintLine(h));
+  }
+
+  return [head, ...sections, tail].join("\n");
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+interface RecallRequestBody {
+  query: string;
+  project: string | null;
+  k: number;
+  tool_name: string;
+  scope?: string;
+  type?: string;
+}
+
+function postRecall(
+  baseUrl: string,
+  body: RecallRequestBody,
+  timeoutMs: number,
+): Promise<RecallResponse> {
+  return new Promise((resolve, reject) => {
+    let url: URL;
+    try {
+      url = new URL("/hook/recall", baseUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const payload = Buffer.from(JSON.stringify(body), "utf8");
+    const req = request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": payload.byteLength.toString(),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const data = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(`HTTP ${res.statusCode}: ${data.slice(0, 200)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(data) as RecallResponse);
+          } catch {
+            reject(new Error("invalid JSON response from daemon"));
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("timeout"));
+    });
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+interface PromptHookTelemetry {
+  detected_mode: DetectedMode;
+  prompt_chars: number;
+  daemon_url: string | null;
+  daemon_reachable: boolean;
+  hint_count: number;
+  top_score: number | null;
+  latency_ms_total: number;
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
+  error: string | null;
+}
+
+async function writeTelemetry(payload: PromptHookTelemetry): Promise<void> {
+  if ((envFirst("BASTRA_TELEMETRY", "NEXUS_TELEMETRY") ?? "on").toLowerCase() === "off") return;
+  try {
+    const logDir = envFirst("BASTRA_LOG_PATH", "NEXUS_LOG_PATH") ?? defaultLogDir();
+    await mkdir(logDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const event = {
+      kind: "prompt_hook_call",
+      ts,
+      session_id: randomUUID(),
+      hook_version: HOOK_VERSION,
+      ...payload,
+    };
+    const file = join(logDir, `events-${ts.slice(0, 10)}.jsonl`);
+    await appendFile(file, JSON.stringify(event) + "\n", "utf8");
+  } catch {
+    // Telemetry must never break the hook.
+  }
+}
+
+// Only run the CLI when invoked directly (filename match), not when imported by tests.
+const argv1 = process.argv[1] ?? "";
+const isCliEntry = argv1.endsWith("prompt-hook.js") || argv1.endsWith("prompt-hook.ts");
+
+if (isCliEntry) {
+  const killSwitch = setTimeout(() => {
+    emitEmpty();
+    process.exit(0);
+  }, HOOK_TIMEOUT_MS + 50);
+  killSwitch.unref();
+
+  main()
+    .then(() => process.exit(0))
+    .catch(() => {
+      emitEmpty();
+      process.exit(0);
+    });
+}

--- a/packages/daemon/src/todo-hook.ts
+++ b/packages/daemon/src/todo-hook.ts
@@ -1,0 +1,435 @@
+#!/usr/bin/env node
+/**
+ * bastra-recall todo hook — TodoWrite reflex layer (Issue #36).
+ *
+ * Pipeline:
+ *   stdin (JSON Claude-Code hook payload)
+ *     -> filter to hook_event_name === "PreToolUse" AND tool_name === "TodoWrite"
+ *     -> from tool_input.todos (Array<{ content, status, ... }>):
+ *          · first 1–2 contents as full-text query
+ *          · top-3 topic words (lowercased tokens that appear in >= 2 todos)
+ *     -> if confidence too low (very short query + < 2 topic words): emit `{}`
+ *     -> otherwise POST 127.0.0.1:BASTRA_HTTP_PORT/hook/recall
+ *          { query, project, k=5, type: "project-fact" }
+ *     -> emit <recall-hints surface="claude-code" trigger="todo-plan"> with
+ *        explicit "load project-facts above before starting these todos" instruction.
+ *
+ * Why a separate file (not added to hook.ts):
+ *   - hook.ts is under heavy refactor in a parallel PR; this hook ships as
+ *     its own CLI entry (`bastra-recall-todo-hook`) to avoid merge friction.
+ */
+import { detectProject } from "@bastra-recall/core";
+import { request } from "node:http";
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { envFirst, envInt } from "./env.js";
+import { defaultLogDir } from "./telemetry.js";
+
+const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 250, "NEXUS_HOOK_TIMEOUT_MS");
+const DEFAULT_PORT = 6723;
+const HOOK_VERSION = "0.2.0";
+const SCORE_FLOOR = 50;
+const MUST_LOAD_SCORE = 100;
+const TOPIC_WORD_CAP = 3;
+const MIN_QUERY_LEN_WITHOUT_TOPICS = 10;
+
+export interface TodoItem {
+  content?: unknown;
+  status?: unknown;
+  activeForm?: unknown;
+}
+
+export interface ClaudeHookPayload {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_input?: { todos?: unknown } & Record<string, unknown>;
+}
+
+export interface RecallHit {
+  id: string;
+  title: string;
+  type: string;
+  scope: string;
+  summary: string;
+  score: number;
+}
+
+interface RecallResponse {
+  hits: RecallHit[];
+  vault_size: number;
+  latency_ms: number;
+  recall_id: string;
+}
+
+// Tiny stopword list — covers the most-common DE/EN noise tokens that would
+// otherwise dominate the topic-frequency map ("add", "fix", "the", "und"…).
+const STOPWORDS = new Set([
+  // EN
+  "the", "a", "an", "and", "or", "but", "if", "then", "for", "to", "of", "in",
+  "on", "at", "by", "with", "from", "as", "is", "are", "was", "were", "be",
+  "this", "that", "these", "those", "it", "its", "we", "i", "you", "they",
+  "add", "fix", "update", "make", "do", "use", "run", "set", "get", "new",
+  "all", "any", "into", "via", "out", "up", "down", "also",
+  // DE
+  "der", "die", "das", "den", "dem", "des", "ein", "eine", "einen", "einem",
+  "und", "oder", "aber", "wenn", "dann", "für", "fur", "zu", "von", "in",
+  "an", "auf", "mit", "bei", "aus", "als", "ist", "sind", "war", "waren",
+  "im", "am", "zur", "zum", "auch", "noch", "nicht", "kein", "keine",
+  "neu", "neue", "alle", "alles",
+]);
+
+export interface TopicExtraction {
+  query: string;
+  topics: string[];
+  todoCount: number;
+}
+
+/**
+ * Pull a topic-rich query out of a TodoWrite payload. Strategy:
+ * 1. Use the first 1–2 `content` strings verbatim as the spine of the query.
+ * 2. Tokenize ALL todo contents to a-z/0-9 words (length >= 3, no stopwords).
+ * 3. Pick the top words that appear in >= 2 todos as `topics`.
+ * 4. Final query = "<topics joined>  <first 2 todos joined>".
+ */
+export function extractTopicsFromTodos(todosRaw: unknown): TopicExtraction {
+  if (!Array.isArray(todosRaw)) {
+    return { query: "", topics: [], todoCount: 0 };
+  }
+  const todos: TodoItem[] = todosRaw.filter(
+    (t): t is TodoItem => typeof t === "object" && t !== null,
+  );
+  const contents: string[] = todos
+    .map((t) => (typeof t.content === "string" ? t.content : ""))
+    .filter((c) => c.length > 0);
+
+  if (contents.length === 0) {
+    return { query: "", topics: [], todoCount: todos.length };
+  }
+
+  // Per-todo unique word sets — count "appears in >= N todos", not raw freq,
+  // so a single chatty todo can't dominate the topic list.
+  const perTodoWords: Set<string>[] = contents.map((c) => {
+    const words = c
+      .toLowerCase()
+      .replace(/[^a-z0-9äöüß\s-]/gi, " ")
+      .split(/\s+/)
+      .filter((w) => w.length >= 3 && !STOPWORDS.has(w));
+    return new Set(words);
+  });
+
+  const docFreq = new Map<string, number>();
+  for (const set of perTodoWords) {
+    for (const w of set) {
+      docFreq.set(w, (docFreq.get(w) ?? 0) + 1);
+    }
+  }
+
+  const topics = [...docFreq.entries()]
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, TOPIC_WORD_CAP)
+    .map(([w]) => w);
+
+  const firstTwo = contents.slice(0, 2).join("  ");
+  const queryParts: string[] = [];
+  if (topics.length > 0) queryParts.push(topics.join(" "));
+  queryParts.push(firstTwo);
+  const query = queryParts.join("  ").trim();
+
+  return { query, topics, todoCount: todos.length };
+}
+
+/** Min-confidence gate — reject extractions that are too thin to be useful. */
+export function isLowConfidence(extraction: TopicExtraction): boolean {
+  if (extraction.todoCount === 0) return true;
+  if (extraction.query.length === 0) return true;
+  if (extraction.topics.length < 2 && extraction.query.length < MIN_QUERY_LEN_WITHOUT_TOPICS) {
+    return true;
+  }
+  return false;
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+
+  const raw = await readStdin();
+  let payload: ClaudeHookPayload;
+  try {
+    payload = JSON.parse(raw) as ClaudeHookPayload;
+  } catch {
+    return emitEmpty();
+  }
+
+  if (payload.hook_event_name !== "PreToolUse") return emitEmpty();
+  if (payload.tool_name !== "TodoWrite") return emitEmpty();
+
+  const extraction = extractTopicsFromTodos(payload.tool_input?.todos);
+  if (isLowConfidence(extraction)) {
+    emitEmpty();
+    await writeTelemetry({
+      topic: extraction.topics.join(",") || null,
+      todo_count: extraction.todoCount,
+      query_chars: extraction.query.length,
+      daemon_url: null,
+      daemon_reachable: false,
+      hit_count: 0,
+      top_score: null,
+      latency_ms_total: Date.now() - startedAt,
+      status: "low-confidence",
+      error: null,
+    });
+    return;
+  }
+
+  const project = detectProject(payload.cwd ?? process.cwd());
+  const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
+  const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? String(DEFAULT_PORT);
+  const url = httpURL ?? `http://127.0.0.1:${httpPort}`;
+  const remainingMs = Math.max(50, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
+
+  let resp: RecallResponse | null = null;
+  let status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" | "low-confidence" =
+    "ok";
+  let errMsg: string | null = null;
+  try {
+    resp = await postRecall(
+      url,
+      {
+        query: extraction.query,
+        topics: extraction.topics,
+        project,
+        tool_name: "TodoWrite",
+        k: 5,
+        type: "project-fact",
+      },
+      remainingMs,
+    );
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ECONNREFUSED" || e.code === "ENOTFOUND" || e.code === "EHOSTUNREACH") {
+      status = "daemon-unreachable";
+    } else if (e.message === "timeout") {
+      status = "timeout";
+    } else {
+      status = "error";
+      errMsg = e.message ?? String(err);
+    }
+  }
+
+  const filtered: RecallHit[] = [];
+  if (resp && Array.isArray(resp.hits)) {
+    for (const h of resp.hits) {
+      if (h.score < SCORE_FLOOR) continue;
+      filtered.push(h);
+    }
+  }
+  if (resp && filtered.length === 0) status = "no-hits";
+
+  if (filtered.length === 0) {
+    emitEmpty();
+  } else {
+    const block = formatHintBlock(filtered, project, extraction.topics);
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext: block,
+        },
+      }),
+    );
+  }
+
+  await writeTelemetry({
+    topic: extraction.topics.join(",") || null,
+    todo_count: extraction.todoCount,
+    query_chars: extraction.query.length,
+    daemon_url: url,
+    daemon_reachable: resp !== null,
+    hit_count: filtered.length,
+    top_score: resp?.hits?.[0]?.score ?? null,
+    latency_ms_total: Date.now() - startedAt,
+    status,
+    error: errMsg,
+  });
+}
+
+function emitEmpty(): void {
+  process.stdout.write("{}");
+}
+
+function formatHintLine(h: RecallHit): string {
+  const summary = h.summary.length > 220 ? h.summary.slice(0, 217) + "…" : h.summary;
+  return `- ${h.id} (${h.type}, score ${Math.round(h.score)}): ${summary}`;
+}
+
+export function formatHintBlock(
+  hits: RecallHit[],
+  project: string | null,
+  topics: string[],
+): string {
+  const projAttr = project ? ` project="${escapeAttr(project)}"` : "";
+  const topicsAttr = topics.length > 0 ? ` topics="${escapeAttr(topics.join(","))}"` : "";
+  const head = `<recall-hints surface="claude-code" trigger="todo-plan"${projAttr}${topicsAttr}>`;
+  const tail = `</recall-hints>`;
+
+  const required = hits.filter((h) => h.score >= MUST_LOAD_SCORE);
+  const optional = hits.filter((h) => h.score < MUST_LOAD_SCORE);
+  const sections: string[] = [];
+
+  sections.push(
+    `You just produced a multi-step plan via TodoWrite. ` +
+      `Before starting these todos, load the project-facts above to understand ` +
+      `the current file layout / past decisions in this area. ` +
+      `Call bastra-recall:load_memory(id) for each REQUIRED hit; treat OPTIONAL hits as candidates.`,
+  );
+
+  if (required.length > 0) {
+    sections.push("");
+    sections.push(
+      `REQUIRED — load_memory(id) for EACH of these BEFORE the first todo. ` +
+        `Score >=${MUST_LOAD_SCORE} = strong topology / decision match:`,
+    );
+    for (const h of required) sections.push(formatHintLine(h));
+  }
+
+  if (optional.length > 0) {
+    if (required.length > 0) sections.push("");
+    sections.push(
+      `OPTIONAL (score ${SCORE_FLOOR}–${MUST_LOAD_SCORE - 1}) — load only if title/summary maps to a concrete todo:`,
+    );
+    for (const h of optional) sections.push(formatHintLine(h));
+  }
+
+  return [head, ...sections, tail].join("\n");
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+interface RecallRequestBody {
+  query: string;
+  topics: string[];
+  project: string | null;
+  tool_name: string;
+  k: number;
+  scope?: string;
+  type?: string;
+}
+
+function postRecall(
+  baseUrl: string,
+  body: RecallRequestBody,
+  timeoutMs: number,
+): Promise<RecallResponse> {
+  return new Promise((resolve, reject) => {
+    let url: URL;
+    try {
+      url = new URL("/hook/recall", baseUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const payload = Buffer.from(JSON.stringify(body), "utf8");
+    const req = request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": payload.byteLength.toString(),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const data = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(`HTTP ${res.statusCode}: ${data.slice(0, 200)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(data) as RecallResponse);
+          } catch {
+            reject(new Error("invalid JSON response from daemon"));
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("timeout"));
+    });
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+interface TodoHookTelemetry {
+  topic: string | null;
+  todo_count: number;
+  query_chars: number;
+  daemon_url: string | null;
+  daemon_reachable: boolean;
+  hit_count: number;
+  top_score: number | null;
+  latency_ms_total: number;
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" | "low-confidence";
+  error: string | null;
+}
+
+async function writeTelemetry(payload: TodoHookTelemetry): Promise<void> {
+  if ((envFirst("BASTRA_TELEMETRY", "NEXUS_TELEMETRY") ?? "on").toLowerCase() === "off") return;
+  try {
+    const logDir = envFirst("BASTRA_LOG_PATH", "NEXUS_LOG_PATH") ?? defaultLogDir();
+    await mkdir(logDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const event = {
+      kind: "todo_hook_call",
+      ts,
+      session_id: randomUUID(),
+      hook_version: HOOK_VERSION,
+      ...payload,
+    };
+    const file = join(logDir, `events-${ts.slice(0, 10)}.jsonl`);
+    await appendFile(file, JSON.stringify(event) + "\n", "utf8");
+  } catch {
+    // Telemetry must never break the hook.
+  }
+}
+
+// Only run the CLI when invoked directly, not when imported by tests.
+const argv1 = process.argv[1] ?? "";
+const isCliEntry = argv1.endsWith("todo-hook.js") || argv1.endsWith("todo-hook.ts");
+
+if (isCliEntry) {
+  const killSwitch = setTimeout(() => {
+    emitEmpty();
+    process.exit(0);
+  }, HOOK_TIMEOUT_MS + 50);
+  killSwitch.unref();
+
+  main()
+    .then(() => process.exit(0))
+    .catch(() => {
+      emitEmpty();
+      process.exit(0);
+    });
+}


### PR DESCRIPTION
## Summary

Two new Claude-Code hook CLIs that extend the bastra-recall reflex layer
without touching `packages/daemon/src/hook.ts` (currently under refactor
in PR #43).

- **`bastra-recall-prompt-hook`** — `UserPromptSubmit` reflex (#33).
  Detects DE+EN lookup phrases (`such|finde|wo (ist|sind)|find|search|
  where (is|are)|…`), recalls verbatim against `/hook/recall` (k=5,
  score-floor 50), and emits `<recall-hints surface="claude-code"
  trigger="prompt-lookup">` with an explicit "use bastra-recall:recall
  BEFORE conversation_search / web_search" instruction. Non-retrieval
  prompts emit `{}` by default; `BASTRA_PROMPT_HOOK_MODE=all` flips on a
  generic mode that only surfaces score ≥100 hits.
- **`bastra-recall-todo-hook`** — `PreToolUse` + `TodoWrite` reflex (#36).
  Extracts the top-3 topic words (appears in ≥2 todos, DE+EN stopword
  filter) plus the first 1–2 todo contents as the query, recalls with
  `type=project-fact`, k=5, score-floor 50. Skips silently when topics
  are too thin. Emits `<recall-hints surface="claude-code"
  trigger="todo-plan" topics="…">` instructing Claude to load the
  surfaced project-facts before the first todo.
- **Tests** (`tsx --test`): 21 cases total, 11 for prompt-hook and 10
  for todo-hook. Each suite includes integration tests against an
  in-process mock daemon HTTP server.
- **Docs**: new `docs/hooks.md` with the full `~/.claude/settings.json`
  activation snippet for all four hooks (session, file-mutation, prompt,
  todo) and an env-var reference.
- **New telemetry events**: `prompt_hook_call`, `todo_hook_call`.
- **New bins**: `bastra-recall-prompt-hook`, `bastra-recall-todo-hook`.

Both hooks copy the helper patterns (postRecall, emitEmpty, readStdin,
telemetry) from `hook.ts` rather than importing them, so this PR can
land independently of #43.

Closes #33
Closes #36

## Test plan

- [x] `npm run check:types` clean across the workspace
- [x] `npm run build` clean across the workspace (chmod includes the
      two new dist entries)
- [x] `npm test --workspace=@bastra-recall/daemon` — 21/21 passing
- [ ] Dogfood: install bins (`npm link` or `bastra install-hook`) and
      verify "such mal meinen Strafzettel" triggers recall in a fresh
      Claude Code session
- [ ] Dogfood: TodoWrite over a bastra-recall feature surfaces
      `[[bastra-projekt-ubersicht-master]]` as a hint
- [ ] Verify telemetry rows land in `~/.bastra/logs/events-*.jsonl`
      with `kind: "prompt_hook_call"` and `kind: "todo_hook_call"`

Generated with [Claude Code](https://claude.com/claude-code)