### PR TITLE
feat(hook): Bash safety + autonomous save-eval reflex hooks (#34 #37 #35)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,131 @@
+# Hooks — Claude-Code reflex layer
+
+bastra-recall ships a set of Claude-Code hooks that surface relevant vault
+memories (lessons, decisions, project facts, user preferences) at the exact
+moment Claude is about to act, fail, or stop. The agent reads the hook
+output as `additionalContext` and can `load_memory(id)` the hits before
+proceeding.
+
+All hooks are **non-blocking**: they never set `block: true`. Worst case
+they emit `{}` and Claude continues unaffected. They share three
+discipline rules:
+
+- Hard wall-clock budget (~250 ms for PreToolUse, ~1000 ms for Stop).
+- Any failure path emits `{}` and exits 0.
+- Telemetry is best-effort, never breaks the hook.
+
+## Installed binaries
+
+After `npm run build` the daemon package exposes these bin entries:
+
+| Bin                                | Event                | Tool matcher |
+|------------------------------------|----------------------|--------------|
+| `bastra-recall-hook`               | `PreToolUse`         | Write/Edit/MultiEdit/NotebookEdit |
+| `bastra-recall-session-hook`       | `SessionStart`       | — |
+| `bastra-recall-bash-pre-hook`      | `PreToolUse`         | Bash (destructive/risky) |
+| `bastra-recall-bash-fail-hook`     | `PostToolUse`        | Bash (non-zero exit) |
+| `bastra-recall-stop-hook`          | `Stop`               | — |
+
+## settings.json — minimal snippet
+
+Add to `~/.claude/settings.json` or the project-local `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "command": "bastra-recall-bash-pre-hook" }
+    ],
+    "PostToolUse": [
+      { "matcher": "Bash", "command": "bastra-recall-bash-fail-hook" }
+    ],
+    "Stop": [
+      { "command": "bastra-recall-stop-hook" }
+    ]
+  }
+}
+```
+
+If you also use the existing write/edit + session-start hooks, the full
+shape looks like:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "command": "bastra-recall-session-hook" }
+    ],
+    "PreToolUse": [
+      { "matcher": "Write|Edit|MultiEdit|NotebookEdit", "command": "bastra-recall-hook" },
+      { "matcher": "Bash", "command": "bastra-recall-bash-pre-hook" }
+    ],
+    "PostToolUse": [
+      { "matcher": "Bash", "command": "bastra-recall-bash-fail-hook" }
+    ],
+    "Stop": [
+      { "command": "bastra-recall-stop-hook" }
+    ]
+  }
+}
+```
+
+## Hook semantics
+
+### Bash-Pre-Hook (`bastra-recall-bash-pre-hook`) — issue #34
+
+Matches the Bash command against a curated list of destructive and risky
+patterns. On match it recalls relevant safety lessons / user-preferences
+(`scope=all-projects`, score floor 50) and emits a
+`<recall-hints surface="claude-code" trigger="bash-destructive">` block
+warning Claude to stop and confirm with the user.
+
+Destructive patterns (subset): `rm -rf`, `rm -r`, `rmdir`,
+`git reset --hard`, `git checkout -- `, `git clean -f`, `git branch -D`,
+`git push --force` / `--force-with-lease` / `-f`, `git commit --amend`,
+`gh repo delete`, `gh release delete`, `npm uninstall` / `npm rm`,
+`yarn remove`, `pnpm rm`, `DROP TABLE`, `DROP DATABASE`, `TRUNCATE`,
+`docker rm`, `docker volume rm`, `kubectl delete`.
+
+Risky patterns: `chmod -R`, `chown -R`, `find ... -exec rm`,
+`>` overwrite-redirect.
+
+Does **not** block. The agent decides whether to proceed.
+
+Telemetry: `bash_hook_call` with `matched_pattern, severity, hit_count,
+top_score, status`.
+
+### Bash-Fail-Hook (`bastra-recall-bash-fail-hook`) — issue #37
+
+Fires on `PostToolUse` for Bash when `exit_code !== 0` (excluding 130 =
+Ctrl-C). Extracts the command head + last interesting error lines,
+recalls similar failure-mode memories, and emits
+`<recall-hints surface="claude-code" trigger="bash-fail">`.
+
+Throttled to one hint per 30 s per session (marker file in
+`$TMPDIR/bastra-hook/fail-throttle-<session>.ts`). Skips its own
+`bastra-recall-*` invocations to avoid loops.
+
+Telemetry: `bash_fail_hook_call` with `exit_code, command_head, hit_count,
+top_score, status`.
+
+### Stop-Hook (`bastra-recall-stop-hook`) — issue #35
+
+Fires on `Stop`. Reads the last ~30 transcript turns (from
+`payload.transcript_path` or inline `payload.transcript`) and evaluates
+three heuristics:
+
+1. **frustration-density** — ≥3 cues (`wieder`, `schon wieder`,
+   `wie oft`, CAPS-words, `fuck`, `verdammt`, `scheisse/scheiße`) in the
+   last 10 user turns → suggests a `lesson` save.
+2. **feature-completion** — `git commit` mention + ≥3 distinct file
+   tokens in transcript → suggests a `project-fact` save.
+3. **architecture-decision** — `ok dann | lass uns | entschieden |
+   final | gehen wir mit` in last 5 user turns → suggests a `decision`
+   save.
+
+Output is one or more `<save-eval>` blocks suggesting title/type/body.
+The hook **never calls `save_memory` itself** — only the agent does,
+in the next turn, if it agrees with the suggestion.
+
+Budget 1000 ms. Telemetry: `save_eval_call` with `heuristic,
+suggested_count, turn_count, latency_ms_total`.

--- a/packages/daemon/__tests__/bash-fail-hook.test.ts
+++ b/packages/daemon/__tests__/bash-fail-hook.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, beforeEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { unlink } from "node:fs/promises";
+import {
+  readExitCode,
+  extractErrorContext,
+  extractCommandHead,
+  extractErrorKeywords,
+  formatHintBlock,
+  isThrottled,
+  markThrottle,
+  throttleFile,
+} from "../src/bash-fail-hook.js";
+
+const SESSION = "test-session-fail-hook";
+
+async function clearThrottle(): Promise<void> {
+  try {
+    await unlink(throttleFile(SESSION));
+  } catch {
+    // ignore
+  }
+}
+
+describe("bash-fail-hook: readExitCode", () => {
+  it("reads exit_code from numeric field", () => {
+    assert.equal(readExitCode({ exit_code: 1 }), 1);
+  });
+  it("reads from camelCase exitCode", () => {
+    assert.equal(readExitCode({ exitCode: 2 }), 2);
+  });
+  it("parses string exit codes", () => {
+    assert.equal(readExitCode({ exit_code: "127" }), 127);
+  });
+  it("returns null when missing", () => {
+    assert.equal(readExitCode({}), null);
+  });
+});
+
+describe("bash-fail-hook: extractCommandHead", () => {
+  it("returns first 3 tokens of first clause", () => {
+    assert.equal(extractCommandHead("npm install --save react"), "npm install --save");
+  });
+  it("stops at pipeline operators", () => {
+    assert.equal(extractCommandHead("ls -la | grep foo"), "ls -la");
+  });
+});
+
+describe("bash-fail-hook: extractErrorContext", () => {
+  it("prefers error/Failed/fatal lines", () => {
+    const out = extractErrorContext({
+      stderr: "doing things\nthings happen\nError: ENOENT no such file\ndone",
+    });
+    assert.match(out, /Error: ENOENT/);
+  });
+  it("falls back to tail when no interesting lines", () => {
+    const out = extractErrorContext({ stderr: "plain noise" });
+    assert.equal(out, "plain noise");
+  });
+});
+
+describe("bash-fail-hook: extractErrorKeywords", () => {
+  it("extracts alpha-token keywords, deduped, capped", () => {
+    const out = extractErrorKeywords("Error: ENOENT module not found react react react");
+    assert.match(out, /Error/);
+    assert.match(out, /ENOENT/);
+    assert.match(out, /module/);
+    // dedup: 'react' should appear once
+    assert.equal((out.match(/react/g) ?? []).length, 1);
+  });
+});
+
+describe("bash-fail-hook: formatHintBlock", () => {
+  it("emits bash-fail trigger and the failure-mode wording", () => {
+    const out = formatHintBlock([
+      {
+        id: "some-lesson",
+        title: "t",
+        type: "lesson",
+        scope: "all",
+        summary: "s",
+        score: 80,
+      },
+    ]);
+    assert.match(out, /trigger="bash-fail"/);
+    assert.match(out, /failure modes/);
+    assert.match(out, /some-lesson/);
+  });
+});
+
+describe("bash-fail-hook: throttle", () => {
+  beforeEach(async () => {
+    await clearThrottle();
+  });
+
+  it("is not throttled before any markThrottle call", async () => {
+    assert.equal(await isThrottled(SESSION), false);
+  });
+
+  it("is throttled immediately after markThrottle", async () => {
+    await markThrottle(SESSION);
+    assert.equal(await isThrottled(SESSION), true);
+  });
+});

--- a/packages/daemon/__tests__/bash-pre-hook.test.ts
+++ b/packages/daemon/__tests__/bash-pre-hook.test.ts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import { matchPattern, formatHintBlock } from "../src/bash-pre-hook.js";
+
+describe("bash-pre-hook: matchPattern", () => {
+  it("matches rm -rf as destructive", () => {
+    const m = matchPattern("rm -rf /tmp/x");
+    assert.ok(m, "expected match");
+    assert.equal(m!.severity, "destructive");
+    assert.equal(m!.label, "rm -rf");
+  });
+
+  it("matches git reset --hard as destructive", () => {
+    const m = matchPattern("git reset --hard origin/main");
+    assert.ok(m);
+    assert.equal(m!.severity, "destructive");
+    assert.equal(m!.label, "git reset --hard");
+  });
+
+  it("matches git push --force as destructive", () => {
+    const m = matchPattern("git push --force origin main");
+    assert.ok(m);
+    assert.equal(m!.severity, "destructive");
+  });
+
+  it("matches git push -f as destructive", () => {
+    const m = matchPattern("git push -f origin feat/x");
+    assert.ok(m);
+    assert.equal(m!.severity, "destructive");
+  });
+
+  it("matches DROP TABLE (case-insensitive)", () => {
+    const m = matchPattern("psql -c 'drop table users;'");
+    assert.ok(m);
+    assert.equal(m!.label, "DROP TABLE");
+  });
+
+  it("matches npm uninstall", () => {
+    const m = matchPattern("npm uninstall react");
+    assert.ok(m);
+    assert.equal(m!.label, "npm uninstall");
+  });
+
+  it("matches docker volume rm", () => {
+    const m = matchPattern("docker volume rm myvol");
+    assert.ok(m);
+    assert.equal(m!.label, "docker volume rm");
+  });
+
+  it("matches kubectl delete", () => {
+    const m = matchPattern("kubectl delete pod foo");
+    assert.ok(m);
+    assert.equal(m!.label, "kubectl delete");
+  });
+
+  it("matches chmod -R as risky", () => {
+    const m = matchPattern("chmod -R 755 ./dist");
+    assert.ok(m);
+    assert.equal(m!.severity, "risky");
+    assert.equal(m!.label, "chmod -R");
+  });
+
+  it("matches find ... -exec rm as risky", () => {
+    const m = matchPattern("find . -name '*.tmp' -exec rm {} ;");
+    assert.ok(m);
+    assert.equal(m!.severity, "risky");
+  });
+
+  it("matches > overwrite redirect as risky", () => {
+    const m = matchPattern("echo hi > /etc/hosts");
+    assert.ok(m);
+    assert.equal(m!.severity, "risky");
+  });
+
+  it("does NOT match ls -la", () => {
+    assert.equal(matchPattern("ls -la"), null);
+  });
+
+  it("does NOT match git status", () => {
+    assert.equal(matchPattern("git status"), null);
+  });
+
+  it("does NOT match >> append redirect", () => {
+    assert.equal(matchPattern("echo hi >> log.txt"), null);
+  });
+
+  it("does NOT match 2> stderr redirect alone", () => {
+    assert.equal(matchPattern("cmd 2> err.log"), null);
+  });
+
+  it("does NOT match echo with no redirect", () => {
+    assert.equal(matchPattern("echo hello world"), null);
+  });
+});
+
+describe("bash-pre-hook: formatHintBlock", () => {
+  it("emits destructive trigger and STOP wording", () => {
+    const out = formatHintBlock("rm -rf", "destructive", []);
+    assert.match(out, /trigger="bash-destructive"/);
+    assert.match(out, /STOP — destructive/);
+    assert.match(out, /rm -rf/);
+  });
+
+  it("emits risky trigger and CAUTION wording", () => {
+    const out = formatHintBlock("chmod -R", "risky", []);
+    assert.match(out, /trigger="bash-risky"/);
+    assert.match(out, /CAUTION/);
+  });
+
+  it("includes hits when present", () => {
+    const hits = [
+      {
+        id: "no-force-push",
+        title: "no force push",
+        type: "user-preference",
+        scope: "all-projects",
+        summary: "Never force-push without explicit ok.",
+        score: 95,
+      },
+    ];
+    const out = formatHintBlock("git push --force", "destructive", hits);
+    assert.match(out, /no-force-push/);
+    assert.match(out, /score 95/);
+  });
+});

--- a/packages/daemon/__tests__/stop-hook.test.ts
+++ b/packages/daemon/__tests__/stop-hook.test.ts
@@ -1,0 +1,181 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  evaluateHeuristics,
+  detectFrustration,
+  detectFeatureCompletion,
+  detectArchitectureDecision,
+  formatSuggestion,
+  parseTranscriptFile,
+  normalizeTurns,
+  type TranscriptTurn,
+} from "../src/stop-hook.js";
+
+function userTurn(content: string): TranscriptTurn {
+  return { role: "user", content };
+}
+function assistantTurn(content: string): TranscriptTurn {
+  return { role: "assistant", content };
+}
+
+describe("stop-hook: detectFrustration", () => {
+  it("fires on >=3 'wieder' tokens in window", () => {
+    const turns: TranscriptTurn[] = [
+      userTurn("schon wieder kaputt"),
+      assistantTurn("sorry"),
+      userTurn("wieder das gleiche!"),
+      assistantTurn("fixe ich"),
+      userTurn("wieder!"),
+    ];
+    const s = detectFrustration(turns);
+    assert.ok(s);
+    assert.equal(s!.heuristic, "frustration-density");
+  });
+
+  it("counts CAPS-words as frustration cues", () => {
+    const turns: TranscriptTurn[] = [
+      userTurn("NEIN das war FALSCH"),
+      userTurn("wieder kaputt"),
+      userTurn("ECHT JETZT"),
+    ];
+    const s = detectFrustration(turns);
+    assert.ok(s);
+  });
+
+  it("does not fire below threshold", () => {
+    const turns: TranscriptTurn[] = [
+      userTurn("normal"),
+      userTurn("alles ok"),
+      userTurn("klingt gut"),
+    ];
+    assert.equal(detectFrustration(turns), null);
+  });
+});
+
+describe("stop-hook: detectFeatureCompletion", () => {
+  it("fires on git commit + >=3 file tokens", () => {
+    const turns: TranscriptTurn[] = [
+      assistantTurn(
+        "running git commit -m 'feat: x'\n" +
+          "edited packages/daemon/src/foo.ts, packages/daemon/src/bar.ts, packages/daemon/__tests__/foo.test.ts",
+      ),
+    ];
+    const s = detectFeatureCompletion(turns);
+    assert.ok(s);
+    assert.equal(s!.heuristic, "feature-completion");
+    assert.equal(s!.type, "project-fact");
+  });
+
+  it("does not fire without commit mention", () => {
+    const turns: TranscriptTurn[] = [
+      assistantTurn("just reading foo.ts, bar.ts, baz.ts — no changes"),
+    ];
+    assert.equal(detectFeatureCompletion(turns), null);
+  });
+
+  it("does not fire without enough files", () => {
+    const turns: TranscriptTurn[] = [
+      assistantTurn("git commit -m 'tweak'\nonly foo.ts touched"),
+    ];
+    assert.equal(detectFeatureCompletion(turns), null);
+  });
+});
+
+describe("stop-hook: detectArchitectureDecision", () => {
+  it("fires on 'ok dann'", () => {
+    const turns: TranscriptTurn[] = [
+      userTurn("ok dann nehmen wir Drizzle"),
+    ];
+    const s = detectArchitectureDecision(turns);
+    assert.ok(s);
+    assert.equal(s!.heuristic, "architecture-decision");
+    assert.equal(s!.type, "decision");
+  });
+
+  it("fires on 'lass uns'", () => {
+    assert.ok(detectArchitectureDecision([userTurn("lass uns mit MapKit gehen")]));
+  });
+
+  it("does not fire on neutral chatter", () => {
+    assert.equal(
+      detectArchitectureDecision([userTurn("schauen wir mal weiter")]),
+      null,
+    );
+  });
+});
+
+describe("stop-hook: evaluateHeuristics", () => {
+  it("returns empty array on neutral transcript", () => {
+    const out = evaluateHeuristics([
+      userTurn("bitte X"),
+      assistantTurn("done"),
+    ]);
+    assert.deepEqual(out, []);
+  });
+
+  it("can fire multiple heuristics at once", () => {
+    const turns: TranscriptTurn[] = [
+      userTurn("wieder kaputt"),
+      userTurn("schon wieder"),
+      userTurn("WIE OFT NOCH"),
+      assistantTurn("git commit -m 'fix'\nedited a.ts, b.ts, c.ts"),
+      userTurn("ok dann nehmen wir das"),
+    ];
+    const out = evaluateHeuristics(turns);
+    const kinds = out.map((s) => s.heuristic).sort();
+    assert.deepEqual(kinds, [
+      "architecture-decision",
+      "feature-completion",
+      "frustration-density",
+    ]);
+  });
+});
+
+describe("stop-hook: formatSuggestion", () => {
+  it("emits <save-eval> block with title/type/body lines", () => {
+    const s = {
+      heuristic: "frustration-density" as const,
+      title: "x",
+      type: "lesson" as const,
+      body: "the body",
+    };
+    const out = formatSuggestion(s);
+    assert.match(out, /<save-eval>/);
+    assert.match(out, /heuristic: frustration-density/);
+    assert.match(out, /title: "x"/);
+    assert.match(out, /type: lesson/);
+    assert.match(out, /<\/save-eval>/);
+  });
+});
+
+describe("stop-hook: parseTranscriptFile", () => {
+  it("parses JSONL", () => {
+    const raw = [
+      JSON.stringify({ role: "user", content: "hi" }),
+      JSON.stringify({ role: "assistant", content: "ok" }),
+    ].join("\n");
+    const turns = parseTranscriptFile(raw);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0].role, "user");
+  });
+
+  it("parses Claude-Code nested message shape", () => {
+    const raw = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "hello" },
+    });
+    const turns = parseTranscriptFile(raw);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0].content, "hello");
+  });
+
+  it("parses array-of-content-blocks", () => {
+    const items = [{ role: "user", content: [{ type: "text", text: "hi there" }] }];
+    const turns = normalizeTurns(items);
+    assert.equal(turns[0].content, "hi there");
+  });
+
+  it("returns empty on garbage input", () => {
+    assert.deepEqual(parseTranscriptFile("not json at all"), []);
+  });
+});

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -14,12 +14,15 @@
     "bastra-recall-mcp": "./dist/mcp-forwarder.js",
     "bastra-recall-bridge": "./dist/bridge.js",
     "bastra-recall-hook": "./dist/hook.js",
-    "bastra-recall-session-hook": "./dist/session-hook.js"
+    "bastra-recall-session-hook": "./dist/session-hook.js",
+    "bastra-recall-bash-pre-hook": "./dist/bash-pre-hook.js",
+    "bastra-recall-bash-fail-hook": "./dist/bash-fail-hook.js",
+    "bastra-recall-stop-hook": "./dist/stop-hook.js"
   },
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc && chmod +x dist/index.js dist/mcp-forwarder.js dist/bridge.js dist/hook.js dist/session-hook.js dist/cli.js",
+    "build": "tsc && chmod +x dist/index.js dist/mcp-forwarder.js dist/bridge.js dist/hook.js dist/session-hook.js dist/cli.js dist/bash-pre-hook.js dist/bash-fail-hook.js dist/stop-hook.js",
     "start": "node dist/index.js",
     "check:types": "tsc --noEmit",
     "smoke": "tsx scripts/smoke.ts",

--- a/packages/daemon/src/bash-fail-hook.ts
+++ b/packages/daemon/src/bash-fail-hook.ts
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+/**
+ * bastra-recall bash-fail-hook — PostToolUse hook for failed Bash commands.
+ *
+ * When a Bash command fails (non-zero exit), surface vault lessons that
+ * describe similar failure modes so Claude can check them before retrying
+ * or trying alternatives.
+ *
+ * Pipeline:
+ *   stdin (Claude-Code hook payload, hook_event_name=PostToolUse, tool_name=Bash)
+ *     → guard: exit_code !== 0, not 130 (Ctrl-C), not a bastra-recall-* invocation
+ *     → throttle: max 1 fail-hook / 30s / session
+ *     → extract error tail (last ~500 chars, prefer Error/error/Failed/fatal lines)
+ *     → POST 127.0.0.1:BASTRA_HTTP_PORT/hook/recall (k=3, floor 50)
+ *     → emit <recall-hints surface="claude-code" trigger="bash-fail">
+ *
+ * Discipline (mirrors hook.ts):
+ *   - Any failure path emits `{}` and exits 0.
+ *   - Never blocks the workflow — Claude already saw the failure.
+ *   - Never loops on its own invocations.
+ */
+import { request } from "node:http";
+import { appendFile, mkdir, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { envFirst, envInt } from "./env.js";
+import { defaultLogDir } from "./telemetry.js";
+
+const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 500, "NEXUS_HOOK_TIMEOUT_MS");
+const DEFAULT_PORT = 6723;
+const HOOK_VERSION = "0.1.0";
+const SCORE_FLOOR = 50;
+const THROTTLE_WINDOW_MS = 30_000;
+const THROTTLE_DIR = join(tmpdir(), "bastra-hook");
+
+interface ClaudeHookPayload {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_result?: Record<string, unknown>;
+  tool_response?: Record<string, unknown>;
+}
+
+interface RecallHit {
+  id: string;
+  title: string;
+  type: string;
+  scope: string;
+  summary: string;
+  score: number;
+}
+
+interface RecallResponse {
+  hits: RecallHit[];
+  vault_size: number;
+  latency_ms: number;
+  recall_id: string;
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+
+  const raw = await readStdin();
+  let payload: ClaudeHookPayload;
+  try {
+    payload = JSON.parse(raw) as ClaudeHookPayload;
+  } catch {
+    return emitEmpty();
+  }
+
+  if (payload.hook_event_name !== "PostToolUse") return emitEmpty();
+  if (payload.tool_name !== "Bash") return emitEmpty();
+
+  // Schema is in flux across Claude-Code versions: `tool_result` and
+  // `tool_response` have both been observed. Accept either.
+  const result = (payload.tool_result ?? payload.tool_response ?? {}) as Record<string, unknown>;
+  const exitCode = readExitCode(result);
+  if (exitCode === null || exitCode === 0) return emitEmpty();
+  if (exitCode === 130) return emitEmpty(); // SIGINT — user Ctrl-C
+
+  const toolInput = (payload.tool_input ?? {}) as Record<string, unknown>;
+  const command = typeof toolInput.command === "string" ? toolInput.command : "";
+  if (!command.trim()) return emitEmpty();
+
+  // No loop on our own binaries.
+  if (/\bbastra-recall(?:-[a-z-]+)?\b/.test(command)) return emitEmpty();
+
+  const sessionId = typeof payload.session_id === "string" ? payload.session_id : "default";
+  if (await isThrottled(sessionId)) return emitEmpty();
+
+  const errorContext = extractErrorContext(result);
+  const commandHead = extractCommandHead(command);
+  const errKeywords = extractErrorKeywords(errorContext);
+  const query = `${commandHead} ${errKeywords}`.trim().slice(0, 300);
+
+  const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
+  const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? String(DEFAULT_PORT);
+  const url = httpURL ?? `http://127.0.0.1:${httpPort}`;
+  const remainingMs = Math.max(50, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
+
+  let resp: RecallResponse | null = null;
+  let status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" = "ok";
+  let errMsg: string | null = null;
+  try {
+    resp = await postRecall(
+      url,
+      { query, topics: ["bash", "failure"], project: null, tool_name: "Bash", k: 3 },
+      remainingMs,
+    );
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ECONNREFUSED" || e.code === "ENOTFOUND" || e.code === "EHOSTUNREACH") {
+      status = "daemon-unreachable";
+    } else if (e.message === "timeout") {
+      status = "timeout";
+    } else {
+      status = "error";
+      errMsg = e.message ?? String(err);
+    }
+  }
+
+  const hits: RecallHit[] = [];
+  if (resp && Array.isArray(resp.hits)) {
+    for (const h of resp.hits) {
+      if (h.score >= SCORE_FLOOR) hits.push(h);
+    }
+  }
+  if (resp && hits.length === 0) status = "no-hits";
+
+  // No hits above floor → no value in interrupting Claude.
+  if (hits.length === 0) {
+    emitEmpty();
+  } else {
+    // Mark throttle only when we actually emit — otherwise quiet calls
+    // would burn the budget.
+    await markThrottle(sessionId);
+    const block = formatHintBlock(hits);
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+          additionalContext: block,
+        },
+      }),
+    );
+  }
+
+  const totalMs = Date.now() - startedAt;
+  await writeTelemetry({
+    exit_code: exitCode,
+    command_head: commandHead,
+    daemon_url: url,
+    daemon_reachable: resp !== null,
+    hit_count: hits.length,
+    top_score: resp?.hits?.[0]?.score ?? null,
+    latency_ms_total: totalMs,
+    status,
+    error: errMsg,
+  });
+}
+
+function emitEmpty(): void {
+  process.stdout.write("{}");
+}
+
+function readExitCode(result: Record<string, unknown>): number | null {
+  for (const key of ["exit_code", "exitCode", "returncode", "return_code", "status"]) {
+    const v = result[key];
+    if (typeof v === "number") return v;
+    if (typeof v === "string") {
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+function extractErrorContext(result: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const key of ["stderr", "error", "output", "stdout", "content"]) {
+    const v = result[key];
+    if (typeof v === "string") parts.push(v);
+  }
+  const joined = parts.join("\n");
+  if (!joined) return "";
+  // Last 500 chars first — that's where the real failure usually is.
+  const tail = joined.slice(-500);
+  // Pluck "interesting" lines if any.
+  const interesting = tail
+    .split(/\r?\n/)
+    .filter((line) => /\b(?:Error|error|Failed|FAILED|failed|fatal|FATAL)\b/.test(line))
+    .slice(-5)
+    .join("\n");
+  return interesting || tail;
+}
+
+/** First non-pipeline token of the command — usually the binary. */
+function extractCommandHead(command: string): string {
+  const firstClause = command.split(/[\n;&|]/)[0] ?? "";
+  const tokens = firstClause.trim().split(/\s+/).slice(0, 3);
+  return tokens.join(" ").slice(0, 80);
+}
+
+/** Pull a few alpha-tokens from the error context to seed the recall query. */
+function extractErrorKeywords(ctx: string): string {
+  if (!ctx) return "";
+  const tokens = ctx.match(/[A-Za-z][A-Za-z_.-]{3,}/g) ?? [];
+  // Dedup, keep order, cap.
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const t of tokens) {
+    const k = t.toLowerCase();
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(t);
+    if (out.length >= 12) break;
+  }
+  return out.join(" ");
+}
+
+function formatHintLine(h: RecallHit): string {
+  const summary = h.summary.length > 220 ? h.summary.slice(0, 217) + "…" : h.summary;
+  return `- ${h.id} (${h.type}, score ${Math.round(h.score)}): ${summary}`;
+}
+
+function formatHintBlock(hits: RecallHit[]): string {
+  const head = `<recall-hints surface="claude-code" trigger="bash-fail">`;
+  const tail = `</recall-hints>`;
+  const lines: string[] = [];
+  lines.push(
+    `The Bash command above failed. These memories describe similar failure modes — check before re-running or trying alternatives.`,
+  );
+  for (const h of hits) lines.push(formatHintLine(h));
+  return [head, ...lines, tail].join("\n");
+}
+
+function throttleFile(sessionId: string): string {
+  // sanitize sessionId — keep alnum + dash, fall back if empty
+  const safe = sessionId.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64) || "default";
+  return join(THROTTLE_DIR, `fail-throttle-${safe}.ts`);
+}
+
+async function isThrottled(sessionId: string): Promise<boolean> {
+  try {
+    const s = await stat(throttleFile(sessionId));
+    return Date.now() - s.mtimeMs < THROTTLE_WINDOW_MS;
+  } catch {
+    return false;
+  }
+}
+
+async function markThrottle(sessionId: string): Promise<void> {
+  try {
+    await mkdir(THROTTLE_DIR, { recursive: true });
+    await writeFile(throttleFile(sessionId), String(Date.now()), "utf8");
+  } catch {
+    // Best-effort; missing throttle is acceptable.
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+interface RecallRequestBody {
+  query: string;
+  topics: string[];
+  project: string | null;
+  tool_name: string;
+  k: number;
+  scope?: string;
+}
+
+function postRecall(
+  baseUrl: string,
+  body: RecallRequestBody,
+  timeoutMs: number,
+): Promise<RecallResponse> {
+  return new Promise((resolve, reject) => {
+    let url: URL;
+    try {
+      url = new URL("/hook/recall", baseUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const payload = Buffer.from(JSON.stringify(body), "utf8");
+    const req = request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": payload.byteLength.toString(),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const body = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(`HTTP ${res.statusCode}: ${body.slice(0, 200)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body) as RecallResponse);
+          } catch {
+            reject(new Error("invalid JSON response from daemon"));
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("timeout"));
+    });
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+interface BashFailHookTelemetry {
+  exit_code: number;
+  command_head: string;
+  daemon_url: string;
+  daemon_reachable: boolean;
+  hit_count: number;
+  top_score: number | null;
+  latency_ms_total: number;
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
+  error: string | null;
+}
+
+async function writeTelemetry(payload: BashFailHookTelemetry): Promise<void> {
+  if ((envFirst("BASTRA_TELEMETRY", "NEXUS_TELEMETRY") ?? "on").toLowerCase() === "off") return;
+  try {
+    const logDir = envFirst("BASTRA_LOG_PATH", "NEXUS_LOG_PATH") ?? defaultLogDir();
+    await mkdir(logDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const event = {
+      kind: "bash_fail_hook_call",
+      ts,
+      session_id: randomUUID(),
+      hook_version: HOOK_VERSION,
+      ...payload,
+    };
+    const file = join(logDir, `events-${ts.slice(0, 10)}.jsonl`);
+    await appendFile(file, JSON.stringify(event) + "\n", "utf8");
+  } catch {
+    // Telemetry must never break the hook.
+  }
+}
+
+// Export for testing.
+export {
+  readExitCode,
+  extractErrorContext,
+  extractCommandHead,
+  extractErrorKeywords,
+  formatHintBlock,
+  isThrottled,
+  markThrottle,
+  throttleFile,
+  THROTTLE_WINDOW_MS,
+};
+
+const killSwitch = setTimeout(() => {
+  emitEmpty();
+  process.exit(0);
+}, HOOK_TIMEOUT_MS + 50);
+killSwitch.unref();
+
+const isMain = (() => {
+  if (typeof process.argv[1] !== "string") return false;
+  const argv1 = process.argv[1];
+  return (
+    argv1.endsWith("bash-fail-hook.js") ||
+    argv1.endsWith("bash-fail-hook.ts") ||
+    argv1.endsWith("bastra-recall-bash-fail-hook")
+  );
+})();
+
+if (isMain) {
+  main()
+    .then(() => process.exit(0))
+    .catch(() => {
+      emitEmpty();
+      process.exit(0);
+    });
+}

--- a/packages/daemon/src/bash-pre-hook.ts
+++ b/packages/daemon/src/bash-pre-hook.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+/**
+ * bastra-recall bash-pre-hook — PreToolUse hook for Bash commands.
+ *
+ * Pattern-matches destructive / risky shell commands and surfaces relevant
+ * safety lessons from the vault as `additionalContext` so Claude reads them
+ * BEFORE running e.g. `rm -rf`, `git reset --hard`, `git push --force`, etc.
+ *
+ * Pipeline:
+ *   stdin (Claude-Code hook payload, hook_event_name=PreToolUse, tool_name=Bash)
+ *     → match command against DESTRUCTIVE_PATTERNS / RISKY_PATTERNS
+ *     → POST 127.0.0.1:BASTRA_HTTP_PORT/hook/recall (scope=all-projects, k=3)
+ *     → emit <recall-hints surface="claude-code" trigger="bash-destructive">
+ *
+ * Discipline (mirrors hook.ts):
+ *   - Hard wall-clock budget. Any failure path emits `{}` and exits 0.
+ *   - Never blocks the tool — hint only, no `block: true`.
+ *   - No loop: bastra-recall-* invocations are NOT matched (and would not
+ *     match anyway, but the prefix is checked defensively).
+ */
+import { request } from "node:http";
+import { appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { envFirst, envInt } from "./env.js";
+import { defaultLogDir } from "./telemetry.js";
+
+const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 500, "NEXUS_HOOK_TIMEOUT_MS");
+const DEFAULT_PORT = 6723;
+const HOOK_VERSION = "0.1.0";
+const SCORE_FLOOR = 50;
+
+interface ClaudeHookPayload {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+}
+
+interface RecallHit {
+  id: string;
+  title: string;
+  type: string;
+  scope: string;
+  summary: string;
+  score: number;
+}
+
+interface RecallResponse {
+  hits: RecallHit[];
+  vault_size: number;
+  latency_ms: number;
+  recall_id: string;
+}
+
+/**
+ * Destructive patterns — always need a recall.
+ * Order matters: longer / more specific phrases first so the *match string*
+ * we surface to the user is the meaningful one.
+ */
+const DESTRUCTIVE_PATTERNS: Array<{ label: string; re: RegExp }> = [
+  { label: "rm -rf", re: /\brm\s+(?:-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\b/ },
+  { label: "rm -r", re: /\brm\s+-[a-zA-Z]*r[a-zA-Z]*\b/ },
+  { label: "rmdir", re: /\brmdir\b/ },
+  { label: "git reset --hard", re: /\bgit\s+reset\s+--hard\b/ },
+  { label: "git checkout --", re: /\bgit\s+checkout\s+--\s/ },
+  { label: "git clean -f", re: /\bgit\s+clean\s+-[a-zA-Z]*f[a-zA-Z]*\b/ },
+  { label: "git branch -D", re: /\bgit\s+branch\s+-D\b/ },
+  { label: "git push --force-with-lease", re: /\bgit\s+push\b[^\n]*--force-with-lease/ },
+  { label: "git push --force", re: /\bgit\s+push\b[^\n]*--force\b/ },
+  { label: "git push -f", re: /\bgit\s+push\b[^\n]*\s-f\b/ },
+  { label: "git commit --amend", re: /\bgit\s+commit\b[^\n]*--amend\b/ },
+  { label: "gh repo delete", re: /\bgh\s+repo\s+delete\b/ },
+  { label: "gh release delete", re: /\bgh\s+release\s+delete\b/ },
+  { label: "npm uninstall", re: /\bnpm\s+uninstall\b/ },
+  { label: "npm rm", re: /\bnpm\s+rm\b/ },
+  { label: "yarn remove", re: /\byarn\s+remove\b/ },
+  { label: "pnpm rm", re: /\bpnpm\s+(?:rm|remove)\b/ },
+  { label: "DROP TABLE", re: /\bDROP\s+TABLE\b/i },
+  { label: "DROP DATABASE", re: /\bDROP\s+DATABASE\b/i },
+  { label: "TRUNCATE", re: /\bTRUNCATE\b/i },
+  { label: "docker rm", re: /\bdocker\s+rm\b/ },
+  { label: "docker volume rm", re: /\bdocker\s+volume\s+rm\b/ },
+  { label: "kubectl delete", re: /\bkubectl\s+delete\b/ },
+];
+
+/**
+ * Risky patterns — surface a softer hint. Same code path, only the label
+ * differs so the recall query can pick up the right lessons.
+ */
+const RISKY_PATTERNS: Array<{ label: string; re: RegExp }> = [
+  { label: "chmod -R", re: /\bchmod\s+-[a-zA-Z]*R[a-zA-Z]*\b/ },
+  { label: "chown -R", re: /\bchown\s+-[a-zA-Z]*R[a-zA-Z]*\b/ },
+  { label: "find ... -exec rm", re: /\bfind\b[^\n]*-exec\s+rm\b/ },
+  // Overwrite redirect: `> file` (not `>>` append, not `2>` stderr, not `>&`).
+  // Require a non-`>` char before `>` and at least one whitespace+filename after.
+  { label: "> overwrite redirect", re: /(?:^|[^>&0-9])>\s+[^\s>&]/ },
+];
+
+function matchPattern(cmd: string): { label: string; severity: "destructive" | "risky" } | null {
+  for (const p of DESTRUCTIVE_PATTERNS) {
+    if (p.re.test(cmd)) return { label: p.label, severity: "destructive" };
+  }
+  for (const p of RISKY_PATTERNS) {
+    if (p.re.test(cmd)) return { label: p.label, severity: "risky" };
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+
+  const raw = await readStdin();
+  let payload: ClaudeHookPayload;
+  try {
+    payload = JSON.parse(raw) as ClaudeHookPayload;
+  } catch {
+    return emitEmpty();
+  }
+
+  if (payload.hook_event_name !== "PreToolUse") return emitEmpty();
+  if (payload.tool_name !== "Bash") return emitEmpty();
+
+  const toolInput = (payload.tool_input ?? {}) as Record<string, unknown>;
+  const command = typeof toolInput.command === "string" ? toolInput.command : "";
+  if (!command.trim()) return emitEmpty();
+
+  // Defensive: never recurse on our own hook binaries.
+  if (/\bbastra-recall(?:-[a-z-]+)?\b/.test(command)) return emitEmpty();
+
+  const match = matchPattern(command);
+  if (!match) return emitEmpty();
+
+  const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
+  const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? String(DEFAULT_PORT);
+  const url = httpURL ?? `http://127.0.0.1:${httpPort}`;
+  const remainingMs = Math.max(50, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
+
+  let resp: RecallResponse | null = null;
+  let status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" = "ok";
+  let errMsg: string | null = null;
+  try {
+    resp = await postRecall(
+      url,
+      {
+        query: `${match.label} safety workflow user-preference`,
+        topics: ["bash", match.severity, "safety"],
+        project: null,
+        tool_name: "Bash",
+        scope: "all-projects",
+        k: 3,
+      },
+      remainingMs,
+    );
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ECONNREFUSED" || e.code === "ENOTFOUND" || e.code === "EHOSTUNREACH") {
+      status = "daemon-unreachable";
+    } else if (e.message === "timeout") {
+      status = "timeout";
+    } else {
+      status = "error";
+      errMsg = e.message ?? String(err);
+    }
+  }
+
+  const hits: RecallHit[] = [];
+  if (resp && Array.isArray(resp.hits)) {
+    for (const h of resp.hits) {
+      if (h.score >= SCORE_FLOOR) hits.push(h);
+    }
+  }
+  if (resp && hits.length === 0) status = "no-hits";
+
+  // Emit hint even if no memories match — the warning itself is the point.
+  const block = formatHintBlock(match.label, match.severity, hits);
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: block,
+      },
+    }),
+  );
+
+  const totalMs = Date.now() - startedAt;
+  await writeTelemetry({
+    matched_pattern: match.label,
+    severity: match.severity,
+    daemon_url: url,
+    daemon_reachable: resp !== null,
+    hint_count: hits.length,
+    top_score: resp?.hits?.[0]?.score ?? null,
+    latency_ms_total: totalMs,
+    status,
+    error: errMsg,
+  });
+}
+
+function emitEmpty(): void {
+  process.stdout.write("{}");
+}
+
+function formatHintLine(h: RecallHit): string {
+  const summary = h.summary.length > 220 ? h.summary.slice(0, 217) + "…" : h.summary;
+  return `- ${h.id} (${h.type}, score ${Math.round(h.score)}): ${summary}`;
+}
+
+function formatHintBlock(
+  pattern: string,
+  severity: "destructive" | "risky",
+  hits: RecallHit[],
+): string {
+  const head = `<recall-hints surface="claude-code" trigger="bash-${severity}">`;
+  const tail = `</recall-hints>`;
+  const lines: string[] = [];
+
+  if (severity === "destructive") {
+    lines.push(
+      `STOP — destructive Bash command detected (pattern: \`${pattern}\`). ` +
+        `Per user-preference this needs explicit user confirmation unless authorized in advance. ` +
+        `Do not run blindly: confirm the target paths, the scope of effect, and that Daniel has asked for this exact action.`,
+    );
+  } else {
+    lines.push(
+      `CAUTION — risky Bash command detected (pattern: \`${pattern}\`). ` +
+        `Check the target/scope before running — recursive/destructive side effects are easy to miss.`,
+    );
+  }
+
+  if (hits.length > 0) {
+    lines.push("");
+    lines.push(
+      `Relevant lessons / preferences from the vault — load_memory(id) before deciding to run:`,
+    );
+    for (const h of hits) lines.push(formatHintLine(h));
+  }
+
+  return [head, ...lines, tail].join("\n");
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+interface RecallRequestBody {
+  query: string;
+  topics: string[];
+  project: string | null;
+  tool_name: string;
+  k: number;
+  scope?: string;
+}
+
+function postRecall(
+  baseUrl: string,
+  body: RecallRequestBody,
+  timeoutMs: number,
+): Promise<RecallResponse> {
+  return new Promise((resolve, reject) => {
+    let url: URL;
+    try {
+      url = new URL("/hook/recall", baseUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const payload = Buffer.from(JSON.stringify(body), "utf8");
+    const req = request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": payload.byteLength.toString(),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const body = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(`HTTP ${res.statusCode}: ${body.slice(0, 200)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body) as RecallResponse);
+          } catch {
+            reject(new Error("invalid JSON response from daemon"));
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy(new Error("timeout"));
+    });
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+interface BashHookCallTelemetry {
+  matched_pattern: string;
+  severity: "destructive" | "risky";
+  daemon_url: string;
+  daemon_reachable: boolean;
+  hint_count: number;
+  top_score: number | null;
+  latency_ms_total: number;
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
+  error: string | null;
+}
+
+async function writeTelemetry(payload: BashHookCallTelemetry): Promise<void> {
+  if ((envFirst("BASTRA_TELEMETRY", "NEXUS_TELEMETRY") ?? "on").toLowerCase() === "off") return;
+  try {
+    const logDir = envFirst("BASTRA_LOG_PATH", "NEXUS_LOG_PATH") ?? defaultLogDir();
+    await mkdir(logDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const event = {
+      kind: "bash_hook_call",
+      ts,
+      session_id: randomUUID(),
+      hook_version: HOOK_VERSION,
+      ...payload,
+    };
+    const file = join(logDir, `events-${ts.slice(0, 10)}.jsonl`);
+    await appendFile(file, JSON.stringify(event) + "\n", "utf8");
+  } catch {
+    // Telemetry must never break the hook.
+  }
+}
+
+// Export for testing.
+export { matchPattern, formatHintBlock, DESTRUCTIVE_PATTERNS, RISKY_PATTERNS };
+
+// Global hard cap.
+const killSwitch = setTimeout(() => {
+  emitEmpty();
+  process.exit(0);
+}, HOOK_TIMEOUT_MS + 50);
+killSwitch.unref();
+
+// Only run main() when invoked as a CLI, not when imported by tests.
+const isMain = (() => {
+  if (typeof process.argv[1] !== "string") return false;
+  const argv1 = process.argv[1];
+  return (
+    argv1.endsWith("bash-pre-hook.js") ||
+    argv1.endsWith("bash-pre-hook.ts") ||
+    argv1.endsWith("bastra-recall-bash-pre-hook")
+  );
+})();
+
+if (isMain) {
+  main()
+    .then(() => process.exit(0))
+    .catch(() => {
+      emitEmpty();
+      process.exit(0);
+    });
+}

--- a/packages/daemon/src/stop-hook.ts
+++ b/packages/daemon/src/stop-hook.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+/**
+ * bastra-recall stop-hook — autonomous save-evaluation at Stop event.
+ *
+ * Looks at the recent transcript and surfaces save-suggestions when one of
+ * three heuristics fires. Never calls save_memory itself — only suggests
+ * (the agent decides in the next turn whether to act).
+ *
+ * Heuristics:
+ *   1. Frustration-Density   — >=3 "wieder/schon wieder/CAPS/fuck/verdammt"
+ *      tokens in the last 10 user turns.
+ *   2. Feature-Completion    — `git commit` mentioned + multiple modified
+ *      files in the same area.
+ *   3. Architecture-Decision — `ok dann | lass uns | entschieden | final |
+ *      gehen wir mit` in the last 5 user turns.
+ *
+ * Output: `<save-eval>` blocks, one per matched heuristic. No tool calls.
+ *
+ * Discipline:
+ *   - Budget 1000 ms. Any failure path emits `{}` and exits 0.
+ *   - Never blocks the workflow.
+ *   - Telemetry best-effort.
+ */
+import { readFile, appendFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { envFirst, envInt } from "./env.js";
+import { defaultLogDir } from "./telemetry.js";
+
+const HOOK_TIMEOUT_MS = envInt("BASTRA_STOP_HOOK_TIMEOUT_MS", 1000);
+const HOOK_VERSION = "0.1.0";
+const FRUSTRATION_WINDOW_TURNS = 10;
+const FRUSTRATION_THRESHOLD = 3;
+const DECISION_WINDOW_TURNS = 5;
+
+interface ClaudeStopPayload {
+  session_id?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  transcript_path?: string;
+  transcript?: unknown;
+  stop_hook_active?: boolean;
+}
+
+interface TranscriptTurn {
+  role: "user" | "assistant" | "system" | string;
+  content: string;
+}
+
+type Heuristic = "frustration-density" | "feature-completion" | "architecture-decision";
+
+interface SaveSuggestion {
+  heuristic: Heuristic;
+  title: string;
+  type: "lesson" | "project-fact" | "decision";
+  body: string;
+}
+
+async function main(): Promise<void> {
+  const startedAt = Date.now();
+
+  const raw = await readStdin();
+  let payload: ClaudeStopPayload;
+  try {
+    payload = JSON.parse(raw) as ClaudeStopPayload;
+  } catch {
+    return emitEmpty();
+  }
+
+  if (payload.hook_event_name !== "Stop") return emitEmpty();
+  if (payload.stop_hook_active === true) return emitEmpty();
+
+  const turns = await loadTranscript(payload);
+  if (turns.length === 0) return emitEmpty();
+
+  const last30 = turns.slice(-30);
+  const suggestions = evaluateHeuristics(last30);
+
+  if (suggestions.length === 0) {
+    emitEmpty();
+  } else {
+    const blocks = suggestions.map(formatSuggestion).join("\n");
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "Stop",
+          additionalContext: blocks,
+        },
+      }),
+    );
+  }
+
+  const totalMs = Date.now() - startedAt;
+  await writeTelemetry({
+    heuristic: suggestions.map((s) => s.heuristic).join(",") || null,
+    suggested_count: suggestions.length,
+    turn_count: turns.length,
+    latency_ms_total: totalMs,
+  });
+}
+
+function emitEmpty(): void {
+  process.stdout.write("{}");
+}
+
+async function loadTranscript(payload: ClaudeStopPayload): Promise<TranscriptTurn[]> {
+  if (Array.isArray(payload.transcript)) {
+    return normalizeTurns(payload.transcript as unknown[]);
+  }
+  if (typeof payload.transcript_path === "string") {
+    try {
+      const content = await readFile(payload.transcript_path, "utf8");
+      return parseTranscriptFile(content);
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function parseTranscriptFile(raw: string): TranscriptTurn[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) {
+    try {
+      const arr = JSON.parse(trimmed) as unknown[];
+      return normalizeTurns(arr);
+    } catch {
+      return [];
+    }
+  }
+  const out: unknown[] = [];
+  for (const line of trimmed.split(/\r?\n/)) {
+    const l = line.trim();
+    if (!l) continue;
+    try {
+      out.push(JSON.parse(l));
+    } catch {
+      // skip
+    }
+  }
+  return normalizeTurns(out);
+}
+
+function normalizeTurns(items: unknown[]): TranscriptTurn[] {
+  const out: TranscriptTurn[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const directRole = obj.role;
+    const directContent = obj.content;
+    if (typeof directRole === "string") {
+      out.push({ role: directRole, content: stringifyContent(directContent) });
+      continue;
+    }
+    const msg = obj.message;
+    if (msg && typeof msg === "object") {
+      const m = msg as Record<string, unknown>;
+      const role = typeof m.role === "string" ? m.role : "unknown";
+      out.push({ role, content: stringifyContent(m.content) });
+      continue;
+    }
+    if (typeof obj.text === "string") {
+      out.push({ role: "unknown", content: obj.text });
+    }
+  }
+  return out;
+}
+
+function stringifyContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const c of content) {
+      if (typeof c === "string") parts.push(c);
+      else if (c && typeof c === "object") {
+        const obj = c as Record<string, unknown>;
+        if (typeof obj.text === "string") parts.push(obj.text);
+        else if (typeof obj.content === "string") parts.push(obj.content);
+      }
+    }
+    return parts.join("\n");
+  }
+  if (content && typeof content === "object") {
+    try {
+      return JSON.stringify(content);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function evaluateHeuristics(turns: TranscriptTurn[]): SaveSuggestion[] {
+  const suggestions: SaveSuggestion[] = [];
+  const fr = detectFrustration(turns);
+  if (fr) suggestions.push(fr);
+  const fc = detectFeatureCompletion(turns);
+  if (fc) suggestions.push(fc);
+  const ad = detectArchitectureDecision(turns);
+  if (ad) suggestions.push(ad);
+  return suggestions;
+}
+
+const FRUSTRATION_PATTERNS: RegExp[] = [
+  /\bwieder\b/i,
+  /\bschon wieder\b/i,
+  /\bwie oft\b/i,
+  /\bverdammt\b/i,
+  /\bfuck\b/i,
+  /\bscheisse\b/i,
+  /\bscheiße\b/i,
+];
+
+const CAPS_WORD_RE = /\b[A-ZÄÖÜ]{4,}\b/g;
+
+function detectFrustration(turns: TranscriptTurn[]): SaveSuggestion | null {
+  const userTurns = turns.filter((t) => t.role === "user").slice(-FRUSTRATION_WINDOW_TURNS);
+  let count = 0;
+  const exemplars: string[] = [];
+  for (const t of userTurns) {
+    for (const p of FRUSTRATION_PATTERNS) {
+      if (p.test(t.content)) {
+        count++;
+        if (exemplars.length < 3) exemplars.push(t.content.slice(0, 120));
+        break;
+      }
+    }
+    const caps = t.content.match(CAPS_WORD_RE);
+    if (caps && caps.length > 0) {
+      count++;
+      if (exemplars.length < 3) exemplars.push(caps.slice(0, 3).join(" "));
+    }
+  }
+  if (count < FRUSTRATION_THRESHOLD) return null;
+  return {
+    heuristic: "frustration-density",
+    title: "recurring frustration — capture the underlying lesson",
+    type: "lesson",
+    body: `Detected ${count} frustration cues in the last ${userTurns.length} user turns. ` +
+      `Exemplars: ${exemplars.join(" | ")}. ` +
+      `If a concrete recurring pattern surfaced, save a 'lesson' memory that captures the failure path and the fix.`,
+  };
+}
+
+function detectFeatureCompletion(turns: TranscriptTurn[]): SaveSuggestion | null {
+  const text = turns.map((t) => t.content).join("\n");
+  const commitMatch = /\bgit\s+commit\b/.test(text) || /\[(?:main|master|feat\/[\w./-]+)\s+[0-9a-f]{6,12}\]/.test(text);
+  if (!commitMatch) return null;
+
+  const fileTokens = new Set<string>();
+  const fileRe = /\b[\w./-]+\.(?:ts|tsx|js|jsx|swift|rs|py|go|md|json|yml|yaml|css|html)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = fileRe.exec(text)) !== null) {
+    fileTokens.add(m[0]);
+    if (fileTokens.size > 200) break;
+  }
+  if (fileTokens.size < 3) return null;
+
+  const sample = [...fileTokens].slice(0, 6).join(", ");
+  return {
+    heuristic: "feature-completion",
+    title: "feature-completion — save a topology / project-fact entry",
+    type: "project-fact",
+    body: `A git commit was mentioned alongside ${fileTokens.size} distinct file tokens (e.g. ${sample}). ` +
+      `If this lands a coherent feature/refactor, save a 'project-fact' that maps what was built where ` +
+      `(file paths in path/to/file.ts:42 format, status, links to related decisions).`,
+  };
+}
+
+const DECISION_PATTERNS: RegExp[] = [
+  /\bok dann\b/i,
+  /\blass uns\b/i,
+  /\bentschieden\b/i,
+  /\bfinal\b/i,
+  /\bgehen wir mit\b/i,
+];
+
+function detectArchitectureDecision(turns: TranscriptTurn[]): SaveSuggestion | null {
+  const userTurns = turns.filter((t) => t.role === "user").slice(-DECISION_WINDOW_TURNS);
+  const exemplars: string[] = [];
+  for (const t of userTurns) {
+    for (const p of DECISION_PATTERNS) {
+      if (p.test(t.content)) {
+        if (exemplars.length < 2) exemplars.push(t.content.slice(0, 160));
+        break;
+      }
+    }
+  }
+  if (exemplars.length === 0) return null;
+  return {
+    heuristic: "architecture-decision",
+    title: "decision finalized — save the chosen path and the why",
+    type: "decision",
+    body: `Decision-language in the last ${userTurns.length} user turns: ${exemplars.join(" | ")}. ` +
+      `If an architectural choice was committed (X over Y, the trade-off), save a 'decision' memory ` +
+      `with the why + how-to-apply.`,
+  };
+}
+
+function formatSuggestion(s: SaveSuggestion): string {
+  return [
+    `<save-eval>`,
+    `Suggested save (heuristic: ${s.heuristic}):`,
+    `  title: "${s.title}"`,
+    `  type: ${s.type}`,
+    `  body: "${escapeBody(s.body)}"`,
+    `To save: call save_memory with the values above (or refine first).`,
+    `</save-eval>`,
+  ].join("\n");
+}
+
+function escapeBody(body: string): string {
+  return body.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+interface StopHookTelemetry {
+  heuristic: string | null;
+  suggested_count: number;
+  turn_count: number;
+  latency_ms_total: number;
+}
+
+async function writeTelemetry(payload: StopHookTelemetry): Promise<void> {
+  if ((envFirst("BASTRA_TELEMETRY", "NEXUS_TELEMETRY") ?? "on").toLowerCase() === "off") return;
+  try {
+    const logDir = envFirst("BASTRA_LOG_PATH", "NEXUS_LOG_PATH") ?? defaultLogDir();
+    await mkdir(logDir, { recursive: true });
+    const ts = new Date().toISOString();
+    const event = {
+      kind: "save_eval_call",
+      ts,
+      session_id: randomUUID(),
+      hook_version: HOOK_VERSION,
+      ...payload,
+    };
+    const file = join(logDir, `events-${ts.slice(0, 10)}.jsonl`);
+    await appendFile(file, JSON.stringify(event) + "\n", "utf8");
+  } catch {
+    // Telemetry must never break the hook.
+  }
+}
+
+export {
+  evaluateHeuristics,
+  detectFrustration,
+  detectFeatureCompletion,
+  detectArchitectureDecision,
+  formatSuggestion,
+  parseTranscriptFile,
+  normalizeTurns,
+};
+export type { TranscriptTurn, SaveSuggestion };
+
+const killSwitch = setTimeout(() => {
+  emitEmpty();
+  process.exit(0);
+}, HOOK_TIMEOUT_MS + 50);
+killSwitch.unref();
+
+const isMain = (() => {
+  if (typeof process.argv[1] !== "string") return false;
+  const argv1 = process.argv[1];
+  return (
+    argv1.endsWith("stop-hook.js") ||
+    argv1.endsWith("stop-hook.ts") ||
+    argv1.endsWith("bastra-recall-stop-hook")
+  );
+})();
+
+if (isMain) {
+  main()
+    .then(() => process.exit(0))
+    .catch(() => {
+      emitEmpty();
+      process.exit(0);
+    });
+}


### PR DESCRIPTION
## Summary

Three new reflex-layer Claude-Code hooks that round out the bastra-recall
hook surface, complementing the existing PreToolUse(Write/Edit) and
SessionStart hooks:

- **bash-pre-hook** (`PreToolUse` / Bash) — pattern-matches destructive
  (`rm -rf`, `git reset --hard`, `git push --force`, `npm uninstall`,
  `DROP TABLE`, `docker rm`, `kubectl delete`, ...) and risky (`chmod -R`,
  `chown -R`, `find ... -exec rm`, `>` overwrite) commands; emits
  `<recall-hints trigger="bash-destructive">` with relevant safety lessons.
  Non-blocking — hint only. **Closes #34**
- **bash-fail-hook** (`PostToolUse` / Bash) — fires on `exit_code != 0`
  (skipping 130/SIGINT and self-invocations); recalls similar
  failure-mode memories. Throttled to one hint / 30 s / session via
  `$TMPDIR/bastra-hook/`. **Closes #37**
- **stop-hook** (`Stop`) — reads last ~30 transcript turns and
  evaluates three heuristics (frustration-density, feature-completion,
  architecture-decision); emits one or more `<save-eval>` blocks
  suggesting title/type/body. Never calls `save_memory` itself.
  **Closes #35**

All three are non-blocking, share the bastra-recall hook discipline
(hard wall-clock budget, `{}` on every failure path, best-effort
telemetry), and never recurse on their own binaries.

## Files

- `packages/daemon/src/bash-pre-hook.ts` (new)
- `packages/daemon/src/bash-fail-hook.ts` (new)
- `packages/daemon/src/stop-hook.ts` (new)
- `packages/daemon/__tests__/bash-pre-hook.test.ts` (new, 19 cases)
- `packages/daemon/__tests__/bash-fail-hook.test.ts` (new, 11 cases)
- `packages/daemon/__tests__/stop-hook.test.ts` (new, 17 cases)
- `packages/daemon/package.json` — three new bin entries
  (`bastra-recall-bash-pre-hook`, `bastra-recall-bash-fail-hook`,
  `bastra-recall-stop-hook`) + extended `build` script `chmod +x`
- `docs/hooks.md` (new) — usage doc with `settings.json` snippets

## Telemetry events added

- `bash_hook_call` — `matched_pattern, severity, hit_count, top_score`
- `bash_fail_hook_call` — `exit_code, command_head, hit_count, top_score`
- `save_eval_call` — `heuristic, suggested_count, turn_count`

## Note on overlapping waves

This PR deliberately does NOT touch `packages/daemon/src/hook.ts`,
`session-hook.ts`, or the upcoming `prompt-hook.ts` / `todo-hook.ts` —
those live in parallel PRs (#43 + Welle-2a). All helpers (`postRecall`,
`emitEmpty`, telemetry pattern) are inlined per file rather than
imported from `hook.ts` to avoid a merge dependency.

## Test plan

- [x] `npm run check:types` green
- [x] `npm run build` green (dist files have `+x`)
- [x] `npx tsx --test __tests__/*.test.ts` — 47/47 pass
- [ ] Manual smoke: feed each hook a sample payload via stdin and
      verify the `<recall-hints>` / `<save-eval>` output and the
      JSONL telemetry line.
- [ ] Wire up in `~/.claude/settings.json` per `docs/hooks.md` and
      try `rm -rf /tmp/throwaway` (expect destructive warning),
      `false` (expect exit-code 1 → fail-hook recall), end-of-session
      with a few `wieder` cues (expect save-eval block).

Closes #34
Closes #37
Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)