### PR TITLE
feat(recall-ux): live stage feedback + charming banter (#38)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,9 +1472,11 @@
         "zod": "^3.23.8"
       },
       "bin": {
+        "bastra": "dist/cli.js",
         "bastra-recall": "dist/index.js",
         "bastra-recall-bridge": "dist/bridge.js",
         "bastra-recall-hook": "dist/hook.js",
+        "bastra-recall-mcp": "dist/mcp-forwarder.js",
         "bastra-recall-session-hook": "dist/session-hook.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "check:types": "npm run check:types --workspaces --if-present",
+    "test": "node --import tsx --test packages/core/__tests__/*.test.ts packages/daemon/__tests__/*.test.ts",
     "smoke": "npm run smoke --workspace=@bastra-recall/daemon",
     "smoke:telemetry": "npm run smoke:telemetry --workspace=@bastra-recall/daemon"
   }

--- a/packages/core/__tests__/recall-banter.test.ts
+++ b/packages/core/__tests__/recall-banter.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests für die Banter-Engine (#38).
+ *
+ * Verifiziert:
+ * - DE/EN-Phrasen-Pool je Stage liefert non-empty Strings.
+ * - `mode: "off"` und `mode: "terse"` → null.
+ * - Slow-Phrasen (> 500 ms) kommen aus dem SLOW_PHRASES-Pool, nicht
+ *   aus dem Stage-Pool.
+ * - `banterModeFromEnv` parsed `BASTRA_BANTER` korrekt.
+ *
+ * Runner: `node --import tsx --test packages/core/__tests__/recall-banter.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickPhrase, banterModeFromEnv, type RecallStage } from "../src/index.js";
+
+const STAGES: RecallStage["name"][] = [
+  "query.parse",
+  "cache.hit",
+  "bm25.search",
+  "vector.search",
+  "rrf.fuse",
+  "hops.expand",
+  "staleness.rank",
+  "done",
+];
+
+test("pickPhrase: returns non-empty DE string for every stage in 'on' mode", () => {
+  for (const name of STAGES) {
+    const phrase = pickPhrase(
+      { name, startedAtMs: 1_700_000_000_000 },
+      "on",
+      "de",
+    );
+    assert.equal(typeof phrase, "string");
+    assert.ok(phrase!.length > 0, `empty DE phrase for stage ${name}`);
+  }
+});
+
+test("pickPhrase: returns non-empty EN string for every stage in 'on' mode", () => {
+  for (const name of STAGES) {
+    const phrase = pickPhrase(
+      { name, startedAtMs: 1_700_000_000_000 },
+      "on",
+      "en",
+    );
+    assert.equal(typeof phrase, "string");
+    assert.ok(phrase!.length > 0, `empty EN phrase for stage ${name}`);
+  }
+});
+
+test("pickPhrase: 'off' and 'terse' both return null", () => {
+  const stage: RecallStage = { name: "bm25.search", startedAtMs: Date.now() };
+  assert.equal(pickPhrase(stage, "off", "de"), null);
+  assert.equal(pickPhrase(stage, "off", "en"), null);
+  assert.equal(pickPhrase(stage, "terse", "de"), null);
+  assert.equal(pickPhrase(stage, "terse", "en"), null);
+});
+
+test("pickPhrase: slow-stage (> 500ms) draws from slow pool, not stage pool", () => {
+  // Gleicher Stage einmal schnell, einmal langsam — die Phrase muss
+  // sich unterscheiden (deterministischer Seed über `(name, sekunde)`
+  // bleibt gleich; aber der Pool ist anders).
+  const fast: RecallStage = { name: "bm25.search", startedAtMs: 1_700_000_000_000, durationMs: 50 };
+  const slow: RecallStage = { name: "bm25.search", startedAtMs: 1_700_000_000_000, durationMs: 750 };
+  const fastPhrase = pickPhrase(fast, "on", "de")!;
+  const slowPhrase = pickPhrase(slow, "on", "de")!;
+  assert.notEqual(fastPhrase, slowPhrase, "slow phrase must differ from fast-stage phrase");
+  // Slow-Pool enthält erkennbare Mein-Gott-Phrasen.
+  const slowMarkers = ["dauert", "zieht sich", "tief", "Pause", "voll"];
+  assert.ok(
+    slowMarkers.some((m) => slowPhrase.includes(m)),
+    `slow phrase did not match slow-pool markers: ${slowPhrase}`,
+  );
+});
+
+test("pickPhrase: very-slow-stage (> 1000ms) escalates further", () => {
+  const verySlow: RecallStage = {
+    name: "vector.search",
+    startedAtMs: 1_700_000_000_000,
+    durationMs: 1500,
+  };
+  const phrase = pickPhrase(verySlow, "on", "en")!;
+  assert.equal(typeof phrase, "string");
+  assert.ok(phrase.length > 0);
+});
+
+test("pickPhrase: deterministic within same second bucket", () => {
+  const a: RecallStage = { name: "rrf.fuse", startedAtMs: 1_700_000_001_000 };
+  const b: RecallStage = { name: "rrf.fuse", startedAtMs: 1_700_000_001_500 };
+  assert.equal(
+    pickPhrase(a, "on", "de"),
+    pickPhrase(b, "on", "de"),
+    "same second bucket should yield same phrase",
+  );
+});
+
+test("banterModeFromEnv: parses BASTRA_BANTER", () => {
+  assert.equal(banterModeFromEnv({ BASTRA_BANTER: "off" }), "off");
+  assert.equal(banterModeFromEnv({ BASTRA_BANTER: "terse" }), "terse");
+  assert.equal(banterModeFromEnv({ BASTRA_BANTER: "on" }), "on");
+  assert.equal(banterModeFromEnv({ BASTRA_BANTER: "OFF" }), "off"); // case-insensitive
+  assert.equal(banterModeFromEnv({}), "on", "default is on");
+  assert.equal(banterModeFromEnv({ BASTRA_BANTER: "junk" }), "on", "unknown values fall back to on");
+});

--- a/packages/core/__tests__/recall-stages.test.ts
+++ b/packages/core/__tests__/recall-stages.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests für den Stage-Event-Emitter in `SearchIndex.recall` (#38).
+ *
+ * Verifiziert: Stage-Events feuern in der erwarteten Reihenfolge,
+ * Start/Stop-Pairs haben passende Dauern, `done`-Event enthält
+ * `hit_count` / `vault_size`. Hybrid-Pfad ist hier nicht abgedeckt
+ * (braucht einen Embedding-Provider) — der wird im Banter-Test über
+ * synthetic Stage-Events geprüft.
+ *
+ * Runner: `node --import tsx --test packages/core/__tests__/recall-stages.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex, type RecallStage } from "../src/index.js";
+
+function memoryMarkdown(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: reference",
+    `summary: ${title}`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: test-scope",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+async function makeVault(memos: { id: string; title: string }[]): Promise<{ vault: Vault; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-stages-test-"));
+  for (const m of memos) {
+    await writeFile(join(dir, `${m.id}.md`), memoryMarkdown(m.id, m.title), "utf8");
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  return { vault, dir };
+}
+
+test("recall: emits stages in expected order", async () => {
+  const { vault, dir } = await makeVault([
+    { id: "stage-1", title: "alpha bravo" },
+    { id: "stage-2", title: "charlie delta" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const events: RecallStage[] = [];
+    const hits = idx.recall("alpha", { k: 5, onStage: (s) => events.push(s) });
+
+    // Mindestens ein Hit liefern, sonst war die Query schon defekt.
+    assert.ok(hits.length >= 1, "at least one hit expected");
+
+    // Erwartete Stage-Namen (Reihenfolge): query.parse(start) -> query.parse(stop)
+    // -> bm25.search(start) -> bm25.search(stop) -> staleness.rank(start)
+    // -> staleness.rank(stop) -> done.
+    const names = events.map((e) => `${e.name}${e.durationMs === undefined ? ":start" : ":stop"}`);
+    assert.deepEqual(
+      names,
+      [
+        "query.parse:start",
+        "query.parse:stop",
+        "bm25.search:start",
+        "bm25.search:stop",
+        "staleness.rank:start",
+        "staleness.rank:stop",
+        "done:stop",
+      ],
+      `unexpected stage sequence: ${names.join(", ")}`,
+    );
+
+    // done-Event trägt hit_count + vault_size
+    const done = events.at(-1)!;
+    assert.equal(done.name, "done");
+    assert.equal(done.meta?.hit_count, hits.length);
+    assert.equal(done.meta?.vault_size, 2);
+    assert.equal(typeof done.meta?.total_ms, "number");
+    idx.stop();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("recall: hops.expand stage fires only when expand_hops=1", async () => {
+  const { vault, dir } = await makeVault([
+    { id: "h-1", title: "echo foxtrot" },
+    { id: "h-2", title: "golf hotel" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const noHopEvents: RecallStage[] = [];
+    idx.recall("echo", { k: 3, onStage: (s) => noHopEvents.push(s) });
+    const hasHopsStage = noHopEvents.some((e) => e.name === "hops.expand");
+    assert.equal(hasHopsStage, false, "no hops.expand without expand_hops=1");
+
+    const withHopEvents: RecallStage[] = [];
+    idx.recall("echo", { k: 3, expand_hops: 1, onStage: (s) => withHopEvents.push(s) });
+    const hopsStart = withHopEvents.find((e) => e.name === "hops.expand" && e.durationMs === undefined);
+    const hopsStop = withHopEvents.find((e) => e.name === "hops.expand" && e.durationMs !== undefined);
+    assert.ok(hopsStart, "expected hops.expand start event");
+    assert.ok(hopsStop, "expected hops.expand stop event");
+    assert.equal(typeof hopsStop!.meta?.hop_count, "number");
+
+    idx.stop();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("recall: backwards-compat — no onStage means no stage overhead and same hits", async () => {
+  const { vault, dir } = await makeVault([
+    { id: "bc-1", title: "india juliet" },
+  ]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const withStages: RecallStage[] = [];
+    const aStaged = idx.recall("india", { k: 5, onStage: (s) => withStages.push(s) });
+    const aBare = idx.recall("india", { k: 5 });
+
+    assert.deepEqual(
+      aStaged.map((h) => h.id),
+      aBare.map((h) => h.id),
+      "hits identical with and without onStage",
+    );
+    assert.ok(withStages.length > 0, "onStage was actually called");
+
+    idx.stop();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("recall: empty query short-circuits with done event only", async () => {
+  const { vault, dir } = await makeVault([{ id: "e-1", title: "kilo lima" }]);
+  try {
+    const idx = new SearchIndex(vault);
+    idx.start();
+
+    const events: RecallStage[] = [];
+    const hits = idx.recall("   ", { onStage: (s) => events.push(s) });
+    assert.equal(hits.length, 0);
+    const names = events.map((e) => e.name);
+    assert.ok(names.includes("query.parse"));
+    assert.ok(names.includes("done"));
+    assert.ok(!names.includes("bm25.search"), "no bm25.search on empty query");
+
+    idx.stop();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,12 @@ export type { VaultEvent, VaultListener } from "./vault.js";
 export { SearchIndex } from "./search.js";
 export type { RecallHit, RecallOptions } from "./search.js";
 
+export type { RecallStage, StageListener } from "./recall-stages.js";
+export { RECALL_STAGE_ORDER, progressIndexFor } from "./recall-stages.js";
+
+export { pickPhrase, banterModeFromEnv } from "./recall-banter.js";
+export type { BanterMode, BanterLang } from "./recall-banter.js";
+
 export {
   saveMemory,
   deleteMemoryFile,

--- a/packages/core/src/recall-banter.ts
+++ b/packages/core/src/recall-banter.ts
@@ -1,0 +1,250 @@
+/**
+ * Recall-Banter-Engine (#38).
+ *
+ * Pro Stage 3–5 deutsche und englische Varianten, plus ein Pool an
+ * „Slow-Phrasen" für Stages, die spürbar lange brauchen. Banter ist UI
+ * über dem Event-Stream — niemals blockierend, niemals länger als die
+ * Stage selbst.
+ *
+ * Toggle via `BASTRA_BANTER` env-var:
+ *   - `on`     → Stages + Phrasen (default)
+ *   - `terse`  → Stages, keine Phrasen
+ *   - `off`    → gar nichts (Stages werden trotzdem emittet, der Caller
+ *                kann sie still loggen)
+ *
+ * Der Picker ist deterministisch über `(stageName, durationBucket)`
+ * gestreut — gleicher Stage in derselben Sekunde liefert die gleiche
+ * Phrase. Das macht Tests stabil ohne Seed-Injection.
+ */
+import type { RecallStage } from "./recall-stages.js";
+
+export type BanterMode = "on" | "terse" | "off";
+export type BanterLang = "de" | "en";
+
+interface PhrasePool {
+  de: string[];
+  en: string[];
+}
+
+const STAGE_PHRASES: Record<RecallStage["name"], PhrasePool> = {
+  "query.parse": {
+    de: [
+      "Query zerlegen …",
+      "Stichworte sortieren …",
+      "Was suchst du eigentlich?",
+      "Tokens packen …",
+    ],
+    en: [
+      "Parsing the query …",
+      "Sorting keywords …",
+      "What are we looking for?",
+      "Tokenizing …",
+    ],
+  },
+  "cache.hit": {
+    de: [
+      "Schon im Kopf — direkt zurück!",
+      "Cache greift, kurzer Weg.",
+      "Kenn ich, da war ich gerade.",
+      "Cache-Hit — instant.",
+    ],
+    en: [
+      "Already in my head — instant.",
+      "Cache hit, taking the shortcut.",
+      "Been there a second ago.",
+      "Straight from cache.",
+    ],
+  },
+  "bm25.search": {
+    de: [
+      "Stichwörter durchforsten …",
+      "BM25 wühlt im Index …",
+      "Treffer einsammeln …",
+      "Index abklappern …",
+      "Lexikalisch matchen …",
+    ],
+    en: [
+      "Scanning keywords …",
+      "BM25 doing its thing …",
+      "Collecting matches …",
+      "Combing the index …",
+      "Lexical match in progress …",
+    ],
+  },
+  "vector.search": {
+    de: [
+      "Semantik abgleichen …",
+      "Embeddings nachdenken lassen …",
+      "Vektoren vergleichen …",
+      "Bedeutung suchen, nicht nur Worte …",
+    ],
+    en: [
+      "Comparing semantics …",
+      "Embeddings pondering …",
+      "Vector math in progress …",
+      "Meaning over words …",
+    ],
+  },
+  "rrf.fuse": {
+    de: [
+      "Treffer fusionieren …",
+      "Rankings verschmelzen …",
+      "Reciprocal-Rank tanzt …",
+      "Listen mergen …",
+    ],
+    en: [
+      "Fusing rankings …",
+      "Merging hit lists …",
+      "RRF doing the dance …",
+      "Combining scores …",
+    ],
+  },
+  "hops.expand": {
+    de: [
+      "Nachbarn besuchen …",
+      "Related-via folgen …",
+      "Ein Hop weiter …",
+      "Verwandte einsammeln …",
+    ],
+    en: [
+      "Visiting neighbors …",
+      "Following related-via …",
+      "One hop further …",
+      "Collecting kinfolk …",
+    ],
+  },
+  "staleness.rank": {
+    de: [
+      "Frische prüfen …",
+      "Alte Memories sanft rausnehmen …",
+      "Staleness-Re-Rank …",
+      "Wie alt ist das nochmal?",
+    ],
+    en: [
+      "Checking freshness …",
+      "Gently demoting old memories …",
+      "Staleness re-rank …",
+      "How old is this again?",
+    ],
+  },
+  done: {
+    de: [
+      "Da, bitte.",
+      "Hab ich dir.",
+      "Fertig.",
+      "Soweit alles.",
+    ],
+    en: [
+      "There you go.",
+      "Got you.",
+      "Done.",
+      "All set.",
+    ],
+  },
+  error: {
+    de: [
+      "Hmm, da ging was schief.",
+      "Das wollte nicht.",
+      "Fehler — guck mal nach.",
+    ],
+    en: [
+      "Hmm, something tripped.",
+      "That didn't work.",
+      "Error — please check.",
+    ],
+  },
+};
+
+/** Phrasen für Stages, die spürbar lange brauchen (> 500 ms). Wird
+ *  unabhängig vom Stage-Pool benutzt, damit die UX auch dann charmant
+ *  bleibt, wenn der eigentliche Stage-Banter schon ausgespielt war. */
+const SLOW_PHRASES: PhrasePool = {
+  de: [
+    "Heute dauert's wieder, einen Moment …",
+    "Mein Gott, das zieht sich. Bitte etwas Geduld!",
+    "Ich grabe gerade tief — gleich da.",
+    "Embeddings haben heute Pause? Moment …",
+    "Brauche kurz, sorry — der Vault ist voll.",
+  ],
+  en: [
+    "Taking a moment today, hang tight …",
+    "Wow, this is slow. Patience, please.",
+    "Digging deep — almost there.",
+    "Embeddings on a coffee break? One sec …",
+    "Vault is dense today — bear with me.",
+  ],
+};
+
+const VERY_SLOW_PHRASES: PhrasePool = {
+  de: [
+    "Okay, das wird heute eine längere Reise …",
+    "Eine Sekunde noch — die Memories sind träge.",
+    "Du, das dauert wirklich. Nicht weglaufen!",
+  ],
+  en: [
+    "Okay, this is taking a while …",
+    "Hold on — memories are sluggish today.",
+    "Really slow, this one. Don't run off!",
+  ],
+};
+
+const SLOW_STAGE_MS = 500;
+const VERY_SLOW_STAGE_MS = 1000;
+
+/**
+ * Mode aus `BASTRA_BANTER` env-var. Default `on`. Unbekannte Werte
+ * fallen auf `on` zurück — kein Fail-Hard für Typos im RC-File.
+ */
+export function banterModeFromEnv(env: NodeJS.ProcessEnv = process.env): BanterMode {
+  const raw = (env.BASTRA_BANTER ?? "on").toLowerCase();
+  if (raw === "off") return "off";
+  if (raw === "terse") return "terse";
+  return "on";
+}
+
+/**
+ * Liefert eine Banter-Phrase für eine Stage. `null` bedeutet „nichts
+ * zeigen" (`mode = "off"` oder `mode = "terse"`). Bei „slow"-Phrasen
+ * mit `durationMs > 500 ms` wird zusätzlich aus dem SLOW-Pool gepickt,
+ * statt aus dem Stage-Pool — der User sieht, dass die App den
+ * Latenz-Spike erkannt hat, statt einer normalen Stage-Phrase.
+ */
+export function pickPhrase(
+  stage: RecallStage,
+  mode: BanterMode,
+  lang: BanterLang,
+): string | null {
+  if (mode === "off" || mode === "terse") return null;
+
+  const duration = stage.durationMs ?? 0;
+  if (duration >= VERY_SLOW_STAGE_MS) {
+    return pickFromPool(VERY_SLOW_PHRASES, lang, deterministicSeed(stage));
+  }
+  if (duration >= SLOW_STAGE_MS) {
+    return pickFromPool(SLOW_PHRASES, lang, deterministicSeed(stage));
+  }
+  const pool = STAGE_PHRASES[stage.name];
+  if (!pool) return null;
+  return pickFromPool(pool, lang, deterministicSeed(stage));
+}
+
+/**
+ * Stabile, billige Streuung über `(stageName, sekundenBucket)`. Tests
+ * können denselben Stage in derselben Sekunde mehrfach picken und
+ * bekommen dieselbe Phrase — keine Snapshot-Drift.
+ */
+function deterministicSeed(stage: RecallStage): number {
+  const bucket = Math.floor(stage.startedAtMs / 1000);
+  let hash = 0;
+  const key = `${stage.name}:${bucket}`;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function pickFromPool(pool: PhrasePool, lang: BanterLang, seed: number): string {
+  const arr = pool[lang];
+  if (arr.length === 0) return "";
+  return arr[seed % arr.length];
+}

--- a/packages/core/src/recall-stages.ts
+++ b/packages/core/src/recall-stages.ts
@@ -1,0 +1,77 @@
+/**
+ * Stage-Event-Typen für die Recall-Pipeline (#38).
+ *
+ * Der Recall-Pfad in `SearchIndex` (BM25 + Vector + RRF + Hops + Staleness)
+ * emittiert auf Wunsch nach jedem Schritt ein `RecallStage`-Event. Ein
+ * Caller (MCP-progress-notification, HTTP-SSE, CLI-stderr-Spinner) hängt
+ * sich via `RecallOptions.onStage` ein und macht die Schritte sichtbar.
+ *
+ * Designprinzipien:
+ *   - Null Overhead, wenn `onStage` nicht gesetzt ist (Hot-Path bleibt
+ *     unverändert, die einzigen Adds sind `t = Date.now()` + ein
+ *     `?.()`-Aufruf).
+ *   - Stage-Namen sind ein geschlossener String-Union — keine freien
+ *     Strings, damit Banter-Engine und Telemetry exhaustiv matchen
+ *     können.
+ *   - `meta` ist optional und Free-Form (z.B. `{ vault_size: 163 }`
+ *     beim `done`-Event, `{ cache: "query" }` beim `cache.hit`-Event).
+ *   - `startedAtMs` + `durationMs`: ein einzelner Event-Type für Start
+ *     und Stop. Der Banter-Picker entscheidet anhand von `durationMs`
+ *     ob „Slow"-Phrasen gefeuert werden.
+ */
+export interface RecallStage {
+  name:
+    | "query.parse"
+    | "cache.hit"
+    | "bm25.search"
+    | "vector.search"
+    | "rrf.fuse"
+    | "hops.expand"
+    | "staleness.rank"
+    | "done"
+    | "error";
+  /** Unix-ms beim Start der Stage (auch beim Stop-Event identisch — der
+   *  Caller kann so Start- und Stop-Events korrelieren). */
+  startedAtMs: number;
+  /** Wenn gesetzt: Stage ist abgeschlossen, Dauer in ms. Wenn fehlend:
+   *  Stage hat gerade erst gestartet. */
+  durationMs?: number;
+  /** Freie Metadaten — Stage-spezifisch. Beispiele:
+   *  - `cache.hit`: `{ cache: "query" }`
+   *  - `bm25.search`: `{ raw_hit_count: 42 }`
+   *  - `vector.search`: `{ vector_hit_count: 17 }`
+   *  - `rrf.fuse`: `{ fused_count: 50 }`
+   *  - `hops.expand`: `{ hop_count: 3 }`
+   *  - `done`: `{ hit_count, vault_size, total_ms }` */
+  meta?: Record<string, unknown>;
+}
+
+export type StageListener = (stage: RecallStage) => void;
+
+/**
+ * Geordnete Stage-Sequenz für `recallHybrid`. Wird von Banter-Engine
+ * und Progress-Counter gleichermaßen konsumiert (`total = 8` als
+ * Anker für UI-Bars). Reihenfolge ist absichtlich stabil — neue Stages
+ * werden hinten angehängt.
+ */
+export const RECALL_STAGE_ORDER: RecallStage["name"][] = [
+  "query.parse",
+  "cache.hit",
+  "bm25.search",
+  "vector.search",
+  "rrf.fuse",
+  "hops.expand",
+  "staleness.rank",
+  "done",
+];
+
+/**
+ * 1-basierter Index für UI-Progress (`progress: number` im
+ * MCP-`notifications/progress`-Payload erwartet eine Zahl). `error`
+ * bekommt `0`, `done` bekommt `RECALL_STAGE_ORDER.length`.
+ */
+export function progressIndexFor(name: RecallStage["name"]): number {
+  if (name === "error") return 0;
+  const idx = RECALL_STAGE_ORDER.indexOf(name);
+  return idx >= 0 ? idx + 1 : 0;
+}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -3,6 +3,7 @@ import type { Memory } from "./schema.js";
 import type { Vault, VaultEvent } from "./vault.js";
 import type { EmbeddingIndex } from "./embeddings.js";
 import { fuseRRF } from "./embeddings.js";
+import type { RecallStage, StageListener } from "./recall-stages.js";
 
 export interface RecallHit {
   id: string;
@@ -37,6 +38,15 @@ export interface RecallOptions {
    * `hop: "1-hop"`.
    */
   expand_hops?: 0 | 1;
+  /**
+   * Stage-Event-Listener (#38). Wenn gesetzt, emittiert die Recall-
+   * Pipeline pro Schritt einen Start- + Stop-Event (`query.parse`,
+   * `bm25.search`, `vector.search`, `rrf.fuse`, `hops.expand`,
+   * `staleness.rank`, `done`). Bei Query-Cache-Hits feuert zusätzlich
+   * ein `cache.hit`-Event mit `meta.cache = "query"` — danach folgt
+   * direkt `done`. Null-Overhead, wenn nicht gesetzt.
+   */
+  onStage?: StageListener;
 }
 
 interface IndexDoc {
@@ -127,8 +137,20 @@ export class SearchIndex {
 
   recall(query: string, opts: RecallOptions = {}): RecallHit[] {
     const k = opts.k ?? 5;
-    if (!query.trim()) return [];
+    const stage = new StageEmitter(opts.onStage);
+    const recallStart = Date.now();
+
+    const tParse = stage.start("query.parse");
+    if (!query.trim()) {
+      stage.end("query.parse", tParse);
+      stage.emit("done", recallStart, { hit_count: 0, vault_size: this.mini.documentCount, total_ms: 0 });
+      return [];
+    }
+    stage.end("query.parse", tParse);
+
+    const tBm = stage.start("bm25.search");
     const raw = this.mini.search(query);
+    stage.end("bm25.search", tBm, { raw_hit_count: raw.length });
 
     const filtered = raw.filter((r) => {
       if (!passesRecallFilters(r, opts)) return false;
@@ -153,10 +175,26 @@ export class SearchIndex {
     }));
     const direct = directFull.slice(0, k);
 
-    const withHops = opts.expand_hops === 1
-      ? [...direct, ...this.collectOneHopNeighbors(directFull, opts, new Set(direct.map((h) => h.id))).slice(0, k)]
-      : direct;
-    return applyStalenessMultiplier(withHops, (id) => this.vault.get(id)?.fm as Record<string, unknown> | undefined);
+    let withHops: RecallHit[];
+    if (opts.expand_hops === 1) {
+      const tHops = stage.start("hops.expand");
+      const neighbors = this.collectOneHopNeighbors(directFull, opts, new Set(direct.map((h) => h.id))).slice(0, k);
+      stage.end("hops.expand", tHops, { hop_count: neighbors.length });
+      withHops = [...direct, ...neighbors];
+    } else {
+      withHops = direct;
+    }
+
+    const tStale = stage.start("staleness.rank");
+    const ranked = applyStalenessMultiplier(withHops, (id) => this.vault.get(id)?.fm as Record<string, unknown> | undefined);
+    stage.end("staleness.rank", tStale, { reranked_count: ranked.length });
+
+    stage.emit("done", recallStart, {
+      hit_count: ranked.length,
+      vault_size: this.mini.documentCount,
+      total_ms: Date.now() - recallStart,
+    });
+    return ranked;
   }
 
   /** Hybrid-Recall: BM25 + Vector via Reciprocal-Rank-Fusion. Wenn kein
@@ -166,13 +204,25 @@ export class SearchIndex {
   async recallHybrid(query: string, opts: RecallOptions = {}): Promise<RecallHit[]> {
     if (!this.embeddings) return this.recall(query, opts);
     const k = opts.k ?? 5;
-    if (!query.trim()) return [];
+    const stage = new StageEmitter(opts.onStage);
+    const recallStart = Date.now();
+
+    const tParse = stage.start("query.parse");
+    if (!query.trim()) {
+      stage.end("query.parse", tParse);
+      stage.emit("done", recallStart, { hit_count: 0, vault_size: this.mini.documentCount, total_ms: 0 });
+      return [];
+    }
+    stage.end("query.parse", tParse);
 
     // BM25 — top 50 für RRF-Pool.
+    const tBm = stage.start("bm25.search");
     const bm25 = this.mini.search(query).filter((r) => passesRecallFilters(r, opts));
     const bm25Top = bm25.slice(0, 50);
+    stage.end("bm25.search", tBm, { raw_hit_count: bm25.length });
 
     // Vector — top 50 für RRF-Pool, plus type/scope/sensitivity-Filter über vault.
+    const tVec = stage.start("vector.search");
     const vec = await this.embeddings.search(query, 100);
     const vectorTop = vec
       .map((h) => ({ hit: h, mem: this.vault.get(h.id) }))
@@ -190,7 +240,9 @@ export class SearchIndex {
         return true;
       })
       .slice(0, 50);
+    stage.end("vector.search", tVec, { vector_hit_count: vectorTop.length });
 
+    const tFuse = stage.start("rrf.fuse");
     const bm25Ids = bm25Top.map((r) => r.id as string);
     const vectorIds = vectorTop.map(({ hit }) => hit.id);
     const fused = fuseRRF(bm25Ids, vectorIds);
@@ -226,11 +278,29 @@ export class SearchIndex {
         hop: "direct" as const,
       });
     }
+    stage.end("rrf.fuse", tFuse, { fused_count: outFull.length });
+
     const out = outFull.slice(0, k);
-    const withHops = opts.expand_hops === 1
-      ? [...out, ...this.collectOneHopNeighbors(outFull, opts, new Set(out.map((h) => h.id))).slice(0, k)]
-      : out;
-    return applyStalenessMultiplier(withHops, (id) => this.vault.get(id)?.fm as Record<string, unknown> | undefined);
+    let withHops: RecallHit[];
+    if (opts.expand_hops === 1) {
+      const tHops = stage.start("hops.expand");
+      const neighbors = this.collectOneHopNeighbors(outFull, opts, new Set(out.map((h) => h.id))).slice(0, k);
+      stage.end("hops.expand", tHops, { hop_count: neighbors.length });
+      withHops = [...out, ...neighbors];
+    } else {
+      withHops = out;
+    }
+
+    const tStale = stage.start("staleness.rank");
+    const ranked = applyStalenessMultiplier(withHops, (id) => this.vault.get(id)?.fm as Record<string, unknown> | undefined);
+    stage.end("staleness.rank", tStale, { reranked_count: ranked.length });
+
+    stage.emit("done", recallStart, {
+      hit_count: ranked.length,
+      vault_size: this.mini.documentCount,
+      total_ms: Date.now() - recallStart,
+    });
+    return ranked;
   }
 
   /**
@@ -362,6 +432,45 @@ function passesRecallFilters(
 
 function round(n: number): number {
   return Math.round(n * 1000) / 1000;
+}
+
+// MARK: - Stage-Event-Emitter (#38)
+
+/**
+ * Hilfsklasse für Stage-Events in `recall` / `recallHybrid`. Hält den
+ * optionalen Listener und liefert `start()`/`end()`/`emit()`. Bei
+ * fehlendem Listener sind alle Methoden no-op und allokationsfrei
+ * (kein `Date.now()` ohne Bedarf). Die Klasse lebt nur in `search.ts`,
+ * weil sie tight an die Stage-Sequenz gekoppelt ist — die public Types
+ * stehen in `recall-stages.ts`.
+ */
+class StageEmitter {
+  constructor(private readonly listener?: StageListener) {}
+
+  /** Start-Event feuern. Liefert den Start-Timestamp, der unverändert
+   *  an `end()` zurückgegeben wird (so muss der Caller kein lokales
+   *  `const t = Date.now()` aufmachen). */
+  start(name: RecallStage["name"], meta?: Record<string, unknown>): number {
+    if (!this.listener) return 0;
+    const t = Date.now();
+    this.listener({ name, startedAtMs: t, meta });
+    return t;
+  }
+
+  /** Stop-Event feuern. `startedAt` ist der Rückgabewert von `start()`. */
+  end(name: RecallStage["name"], startedAt: number, meta?: Record<string, unknown>): void {
+    if (!this.listener) return;
+    const dur = Date.now() - startedAt;
+    this.listener({ name, startedAtMs: startedAt, durationMs: dur, meta });
+  }
+
+  /** One-shot-Event (kein separates Stop) — für `cache.hit`, `done`,
+   *  `error`. `startedAtMs` ist der „Recall-Start" (für `done`) oder
+   *  der Event-Zeitpunkt selbst. */
+  emit(name: RecallStage["name"], startedAtMs: number, meta?: Record<string, unknown>): void {
+    if (!this.listener) return;
+    this.listener({ name, startedAtMs, durationMs: Date.now() - startedAtMs, meta });
+  }
 }
 
 // MARK: - Lifecycle-Reranking (#74)

--- a/packages/daemon/__tests__/sse-hook-recall.test.ts
+++ b/packages/daemon/__tests__/sse-hook-recall.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests für den SSE-Branch von `/hook/recall` (#38).
+ *
+ * Verifiziert:
+ * - Mit `Accept: text/event-stream` → Content-Type ist SSE, Stages
+ *   kommen als named events, finaler `event: done`-Frame trägt die
+ *   hits[].
+ * - Ohne `Accept`-Header → bestehende JSON-Response (BC).
+ *
+ * Runner: `node --import tsx --test packages/daemon/__tests__/sse-hook-recall.test.ts`
+ *
+ * Der Test startet einen echten Daemon-HTTP-Server gegen ein
+ * temporäres File-Vault — kein Mocking des SearchIndex, damit der
+ * Stage-Flow real durchläuft.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { request } from "node:http";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+import { startHttpServer } from "../src/http.js";
+import { Telemetry } from "../src/telemetry.js";
+
+function memoryMarkdown(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: reference",
+    `summary: ${title}`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: sse-test",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+interface HttpResult {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+function httpPost(
+  port: number,
+  path: string,
+  payload: unknown,
+  headers: Record<string, string> = {},
+): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload);
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body).toString(),
+          ...headers,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c as Buffer));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+async function makeDaemon(): Promise<{ port: number; close: () => Promise<void>; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-sse-test-"));
+  await writeFile(join(dir, "alpha.md"), memoryMarkdown("alpha", "alpha bravo"), "utf8");
+  await writeFile(join(dir, "charlie.md"), memoryMarkdown("charlie", "charlie delta"), "utf8");
+  const vault = new Vault(dir);
+  await vault.init();
+  const search = new SearchIndex(vault);
+  search.start();
+  const telemetry = new Telemetry();
+
+  const handle = await startHttpServer({
+    port: 0, // OS picks free port
+    vault,
+    search,
+    telemetry,
+    version: "test",
+    toolDeps: { vault, search, telemetry, vaultPath: dir },
+    documentWriteEnabled: false,
+  });
+  return {
+    port: handle.port!,
+    close: async () => {
+      search.stop();
+      await vault.stop?.();
+      await handle.close();
+      await rm(dir, { recursive: true, force: true });
+    },
+    dir,
+  };
+}
+
+test("hook/recall: without Accept header returns JSON", async () => {
+  const d = await makeDaemon();
+  try {
+    const r = await httpPost(d.port, "/hook/recall", { query: "alpha" });
+    assert.equal(r.status, 200);
+    const ct = String(r.headers["content-type"] ?? "");
+    assert.ok(ct.includes("application/json"), `expected JSON content-type, got ${ct}`);
+    const parsed = JSON.parse(r.body);
+    assert.ok(Array.isArray(parsed.hits), "hits must be array");
+    assert.equal(typeof parsed.recall_id, "string");
+    assert.equal(typeof parsed.latency_ms, "number");
+  } finally {
+    await d.close();
+  }
+});
+
+test("hook/recall: with Accept: text/event-stream returns SSE stages + done", async () => {
+  const d = await makeDaemon();
+  try {
+    const r = await httpPost(
+      d.port,
+      "/hook/recall",
+      { query: "alpha" },
+      { Accept: "text/event-stream" },
+    );
+    assert.equal(r.status, 200);
+    const ct = String(r.headers["content-type"] ?? "");
+    assert.ok(ct.includes("text/event-stream"), `expected SSE content-type, got ${ct}`);
+
+    // Body enthält named events (\nevent: stage\ndata: {...}\n\n)
+    assert.ok(r.body.includes("event: stage"), "no stage events in SSE body");
+    assert.ok(r.body.includes("event: done"), "no done event in SSE body");
+
+    // Parse jeden Event-Block — wir wollen mindestens query.parse,
+    // bm25.search, staleness.rank Stages und einen finalen done-Frame
+    // mit hits[].
+    const blocks = r.body.split("\n\n").filter((b) => b.startsWith("event: "));
+    const stageNames = blocks
+      .filter((b) => b.includes("event: stage"))
+      .map((b) => {
+        const m = b.match(/data: (.+)$/m);
+        return m ? (JSON.parse(m[1]) as { name: string }).name : "";
+      });
+    assert.ok(stageNames.includes("query.parse"), `missing query.parse in ${stageNames.join(",")}`);
+    assert.ok(stageNames.includes("bm25.search"), `missing bm25.search in ${stageNames.join(",")}`);
+    assert.ok(stageNames.includes("staleness.rank"), `missing staleness.rank in ${stageNames.join(",")}`);
+
+    const doneBlock = blocks.find((b) => b.includes("event: done"))!;
+    const doneJson = JSON.parse(doneBlock.match(/data: (.+)$/m)![1]);
+    assert.ok(Array.isArray(doneJson.hits));
+    assert.equal(typeof doneJson.recall_id, "string");
+    assert.equal(typeof doneJson.latency_ms, "number");
+  } finally {
+    await d.close();
+  }
+});
+
+test("hook/recall: SSE missing query returns error event", async () => {
+  const d = await makeDaemon();
+  try {
+    const r = await httpPost(
+      d.port,
+      "/hook/recall",
+      {},
+      { Accept: "text/event-stream" },
+    );
+    assert.equal(r.status, 200, "SSE keeps 200 even on error — event carries the failure");
+    assert.ok(r.body.includes("event: error"), `expected error event, got: ${r.body}`);
+  } finally {
+    await d.close();
+  }
+});

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -42,7 +42,7 @@
  */
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
-import type { Vault, SearchIndex } from "@bastra-recall/core";
+import type { Vault, SearchIndex, RecallStage, StageListener } from "@bastra-recall/core";
 import { fireAndForget, type Telemetry } from "./telemetry.js";
 import {
   recallHandler,
@@ -223,11 +223,24 @@ function handleHookRecall(
   search: SearchIndex,
   telemetry: Telemetry,
 ): void {
+  // SSE-Branch (#38): wenn der Caller `Accept: text/event-stream`
+  // sendet, streamen wir Stages live. Default-JSON-Response bleibt
+  // BC-erhalten — alte Hook-CLIs und REST-Caller sehen keinen
+  // Unterschied.
+  const accept = String(req.headers.accept ?? "");
+  const wantsSse = accept.includes("text/event-stream");
+
   readJsonBody(req, MAX_BODY_BYTES)
     .then(async (body) => {
       const query = typeof body.query === "string" ? body.query.trim() : "";
       if (!query) {
-        sendJson(res, 400, { error: "query is required" });
+        if (wantsSse) {
+          openSseHeaders(res);
+          writeSseEvent(res, "error", { error: "query is required" });
+          res.end();
+        } else {
+          sendJson(res, 400, { error: "query is required" });
+        }
         return;
       }
       const k = clampInt(body.k, 1, 10, 3);
@@ -238,10 +251,49 @@ function handleHookRecall(
       // Caller kann explizit 0 schicken um es zu deaktivieren.
       const expand_hops = body.expand_hops === 0 ? 0 : 1;
 
+      const stageTimings: NonNullable<Parameters<Telemetry["logHookRecall"]>[0]["recall_stages"]> = {};
+      const collectStage = (s: RecallStage): void => {
+        if (s.name === "cache.hit") {
+          stageTimings.cache_hit = true;
+          return;
+        }
+        if (s.durationMs === undefined) return;
+        switch (s.name) {
+          case "query.parse": stageTimings.query_parse_ms = s.durationMs; break;
+          case "bm25.search": stageTimings.bm25_search_ms = s.durationMs; break;
+          case "vector.search": stageTimings.vector_search_ms = s.durationMs; break;
+          case "rrf.fuse": stageTimings.rrf_fuse_ms = s.durationMs; break;
+          case "hops.expand": stageTimings.hops_expand_ms = s.durationMs; break;
+          case "staleness.rank": stageTimings.staleness_rank_ms = s.durationMs; break;
+        }
+      };
+
+      if (wantsSse) {
+        openSseHeaders(res);
+      }
+
+      const onStage: StageListener = (s: RecallStage) => {
+        collectStage(s);
+        if (wantsSse) {
+          // Nur Stop- + cache.hit + done-Events streamen (Start-Events
+          // wären für UI redundant). `done`-Event kommt unten als
+          // separater finaler SSE-Event mit den hits[] — wir
+          // unterdrücken den Stage-`done`, damit der finale Frame
+          // nicht doppelt rendert.
+          if (s.name === "done") return;
+          if (s.durationMs === undefined && s.name !== "cache.hit") return;
+          writeSseEvent(res, "stage", {
+            name: s.name,
+            durationMs: s.durationMs,
+            meta: s.meta,
+          });
+        }
+      };
+
       const tRecall0 = Date.now();
       const hits = search.hasEmbeddings()
-        ? await search.recallHybrid(query, { k, scope, type, expand_hops })
-        : search.recall(query, { k, scope, type, expand_hops });
+        ? await search.recallHybrid(query, { k, scope, type, expand_hops, onStage })
+        : search.recall(query, { k, scope, type, expand_hops, onStage });
       const recallLatencyMs = Date.now() - tRecall0;
       const totalLatencyMs = Date.now() - t0;
       const recallId = telemetry.newRecallId();
@@ -265,19 +317,53 @@ function handleHookRecall(
           hits: hits.map((h) => ({ id: h.id, score: h.score, type: h.type })),
           latency_ms_recall: recallLatencyMs,
           latency_ms_total: totalLatencyMs,
+          recall_stages: stageTimings,
         }),
       );
 
-      sendJson(res, 200, {
+      const payload = {
         hits,
         vault_size: vault.size(),
         latency_ms: totalLatencyMs,
         recall_id: recallId,
-      });
+      };
+      if (wantsSse) {
+        writeSseEvent(res, "done", payload);
+        res.end();
+      } else {
+        sendJson(res, 200, payload);
+      }
     })
     .catch((err: Error) => {
-      sendJson(res, 400, { error: err.message });
+      if (wantsSse && !res.headersSent) {
+        openSseHeaders(res);
+      }
+      if (wantsSse) {
+        writeSseEvent(res, "error", { error: err.message });
+        res.end();
+      } else {
+        sendJson(res, 400, { error: err.message });
+      }
     });
+}
+
+// ─── SSE helpers ─────────────────────────────────────────────────
+
+function openSseHeaders(res: ServerResponse): void {
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  // Disable Nagle for prompt event delivery on local connections.
+  res.setHeader("X-Accel-Buffering", "no");
+  res.writeHead(200);
+  // First chunk forces headers to flush so curl/test clients see them
+  // before the first stage event lands.
+  res.write(":ok\n\n");
+}
+
+function writeSseEvent(res: ServerResponse, event: string, data: unknown): void {
+  res.write(`event: ${event}\n`);
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
 }
 
 // ─── /api/v1 dispatcher ──────────────────────────────────────────

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -24,7 +24,13 @@ import {
   OpenAIEmbeddingProvider,
   OllamaEmbeddingProvider,
   RelatedEnricher,
+  pickPhrase,
+  banterModeFromEnv,
+  progressIndexFor,
+  RECALL_STAGE_ORDER,
   type EmbeddingProvider,
+  type RecallStage,
+  type StageListener,
 } from "@bastra-recall/core";
 import * as path from "node:path";
 import { Telemetry, logDirFor } from "./telemetry.js";
@@ -164,12 +170,49 @@ async function main(): Promise<void> {
   }));
 
 
-  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  // Banter-Lang: nutzt BASTRA_BANTER_LANG (de|en), default `en` —
+  // MCP-Clients sind heterogen, ein deutsches "Stichwörter durchforsten"
+  // im englischen Chat-Verlauf wirkt fremd. Deutsche Mac-App-User setzen
+  // BASTRA_BANTER_LANG=de in ihrer Shell oder dem Daemon-Launchd-Plist.
+  const banterMode = banterModeFromEnv(process.env);
+  const banterLang = (process.env.BASTRA_BANTER_LANG ?? "en").toLowerCase() === "de" ? "de" : "en";
+
+  server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
     const { name, arguments: args } = req.params;
 
     if (name === "recall") {
       try {
-        const result = await recallHandler(toolDeps, args);
+        // MCP-Progress-Notification (#38): wenn der Caller einen
+        // progressToken mitschickt, leiten wir Stage-Events als
+        // `notifications/progress` weiter. Claude Code rendert die als
+        // Live-Stage-Lines unter dem Tool-Aufruf. Banter-Phrase landet
+        // im `message`-Feld der Notification.
+        const progressToken = (req.params as { _meta?: { progressToken?: string | number } })._meta
+          ?.progressToken;
+        const onStage: StageListener | undefined = progressToken !== undefined
+          ? (s: RecallStage) => {
+              // Nur Stop-Events (mit durationMs) als Progress-Tick
+              // emittieren — Start-Events würden Claude Code mit
+              // doppelten Lines fluten.
+              if (s.durationMs === undefined && s.name !== "cache.hit" && s.name !== "done") return;
+              const phrase = pickPhrase(s, banterMode, banterLang);
+              const message = phrase
+                ? `${s.name} — ${phrase}${s.durationMs !== undefined ? ` (${s.durationMs}ms)` : ""}`
+                : `${s.name}${s.durationMs !== undefined ? ` (${s.durationMs}ms)` : ""}`;
+              // Fire-and-forget — Notification-Failures dürfen den
+              // Recall nicht kippen.
+              void extra.sendNotification({
+                method: "notifications/progress",
+                params: {
+                  progressToken,
+                  progress: progressIndexFor(s.name),
+                  total: RECALL_STAGE_ORDER.length,
+                  message,
+                },
+              }).catch(() => undefined);
+            }
+          : undefined;
+        const result = await recallHandler(toolDeps, args, { onStage });
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -46,6 +46,20 @@ export interface RecallEvent extends BaseEvent {
   top_score: number | null;
   hits: { id: string; score: number; type: string }[];
   latency_ms: number;
+  /**
+   * Pro-Stage-Timings (#38). Optional — alte Events ohne Stage-Emitter
+   * haben das Feld nicht. `cache_hit: true` zeigt einen Query-Cache-Hit,
+   * dann fehlen die übrigen Stage-Felder (außer query_parse_ms).
+   */
+  recall_stages?: {
+    query_parse_ms?: number;
+    bm25_search_ms?: number;
+    vector_search_ms?: number;
+    rrf_fuse_ms?: number;
+    hops_expand_ms?: number;
+    staleness_rank_ms?: number;
+    cache_hit?: boolean;
+  };
 }
 
 export interface LoadMemoryEvent extends BaseEvent {
@@ -90,6 +104,17 @@ export interface HookRecallEvent extends BaseEvent {
   hits: { id: string; score: number; type: string }[];
   latency_ms_recall: number;
   latency_ms_total: number;
+  /** Pro-Stage-Timings (#38). Optional — alte Hook-Events ohne Stage-
+   *  Emitter haben das Feld nicht. */
+  recall_stages?: {
+    query_parse_ms?: number;
+    bm25_search_ms?: number;
+    vector_search_ms?: number;
+    rrf_fuse_ms?: number;
+    hops_expand_ms?: number;
+    staleness_rank_ms?: number;
+    cache_hit?: boolean;
+  };
 }
 
 /** Hook CLI invocation (client-side view: total wall-clock incl. network). */

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -10,7 +10,14 @@
  * Vault-Mutation — kein doppelter Code, kein Drift.
  */
 import { z } from "zod";
-import { saveMemory, SaveMemoryInput, type Vault, type SearchIndex } from "@bastra-recall/core";
+import {
+  saveMemory,
+  SaveMemoryInput,
+  type Vault,
+  type SearchIndex,
+  type StageListener,
+  type RecallStage,
+} from "@bastra-recall/core";
 import { Telemetry, fireAndForget } from "./telemetry.js";
 
 export interface ToolDeps {
@@ -62,20 +69,76 @@ export interface RecallResult {
   latency_ms: number;
 }
 
+/**
+ * Pro-Stage-Dauern in ms (#38). Caller-agnostisch — sowohl der
+ * MCP-Stdio-Handler als auch HTTP-SSE und der Telemetry-Pfad bekommen
+ * dieselben Bucket-Namen. Wird in `recall_call`-JSONL-Logs als
+ * `recall_stages` mitgeschrieben, um Bottlenecks zu identifizieren.
+ */
+export interface RecallStageTimings {
+  query_parse_ms?: number;
+  bm25_search_ms?: number;
+  vector_search_ms?: number;
+  rrf_fuse_ms?: number;
+  hops_expand_ms?: number;
+  staleness_rank_ms?: number;
+  cache_hit?: boolean;
+}
+
+/** Stage-Namen → ms-Bucket in `RecallStageTimings`. `cache_hit` ist
+ *  bewusst nicht hier — der ist ein boolean und wird separat gesetzt. */
+type StageMsKey = "query_parse_ms" | "bm25_search_ms" | "vector_search_ms" | "rrf_fuse_ms" | "hops_expand_ms" | "staleness_rank_ms";
+
+const STAGE_TO_TIMING_KEY: Partial<Record<RecallStage["name"], StageMsKey>> = {
+  "query.parse": "query_parse_ms",
+  "bm25.search": "bm25_search_ms",
+  "vector.search": "vector_search_ms",
+  "rrf.fuse": "rrf_fuse_ms",
+  "hops.expand": "hops_expand_ms",
+  "staleness.rank": "staleness_rank_ms",
+};
+
+/**
+ * Sammelt Stage-Timings und fan-out zu einem optional externen Listener
+ * (MCP-progress-notification oder HTTP-SSE). Der Caller bekommt die
+ * Stage-Bucket-Map zurück, sobald `recall()` resolved ist — die Werte
+ * landen dann in der Telemetrie.
+ */
+function makeStageCollector(forward?: StageListener): { listener: StageListener; timings: RecallStageTimings } {
+  const timings: RecallStageTimings = {};
+  const listener: StageListener = (stage: RecallStage) => {
+    forward?.(stage);
+    if (stage.name === "cache.hit") {
+      timings.cache_hit = true;
+      return;
+    }
+    if (stage.durationMs === undefined) return;
+    const key = STAGE_TO_TIMING_KEY[stage.name];
+    if (!key) return;
+    // Stop-Events kommen nach Start-Events — durch das Überschreiben
+    // (statt += ) bleibt der finale Wert die echte Dauer.
+    timings[key] = stage.durationMs;
+  };
+  return { listener, timings };
+}
+
 export async function recallHandler(
   deps: ToolDeps,
   rawArgs: unknown,
-): Promise<RecallResult> {
+  options: { onStage?: StageListener } = {},
+): Promise<RecallResult & { stages?: RecallStageTimings }> {
   const parsed = RecallArgs.safeParse(rawArgs);
   if (!parsed.success) throw new Error(parsed.error.message);
 
   const t0 = Date.now();
+  const collector = makeStageCollector(options.onStage);
   const recallOpts = {
     k: parsed.data.k,
     scope: parsed.data.scope,
     type: parsed.data.type,
     allow_private: parsed.data.allow_private ?? false,
     expand_hops: parsed.data.expand_hops as 0 | 1 | undefined,
+    onStage: collector.listener,
   };
   const hits = deps.search.hasEmbeddings()
     ? await deps.search.recallHybrid(parsed.data.query, recallOpts)
@@ -94,6 +157,7 @@ export async function recallHandler(
       top_score: hits[0]?.score ?? null,
       hits: hits.map((h) => ({ id: h.id, score: h.score, type: h.type })),
       latency_ms: latencyMs,
+      recall_stages: collector.timings,
     }),
   );
 
@@ -103,6 +167,7 @@ export async function recallHandler(
     hits,
     recall_id: recallId,
     latency_ms: latencyMs,
+    stages: collector.timings,
   };
 }
 

--- a/scripts/sse-demo.ts
+++ b/scripts/sse-demo.ts
@@ -1,0 +1,96 @@
+/**
+ * Manual SSE-Demo für `/hook/recall` (#38). Startet einen ephemeral
+ * Daemon gegen ein temporäres Vault, sendet eine Recall-Anfrage mit
+ * `Accept: text/event-stream` und druckt die Stage-Lines aus.
+ *
+ * Run: npx tsx scripts/sse-demo.ts
+ */
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { request } from "node:http";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+import { startHttpServer } from "../packages/daemon/src/http.js";
+import { Telemetry } from "../packages/daemon/src/telemetry.js";
+
+function mem(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: reference",
+    `summary: ${title}`,
+    "topic_path:",
+    "  - demo",
+    "tags:",
+    "  - demo",
+    "scope: demo-scope",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+async function main(): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "sse-demo-"));
+  await writeFile(join(dir, "a.md"), mem("alpha-demo", "alpha bravo charlie"), "utf8");
+  await writeFile(join(dir, "b.md"), mem("beta-demo", "alpha delta echo"), "utf8");
+  const vault = new Vault(dir);
+  await vault.init();
+  const search = new SearchIndex(vault);
+  search.start();
+  const tele = new Telemetry();
+  const handle = await startHttpServer({
+    port: 0,
+    vault,
+    search,
+    telemetry: tele,
+    version: "demo",
+    toolDeps: { vault, search, telemetry: tele, vaultPath: dir },
+    documentWriteEnabled: false,
+  });
+
+  const body = JSON.stringify({ query: "alpha" });
+  const out = await new Promise<string>((resolve, reject) => {
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port: handle.port!,
+        path: "/hook/recall",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body).toString(),
+          Accept: "text/event-stream",
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c as Buffer));
+        res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+
+  console.log("=== SSE OUTPUT ===");
+  console.log(out);
+  console.log("=== END ===");
+  await handle.close();
+  search.stop();
+  await vault.stop?.();
+  await rm(dir, { recursive: true, force: true });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a stage-event emitter to `SearchIndex.recall` / `recallHybrid` with an additive `onStage` listener on `RecallOptions` — null-overhead when not set, BC for all existing callers.
- Adds a charming, deterministic banter engine (DE + EN, 3–5 variants per stage, adaptive slow + very-slow pools for >500ms / >1s stages), toggled via `BASTRA_BANTER=on|terse|off`.
- Wires stages into both transports: MCP `notifications/progress` (when a `progressToken` is sent in `_meta`) and HTTP-SSE on `/hook/recall` (gated by `Accept: text/event-stream`; default JSON response is untouched).
- Persists per-stage ms buckets + a `cache_hit` flag in the existing JSONL telemetry under `recall_stages`.

Closes #38.

## SSE snippet

Real output from `scripts/sse-demo.ts` against an ephemeral 2-memory vault:

```
:ok

event: stage
data: {"name":"query.parse","durationMs":0}

event: stage
data: {"name":"bm25.search","durationMs":1,"meta":{"raw_hit_count":2}}

event: stage
data: {"name":"hops.expand","durationMs":0,"meta":{"hop_count":0}}

event: stage
data: {"name":"staleness.rank","durationMs":0,"meta":{"reranked_count":2}}

event: done
data: {"hits":[{"id":"alpha-demo",...,"score":3.282,"mode":"bm25"}, ...],"vault_size":2,"latency_ms":1,"recall_id":"ac273203-..."}
```

## Coordination with PR #44

PR #44 (`perf/search-cache-29-30`) adds the staleness + query LRU cache to `SearchIndex`. This PR is **additive** — it touches the same `recall()` / `recallHybrid()` bodies but only inserts `onStage?.()` calls and a new `RecallOptions.onStage` field. Signatures stay stable. On merge, the rebase needs to:

1. Keep both PR #44's cache short-circuit and this PR's stage emitters.
2. Add a `cache.hit` stage event right where #44 returns the cached hits (next to the `lookupQueryCache` early-return) with `meta: { cache: "query" }`. The collector code is already prepared for that name in `tool-handlers.ts:STAGE_TO_TIMING_KEY` and the SSE/MCP forwarders pass `cache.hit` through untouched.

## Test plan

- [x] `npm run check:types` (core + daemon) — green
- [x] `npm run build` — green
- [x] `npm test` — 14/14 passing (4 stage tests, 7 banter tests, 3 SSE tests)
- [x] Manual SSE demo via `scripts/sse-demo.ts` — verified above
- [x] `npm run smoke` — fails on Vault-Pfad-Issue identical to main (worktree without migration vault)
- [ ] Manual MCP-progress smoke test inside Claude Code once the branch is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)