### PR TITLE
feat: surface save quality score

### DIFF
--- a/packages/daemon/__tests__/tool-handlers-lean.test.ts
+++ b/packages/daemon/__tests__/tool-handlers-lean.test.ts
@@ -51,6 +51,31 @@ function leanMemory(id: string, title: string): string {
   ].join("\n");
 }
 
+function privateMemory(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: lesson",
+    `summary: ${title} summary text`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - private",
+    "scope: lean-test",
+    "sensitivity: private",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Private body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
 /** Memory mit voller Frontmatter (related_via/source/confidence) + Auto-Related-Block. */
 function richMemory(id: string, title: string): string {
   const ts = new Date().toISOString();
@@ -119,6 +144,7 @@ async function makeDeps(): Promise<{ deps: ToolDeps; close: () => Promise<void> 
   await writeFile(join(dir, "charlie.md"), leanMemory("charlie", "charlie delta"), "utf8");
   await writeFile(join(dir, "rich.md"), richMemory("rich", "rich echo"), "utf8");
   await writeFile(join(dir, "longsum.md"), longSummaryMemory("longsum", "alpha bravo"), "utf8");
+  await writeFile(join(dir, "private.md"), privateMemory("private-checkout-focus", "checkout button focus private leak"), "utf8");
   const vault = new Vault(dir);
   await vault.init();
   const search = new SearchIndex(vault);
@@ -259,6 +285,26 @@ test("save_memory returns advisory save_quality with low score for generic trigg
       "generic trigger should be reported",
     );
     assert.ok(res.save_quality.suggestions.length > 0, "expected concrete tightening suggestion");
+  } finally {
+    await close();
+  }
+});
+
+test("save_memory save_quality does not surface private duplicate candidates by default", async () => {
+  const { deps, close } = await makeDeps();
+  try {
+    const res = await saveMemoryHandler(deps, {
+      title: "checkout button focus private leak follow-up",
+      type: "lesson",
+      summary: "Follow-up about the checkout button focus private leak memory.",
+      body: "Do not expose private duplicate ids through save quality output.",
+      topic_path: ["checkout", "accessibility", "focus"],
+      tags: ["checkout-focus"],
+      scope: "lean-test",
+      recall_when: ["checkout button focus private leak"],
+    });
+    assert.deepEqual(res.save_quality.duplicate_candidates, []);
+    assert.deepEqual(res.save_quality.trigger_collisions, []);
   } finally {
     await close();
   }

--- a/packages/daemon/__tests__/tool-handlers-lean.test.ts
+++ b/packages/daemon/__tests__/tool-handlers-lean.test.ts
@@ -21,7 +21,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Vault, SearchIndex, AUTO_RELATED_START } from "@bastra-recall/core";
 import { Telemetry } from "../src/telemetry.js";
-import { recallHandler, loadMemoryHandler, truncateSummary, type ToolDeps } from "../src/tool-handlers.js";
+import { recallHandler, loadMemoryHandler, saveMemoryHandler, truncateSummary, type ToolDeps } from "../src/tool-handlers.js";
 
 const LONG_SUMMARY =
   "alpha bravo charlie delta echo foxtrot golf hotel india juliett kilo lima mike november " +
@@ -234,6 +234,56 @@ test("load_memory verbosity:full: complete frontmatter + raw body", async () => 
     assert.ok(res.body.includes(AUTO_RELATED_START), "full body keeps auto-related block");
     assert.ok("related_via" in res.frontmatter, "full frontmatter keeps related_via");
     assert.ok("source" in res.frontmatter, "full frontmatter keeps source");
+  } finally {
+    await close();
+  }
+});
+
+test("save_memory returns advisory save_quality with low score for generic triggers", async () => {
+  const { deps, close } = await makeDeps();
+  try {
+    const res = await saveMemoryHandler(deps, {
+      title: "generic css lesson",
+      type: "lesson",
+      summary: "Remember to handle the project checkout button focus regression before changing css.",
+      body: "Use the checkout button focus fixture before changing styles.",
+      topic_path: ["checkout", "styles"],
+      tags: ["css"],
+      scope: "lean-test",
+      recall_when: ["css", "swift"],
+    });
+    assert.equal(res.save_quality.band, "low");
+    assert.ok(res.save_quality.score < 50, `expected low score, got ${res.save_quality.score}`);
+    assert.ok(
+      res.save_quality.issues.some((issue) => issue.includes("css")),
+      "generic trigger should be reported",
+    );
+    assert.ok(res.save_quality.suggestions.length > 0, "expected concrete tightening suggestion");
+  } finally {
+    await close();
+  }
+});
+
+test("save_memory returns high save_quality for specific anchored triggers", async () => {
+  const { deps, close } = await makeDeps();
+  try {
+    const res = await saveMemoryHandler(deps, {
+      title: "checkout button focus fixture",
+      type: "lesson",
+      summary: "Before changing checkout button focus styles, run the regression fixture that covers keyboard focus rings.",
+      body: "Run the checkout focus fixture before changing keyboard focus styles.",
+      topic_path: ["checkout", "accessibility", "focus"],
+      tags: ["checkout-focus", "accessibility"],
+      scope: "lean-test",
+      recall_when: [
+        "about to change checkout button keyboard focus styles",
+        "debugging missing focus ring in checkout flow",
+      ],
+    });
+    assert.equal(res.save_quality.band, "high");
+    assert.ok(res.save_quality.score >= 80, `expected high score, got ${res.save_quality.score}`);
+    assert.deepEqual(res.save_quality.issues, []);
+    assert.deepEqual(res.save_quality.suggestions, []);
   } finally {
     await close();
   }

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -425,7 +425,7 @@ function scoreSaveQuality(deps: ToolDeps, input: SaveMemoryInput): SaveQualityRe
 
   const duplicateQuery = [input.title, input.summary, ...input.recall_when, ...input.tags].join(" ");
   const duplicateCandidates = deps.search
-    .recall(duplicateQuery, { k: 5, scope: input.scope, type: input.type, allow_private: true })
+    .recall(duplicateQuery, { k: 5, scope: input.scope, type: input.type, allow_private: false })
     .filter((hit) => hit.id !== input.id)
     .filter((hit) => hit.score >= 20)
     .slice(0, 3)
@@ -439,7 +439,7 @@ function scoreSaveQuality(deps: ToolDeps, input: SaveMemoryInput): SaveQualityRe
   const triggerCollisions = input.recall_when
     .map((trigger) => {
       const hits = deps.search
-        .recall(trigger, { k: 20, scope: input.scope, type: input.type, allow_private: true })
+        .recall(trigger, { k: 20, scope: input.scope, type: input.type, allow_private: false })
         .filter((hit) => hit.id !== input.id);
       return { trigger, count: hits.length, examples: hits.slice(0, 3).map((h) => h.id) };
     })

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -325,12 +325,140 @@ export async function loadMemoryHandler(
 
 // ─── Save Memory ─────────────────────────────────────────────────
 
+export interface SaveQualityResult {
+  /** 0-100 advisory score: higher means more specific, less duplicative triggers. */
+  score: number;
+  band: "low" | "medium" | "high";
+  issues: string[];
+  suggestions: string[];
+  duplicate_candidates: Array<{ id: string; score: number; title: string }>;
+  trigger_collisions: Array<{ trigger: string; count: number; examples: string[] }>;
+}
+
 export interface SaveMemoryResult {
   id: string;
   file_path: string;
   created: boolean;
+  /** Advisory save-time quality signal for the agent; not persisted. */
+  save_quality: SaveQualityResult;
   /** Present only when saveMemory auto-truncated an over-long summary. */
   summary_note?: string;
+}
+
+const GENERIC_TRIGGER_WORDS = new Set([
+  "api",
+  "app",
+  "auth",
+  "bug",
+  "code",
+  "css",
+  "data",
+  "db",
+  "debug",
+  "design",
+  "docs",
+  "error",
+  "fix",
+  "frontend",
+  "ios",
+  "js",
+  "macos",
+  "memory",
+  "node",
+  "python",
+  "react",
+  "refactor",
+  "server",
+  "swift",
+  "test",
+  "typescript",
+  "ui",
+  "ux",
+]);
+
+function words(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? [];
+}
+
+function triggerSpecificityIssue(trigger: string): string | undefined {
+  const tokens = words(trigger);
+  if (tokens.length <= 1) return `recall_when '${trigger}' is too short/generic`;
+  if (tokens.length <= 2 && tokens.every((t) => GENERIC_TRIGGER_WORDS.has(t))) {
+    return `recall_when '${trigger}' is only generic technology words`;
+  }
+  return undefined;
+}
+
+function buildSpecificTriggerSuggestion(input: SaveMemoryInput): string {
+  const path = input.topic_path.join("/") || input.scope;
+  const summaryTokens = words(input.summary)
+    .filter((t) => !GENERIC_TRIGGER_WORDS.has(t))
+    .slice(0, 5)
+    .join(" ");
+  const anchor = summaryTokens || input.title.toLowerCase();
+  return `tighten recall_when around an action + anchor, e.g. 'about to ${input.type} in ${path}: ${anchor}'`;
+}
+
+function scoreSaveQuality(deps: ToolDeps, input: SaveMemoryInput): SaveQualityResult {
+  const issues: string[] = [];
+  const suggestions: string[] = [];
+  let score = 100;
+
+  const triggerIssues = input.recall_when
+    .map(triggerSpecificityIssue)
+    .filter((issue): issue is string => issue !== undefined);
+  if (triggerIssues.length > 0) {
+    issues.push(...triggerIssues);
+    suggestions.push(buildSpecificTriggerSuggestion(input));
+    score -= Math.min(55, triggerIssues.length * 25);
+  }
+
+  const genericTags = input.tags.filter((tag) => {
+    const tokens = words(tag);
+    return tokens.length === 1 && GENERIC_TRIGGER_WORDS.has(tokens[0]);
+  });
+  if (genericTags.length > 0) {
+    issues.push(`generic tags: ${genericTags.join(", ")}`);
+    suggestions.push("add at least one project/component/outcome tag so future matches are narrower");
+    score -= Math.min(24, genericTags.length * 12);
+  }
+
+  const duplicateQuery = [input.title, input.summary, ...input.recall_when, ...input.tags].join(" ");
+  const duplicateCandidates = deps.search
+    .recall(duplicateQuery, { k: 5, scope: input.scope, type: input.type, allow_private: true })
+    .filter((hit) => hit.id !== input.id)
+    .filter((hit) => hit.score >= 20)
+    .slice(0, 3)
+    .map((hit) => ({ id: hit.id, score: hit.score, title: hit.title }));
+  if (duplicateCandidates.length > 0) {
+    issues.push(`possible duplicate: ${duplicateCandidates[0].id}`);
+    suggestions.push(`consider load_memory('${duplicateCandidates[0].id}') and overwrite/update instead of creating a near-duplicate`);
+    score -= Math.min(30, 12 + duplicateCandidates.length * 6);
+  }
+
+  const triggerCollisions = input.recall_when
+    .map((trigger) => {
+      const hits = deps.search
+        .recall(trigger, { k: 20, scope: input.scope, type: input.type, allow_private: true })
+        .filter((hit) => hit.id !== input.id);
+      return { trigger, count: hits.length, examples: hits.slice(0, 3).map((h) => h.id) };
+    })
+    .filter((collision) => collision.count >= 3);
+  if (triggerCollisions.length > 0) {
+    issues.push(`trigger collision: ${triggerCollisions[0].trigger} already matches ${triggerCollisions[0].count} memories`);
+    suggestions.push("make high-collision triggers include a concrete action, subsystem, failure mode, or file family");
+    score -= Math.min(30, triggerCollisions.length * 12);
+  }
+
+  const clamped = Math.max(0, Math.min(100, Math.round(score)));
+  return {
+    score: clamped,
+    band: clamped >= 80 ? "high" : clamped >= 50 ? "medium" : "low",
+    issues,
+    suggestions: Array.from(new Set(suggestions)),
+    duplicate_candidates: duplicateCandidates,
+    trigger_collisions: triggerCollisions,
+  };
 }
 
 export async function saveMemoryHandler(
@@ -339,6 +467,8 @@ export async function saveMemoryHandler(
 ): Promise<SaveMemoryResult> {
   const parsed = SaveMemoryInput.safeParse(rawArgs);
   if (!parsed.success) throw new Error(parsed.error.message);
+
+  const saveQuality = scoreSaveQuality(deps, parsed.data);
 
   const result = await saveMemory(deps.vaultPath, parsed.data);
   // Don't trust the watcher on cloud-storage mounts — force-index now
@@ -359,7 +489,7 @@ export async function saveMemoryHandler(
     }),
   );
 
-  return result;
+  return { ...result, save_quality: saveQuality };
 }
 
 // ─── MCP Tool-Definitionen ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a non-persisted advisory `save_quality` object to the `save_memory` response so agents get immediate feedback when a memory is likely to be too generic, duplicative, or collision-prone.

The response includes:

- `score` and `band`
- `issues`
- `suggestions`
- `duplicate_candidates`
- `trigger_collisions`

The checks are deliberately advisory only: no persisted schema change and no save rejection.

## Implementation notes

- Penalizes bare/generic `recall_when` triggers and tags like `css` / `swift`.
- Reuses the existing recall/BM25 search path for duplicate and trigger-collision candidates.
- Keeps `save_memory` backwards-compatible while surfacing quality feedback to the caller.

## Verification

- `npm run build --workspace=@bastra-recall/core`
- `npm run check:types --workspace=@bastra-recall/daemon`
- `npm test -- --test-name-pattern='save_memory returns'`

The targeted test command currently executes the broader node test suite in this repo; latest local run: 169 passing.

Closes #70.
