### PR TITLE
feat: add acted_on recall episodes

### DIFF
--- a/packages/daemon/__tests__/telemetry-acted-on.test.ts
+++ b/packages/daemon/__tests__/telemetry-acted-on.test.ts
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Telemetry } from "../src/telemetry.js";
+
+test("recall_episode closes a loaded memory with acted_on=true without logging raw tokens", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-acted-on-"));
+  const prevPath = process.env.BASTRA_LOG_PATH;
+  const prevTelemetry = process.env.BASTRA_TELEMETRY;
+  process.env.BASTRA_LOG_PATH = dir;
+  process.env.BASTRA_TELEMETRY = "on";
+
+  try {
+    const telemetry = new Telemetry();
+    telemetry.rotateTurn("session-a");
+    telemetry.recordLoadedMemory({
+      memory_id: "mem-a",
+      distinctive_tokens: ["secretbanana", "privateraisin", "thirdanchor"],
+      hook_hint: { recall_id: "recall-a", score: 125 },
+      session_id: "session-a",
+    });
+
+    const episodes = telemetry.matchLoadedMemories({
+      tool_name: "Write",
+      tool_input_excerpt: "Apply the secretbanana migration and preserve privateraisin semantics.",
+      session_id: "session-a",
+    });
+
+    assert.equal(episodes.length, 1);
+    assert.equal(episodes[0].acted_on, true);
+    assert.equal(episodes[0].match_strength, 2);
+    assert.equal(episodes[0].band, "required");
+    await telemetry.logRecallEpisode(episodes[0]);
+
+    const today = new Date().toISOString().slice(0, 10);
+    const raw = await readFile(join(dir, `events-${today}.jsonl`), "utf8");
+    assert.match(raw, /"kind":"recall_episode"/);
+    assert.doesNotMatch(raw, /secretbanana|privateraisin/);
+  } finally {
+    if (prevPath === undefined) delete process.env.BASTRA_LOG_PATH;
+    else process.env.BASTRA_LOG_PATH = prevPath;
+    if (prevTelemetry === undefined) delete process.env.BASTRA_TELEMETRY;
+    else process.env.BASTRA_TELEMETRY = prevTelemetry;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("recall_episode closes disjoint follow-up edits with acted_on=false", () => {
+  const telemetry = new Telemetry();
+  telemetry.rotateTurn("session-b");
+  telemetry.recordLoadedMemory({
+    memory_id: "mem-b",
+    distinctive_tokens: ["quartzledger", "violetbridge"],
+    hook_hint: { recall_id: "recall-b", score: 70 },
+    session_id: "session-b",
+  });
+
+  const episodes = telemetry.matchLoadedMemories({
+    tool_name: "Edit",
+    tool_input_excerpt: "Change the button label and update unrelated copy.",
+    session_id: "session-b",
+  });
+
+  assert.equal(episodes.length, 1);
+  assert.equal(episodes[0].acted_on, false);
+  assert.equal(episodes[0].match_strength, 0);
+  assert.equal(episodes[0].band, "optional");
+
+  const second = telemetry.matchLoadedMemories({
+    tool_name: "Edit",
+    tool_input_excerpt: "quartzledger violetbridge",
+    session_id: "session-b",
+  });
+  assert.equal(second.length, 0);
+});

--- a/packages/daemon/scripts/stats.ts
+++ b/packages/daemon/scripts/stats.ts
@@ -199,6 +199,42 @@ function summarizeFollowThrough(events: AnyEvent[]): void {
   }
 }
 
+function summarizeUseRate(events: AnyEvent[]): void {
+  const hookRecalls = events.filter((e) => e.kind === "hook_recall" && Array.isArray(e.hits));
+  const episodes = events.filter((e) => e.kind === "recall_episode");
+  if (hookRecalls.length === 0 && episodes.length === 0) return;
+
+  const bands = ["required", "optional", "below_floor"] as const;
+  const surfaced = new Map<string, number>(bands.map((band) => [band, 0]));
+  const loaded = new Map<string, number>(bands.map((band) => [band, 0]));
+  const acted = new Map<string, number>(bands.map((band) => [band, 0]));
+
+  for (const r of hookRecalls) {
+    const hits = r.hits as Array<{ score?: number }>;
+    for (const h of hits) {
+      const score = Number(h.score ?? 0);
+      const band = score >= 100 ? "required" : score >= 30 ? "optional" : "below_floor";
+      surfaced.set(band, (surfaced.get(band) ?? 0) + 1);
+    }
+  }
+
+  for (const e of episodes) {
+    const band = bands.includes(e.band as typeof bands[number])
+      ? String(e.band)
+      : "below_floor";
+    if (e.loaded === true) loaded.set(band, (loaded.get(band) ?? 0) + 1);
+    if (e.acted_on === true) acted.set(band, (acted.get(band) ?? 0) + 1);
+  }
+
+  console.log(`\n## USE-rate  (did loaded hints affect the next tool input?)`);
+  for (const band of bands) {
+    const s = surfaced.get(band) ?? 0;
+    const l = loaded.get(band) ?? 0;
+    const a = acted.get(band) ?? 0;
+    console.log(`  ${band.padEnd(11)} surfaced ${s.toString().padStart(4)}  loaded ${l.toString().padStart(4)} (${pct(l, s)})  acted_on ${a.toString().padStart(4)} (${pct(a, s)})`);
+  }
+}
+
 function topHints(events: AnyEvent[]): void {
   const recalls = events.filter((e) => e.kind === "hook_recall" && Array.isArray(e.hits));
   const idCount = new Map<string, number>();
@@ -246,6 +282,7 @@ async function main(): Promise<void> {
   summarizeSessionHook(events);
   summarizeMcp(events);
   summarizeFollowThrough(events);
+  summarizeUseRate(events);
   topProjects(events);
   topHints(events);
 }

--- a/packages/daemon/src/bash-pre-hook.ts
+++ b/packages/daemon/src/bash-pre-hook.ts
@@ -148,6 +148,8 @@ async function main(): Promise<void> {
         topics: ["bash", match.severity, "safety"],
         project: null,
         tool_name: "Bash",
+        session_id: payload.session_id ?? null,
+        tool_input_excerpt: command.slice(0, 4096),
         scope: "all-projects",
         k: 3,
       },
@@ -255,6 +257,8 @@ interface RecallRequestBody {
   topics: string[];
   project: string | null;
   tool_name: string;
+  session_id: string | null;
+  tool_input_excerpt: string;
   k: number;
   scope?: string;
 }

--- a/packages/daemon/src/hook.ts
+++ b/packages/daemon/src/hook.ts
@@ -150,6 +150,8 @@ async function main(): Promise<void> {
       topics: topics.topics,
       project,
       tool_name: toolName,
+      session_id: payload.session_id ?? null,
+      tool_input_excerpt: intent.content_excerpt,
       k: 3,
     }, remainingMs);
   } catch (err) {
@@ -317,6 +319,8 @@ interface RecallRequestBody {
   topics: string[];
   project: string | null;
   tool_name: string;
+  session_id: string | null;
+  tool_input_excerpt: string;
   k: number;
   scope?: string;
 }

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -274,6 +274,11 @@ function handleHookRecall(
         return;
       }
       const k = clampInt(body.k, 1, 10, 3);
+      const hookSessionId = typeof body.session_id === "string" ? body.session_id : null;
+      const hookToolName = typeof body.tool_name === "string" ? body.tool_name : null;
+      if (hookToolName === "UserPromptSubmit") {
+        telemetry.rotateTurn(hookSessionId);
+      }
       const scope = typeof body.scope === "string" ? body.scope : undefined;
       const type = typeof body.type === "string" ? body.type : undefined;
       // expand_hops: Hooks profitieren vom Multi-Hop-Recall sobald
@@ -329,6 +334,19 @@ function handleHookRecall(
       const recallId = telemetry.newRecallId();
       telemetry.recordHookHints(recallId, hits);
 
+      const toolInputExcerpt = typeof body.tool_input_excerpt === "string"
+        ? body.tool_input_excerpt.slice(0, 4096)
+        : "";
+      if (toolInputExcerpt) {
+        for (const episode of telemetry.matchLoadedMemories({
+          tool_name: hookToolName,
+          tool_input_excerpt: toolInputExcerpt,
+          session_id: hookSessionId,
+        })) {
+          fireAndForget(telemetry.logRecallEpisode(episode));
+        }
+      }
+
       fireAndForget(
         telemetry.logHookRecall({
           recall_id: recallId,
@@ -336,7 +354,7 @@ function handleHookRecall(
           topics: Array.isArray(body.topics)
             ? (body.topics as unknown[]).filter((t): t is string => typeof t === "string")
             : [],
-          tool_name: typeof body.tool_name === "string" ? body.tool_name : null,
+          tool_name: hookToolName,
           project: typeof body.project === "string" ? body.project : null,
           k,
           scope: scope ?? null,

--- a/packages/daemon/src/prompt-hook.ts
+++ b/packages/daemon/src/prompt-hook.ts
@@ -186,7 +186,7 @@ async function main(): Promise<void> {
   try {
     resp = await postRecall(
       url,
-      { query: prompt, project, k, tool_name: "UserPromptSubmit" },
+      { query: prompt, project, k, tool_name: "UserPromptSubmit", session_id: payload.session_id ?? null },
       remainingMs,
     );
   } catch (err) {
@@ -308,6 +308,7 @@ interface RecallRequestBody {
   project: string | null;
   k: number;
   tool_name: string;
+  session_id: string | null;
   scope?: string;
   type?: string;
 }

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
-import { envFirst } from "./env.js";
+import { envFirst, envInt } from "./env.js";
 
 /**
  * Migration-aware default log directory: prefer `~/.bastra/logs`, aber
@@ -26,6 +26,7 @@ export type TelemetryEvent =
   | LoadMemoryEvent
   | SaveMemoryEvent
   | HookRecallEvent
+  | RecallEpisodeEvent
   | HookCallEvent
   | SessionHookCallEvent;
 
@@ -77,6 +78,23 @@ export interface LoadMemoryEvent extends BaseEvent {
   from_hook_recall: string | null;
   /** Rank (1-based) at which this id appeared in that hook_recall's hits[]. */
   hook_hint_rank: number | null;
+}
+
+export type RecallBand = "required" | "optional" | "below_floor";
+export type TurnSource = "session" | "inferred";
+
+export interface RecallEpisodeEvent extends BaseEvent {
+  kind: "recall_episode";
+  turn_id: string;
+  turn_source: TurnSource;
+  recall_id: string | null;
+  memory_id: string;
+  surfaced_score: number | null;
+  band: RecallBand;
+  loaded: boolean;
+  acted_on: boolean;
+  match_strength: number;
+  tool_name: string | null;
 }
 
 export interface SaveMemoryEvent extends BaseEvent {
@@ -171,7 +189,41 @@ const HOOK_HINT_WINDOW_MS = 10 * 60 * 1000;
 interface HookHintTrace {
   recall_id: string;
   rank: number;
+  score: number | null;
   ts: number;
+}
+
+interface TurnTrace {
+  turn_id: string;
+  session_id: string;
+  started_at: number;
+}
+
+interface LoadedMemoryTrace {
+  memory_id: string;
+  distinctive_tokens: Set<string>;
+  turn_id: string;
+  turn_source: TurnSource;
+  recall_id: string | null;
+  surfaced_score: number | null;
+  band: RecallBand;
+  ts: number;
+  closed: boolean;
+}
+
+const ACTED_ON_WINDOW_MS = envInt("BASTRA_ACTED_ON_WINDOW_MS", 180_000);
+const SCORE_FLOOR = envInt("BASTRA_RECALL_FLOOR", 30);
+const MUST_LOAD_SCORE = envInt("BASTRA_MUST_LOAD_SCORE", 100);
+
+function bandForScore(score: number | null): RecallBand {
+  if (score === null) return "below_floor";
+  if (score >= MUST_LOAD_SCORE) return "required";
+  if (score >= SCORE_FLOOR) return "optional";
+  return "below_floor";
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? []);
 }
 
 export class Telemetry {
@@ -181,6 +233,9 @@ export class Telemetry {
   private lastRecall: { id: string; ts: number } | null = null;
   /** Map<memory_id, most-recent HookHintTrace>. Older traces are evicted lazily. */
   private hookHints = new Map<string, HookHintTrace>();
+  private turns = new Map<string, TurnTrace>();
+  private latestTurn: TurnTrace | null = null;
+  private loadedMemories: LoadedMemoryTrace[] = [];
   private initPromise: Promise<void> | null = null;
 
   constructor() {
@@ -216,10 +271,17 @@ export class Telemetry {
    * load_memory(id) can report whether (and where) the id was hinted to the
    * user. Most-recent hint wins on collision.
    */
-  recordHookHints(recall_id: string, hits: Array<{ id: string }>): void {
+  recordHookHints(recall_id: string, hits: Array<{ id: string; score?: number }>): void {
     const ts = Date.now();
     for (let i = 0; i < hits.length; i++) {
-      this.hookHints.set(hits[i].id, { recall_id, rank: i + 1, ts });
+      const hit = hits[i];
+      if (!hit) continue;
+      this.hookHints.set(hit.id, {
+        recall_id,
+        rank: i + 1,
+        score: typeof hit.score === "number" ? hit.score : null,
+        ts,
+      });
     }
   }
 
@@ -227,14 +289,118 @@ export class Telemetry {
    * Returns the recall_id + rank if this id was hinted in the last
    * HOOK_HINT_WINDOW_MS. Lazy-evicts the entry on miss.
    */
-  findHookHintFor(id: string): { recall_id: string; rank: number } | null {
+  findHookHintFor(id: string): { recall_id: string; rank: number; score: number | null } | null {
     const t = this.hookHints.get(id);
     if (!t) return null;
     if (Date.now() - t.ts > HOOK_HINT_WINDOW_MS) {
       this.hookHints.delete(id);
       return null;
     }
-    return { recall_id: t.recall_id, rank: t.rank };
+    return { recall_id: t.recall_id, rank: t.rank, score: t.score };
+  }
+
+  rotateTurn(sessionId: string | null): string | null {
+    if (!sessionId) return null;
+    const trace: TurnTrace = {
+      turn_id: randomUUID(),
+      session_id: sessionId,
+      started_at: Date.now(),
+    };
+    this.turns.set(sessionId, trace);
+    this.latestTurn = trace;
+    return trace.turn_id;
+  }
+
+  private currentTurn(sessionId: string | null): { turn_id: string; turn_source: TurnSource } {
+    if (sessionId) {
+      const exact = this.turns.get(sessionId);
+      if (exact) return { turn_id: exact.turn_id, turn_source: "session" };
+    }
+    if (this.latestTurn) return { turn_id: this.latestTurn.turn_id, turn_source: "inferred" };
+    const fallback = randomUUID();
+    this.latestTurn = { turn_id: fallback, session_id: "", started_at: Date.now() };
+    return { turn_id: fallback, turn_source: "inferred" };
+  }
+
+  recordLoadedMemory(payload: {
+    memory_id: string;
+    distinctive_tokens: string[];
+    hook_hint: { recall_id: string; score: number | null } | null;
+    session_id?: string | null;
+  }): void {
+    const tokens = new Set(payload.distinctive_tokens);
+    if (tokens.size === 0) return;
+    const turn = this.currentTurn(payload.session_id ?? null);
+    const now = Date.now();
+    this.loadedMemories = this.loadedMemories.filter(
+      (entry) => !entry.closed && now - entry.ts <= ACTED_ON_WINDOW_MS,
+    );
+    this.loadedMemories.push({
+      memory_id: payload.memory_id,
+      distinctive_tokens: tokens,
+      turn_id: turn.turn_id,
+      turn_source: turn.turn_source,
+      recall_id: payload.hook_hint?.recall_id ?? null,
+      surfaced_score: payload.hook_hint?.score ?? null,
+      band: bandForScore(payload.hook_hint?.score ?? null),
+      ts: now,
+      closed: false,
+    });
+  }
+
+  matchLoadedMemories(payload: {
+    tool_name: string | null;
+    tool_input_excerpt: string;
+    session_id?: string | null;
+  }): Omit<RecallEpisodeEvent, "kind" | "ts" | "session_id">[] {
+    const now = Date.now();
+    const current = this.currentTurn(payload.session_id ?? null);
+    const inputTokens = tokenize(payload.tool_input_excerpt);
+    const episodes: Omit<RecallEpisodeEvent, "kind" | "ts" | "session_id">[] = [];
+
+    for (const entry of this.loadedMemories) {
+      if (entry.closed) continue;
+      if (now - entry.ts > ACTED_ON_WINDOW_MS) {
+        entry.closed = true;
+        continue;
+      }
+      if (entry.turn_source === "session" && entry.turn_id !== current.turn_id) continue;
+
+      let matchStrength = 0;
+      for (const token of entry.distinctive_tokens) {
+        if (inputTokens.has(token)) matchStrength++;
+      }
+      entry.closed = true;
+      episodes.push({
+        turn_id: entry.turn_id,
+        turn_source: entry.turn_source,
+        recall_id: entry.recall_id,
+        memory_id: entry.memory_id,
+        surfaced_score: entry.surfaced_score,
+        band: entry.band,
+        loaded: true,
+        acted_on: matchStrength >= 2,
+        match_strength: matchStrength,
+        tool_name: payload.tool_name,
+      });
+    }
+
+    this.loadedMemories = this.loadedMemories.filter(
+      (entry) => !entry.closed && now - entry.ts <= ACTED_ON_WINDOW_MS,
+    );
+    return episodes;
+  }
+
+  async logRecallEpisode(
+    payload: Omit<RecallEpisodeEvent, "kind" | "ts" | "session_id">,
+  ): Promise<void> {
+    if (!this.enabled) return;
+    await this.write({
+      kind: "recall_episode",
+      ts: new Date().toISOString(),
+      session_id: this.sessionId,
+      ...payload,
+    });
   }
 
   async logRecall(payload: Omit<RecallEvent, "kind" | "ts" | "session_id">): Promise<void> {

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -306,6 +306,15 @@ export async function loadMemoryHandler(
     throw new Error(`memory not found: ${parsed.data.id}`);
   }
 
+  const bodyForTelemetry = stripAutoRelatedSection(m.body);
+  deps.telemetry.recordLoadedMemory({
+    memory_id: parsed.data.id,
+    distinctive_tokens: distinctiveTokensForActedOn(bodyForTelemetry),
+    hook_hint: hookHint
+      ? { recall_id: hookHint.recall_id, score: hookHint.score }
+      : null,
+  });
+
   // Reset-signal for the hook's per-session dedup (#32): touch a marker
   // file so the next hook invocation knows the agent has consumed this
   // memory and the dedup clock should restart.
@@ -318,7 +327,7 @@ export async function loadMemoryHandler(
   return {
     id: m.fm.id,
     frontmatter: full ? fm : leanFrontmatter(fm),
-    body: full ? m.body : stripAutoRelatedSection(m.body),
+    body: full ? m.body : bodyForTelemetry,
     file_path: m.filePath,
   };
 }
@@ -345,7 +354,7 @@ export interface SaveMemoryResult {
   summary_note?: string;
 }
 
-const GENERIC_TRIGGER_WORDS = new Set([
+export const GENERIC_TRIGGER_WORDS = new Set([
   "api",
   "app",
   "auth",
@@ -378,6 +387,40 @@ const GENERIC_TRIGGER_WORDS = new Set([
 
 function words(text: string): string[] {
   return text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? [];
+}
+
+const ACTED_ON_STOPWORDS = new Set([
+  "about",
+  "after",
+  "also",
+  "and",
+  "because",
+  "been",
+  "before",
+  "between",
+  "from",
+  "have",
+  "into",
+  "that",
+  "their",
+  "then",
+  "there",
+  "this",
+  "through",
+  "with",
+  "without",
+  "would",
+]);
+
+export function distinctiveTokensForActedOn(text: string): string[] {
+  return Array.from(
+    new Set(
+      words(text)
+        .filter((token) => token.length >= 4)
+        .filter((token) => !ACTED_ON_STOPWORDS.has(token))
+        .filter((token) => !GENERIC_TRIGGER_WORDS.has(token)),
+    ),
+  ).slice(0, 200);
 }
 
 function triggerSpecificityIssue(trigger: string): string | undefined {


### PR DESCRIPTION
## Summary
- adds additive `recall_episode` telemetry records for loaded hook hints and whether their distinctive tokens reached the next Write/Edit/Bash input
- threads `session_id`/tool input excerpts from Claude Code hooks into `/hook/recall` and rotates a daemon-side turn id on `UserPromptSubmit`
- extends stats with per-band USE-rate and adds privacy-focused tests that assert raw tokens/excerpts are not logged

## Validation
- `npm run check:types --workspace=@bastra-recall/daemon`
- `npm test -- --test-name-pattern='recall_episode|save_memory'` (runner executed full suite: 172 passing)
- `git diff --check`
- `npm run build --workspace=@bastra-recall/daemon`

Closes #69