### PR TITLE
Add @bastra-recall/eval: recall_when marginal-lift ablation (#89)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bastra-recall-monorepo",
-  "version": "0.6.5-beta.1",
+  "version": "0.6.6-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bastra-recall-monorepo",
-      "version": "0.6.5-beta.1",
+      "version": "0.6.6-beta.1",
       "license": "MIT",
       "workspaces": [
         "packages/core",
@@ -2786,7 +2786,7 @@
     },
     "packages/core": {
       "name": "@bastra-recall/core",
-      "version": "0.6.5-beta.1",
+      "version": "0.6.6-beta.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -2805,11 +2805,11 @@
     },
     "packages/daemon": {
       "name": "@bastra-recall/daemon",
-      "version": "0.6.5-beta.1",
+      "version": "0.6.6-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@bastra-recall/core": "0.6.5-beta.1",
-        "@bastra-recall/statusline": "0.6.5-beta.1",
+        "@bastra-recall/core": "0.6.6-beta.1",
+        "@bastra-recall/statusline": "0.6.6-beta.1",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^4.4.3"
       },
@@ -2837,10 +2837,10 @@
     },
     "packages/eval": {
       "name": "@bastra-recall/eval",
-      "version": "0.6.5-beta.1",
+      "version": "0.6.6-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@bastra-recall/core": "0.6.5-beta.1",
+        "@bastra-recall/core": "0.6.6-beta.1",
         "minisearch": "^7.1.1"
       },
       "devDependencies": {
@@ -2854,7 +2854,7 @@
     },
     "packages/statusline": {
       "name": "@bastra-recall/statusline",
-      "version": "0.6.5-beta.1",
+      "version": "0.6.6-beta.1",
       "license": "MIT",
       "bin": {
         "bastra-statusline": "bin/claude-powerline"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "workspaces": [
         "packages/core",
         "packages/daemon",
-        "packages/statusline"
+        "packages/statusline",
+        "packages/eval"
       ],
       "devDependencies": {
         "typescript": "^6.0.3"
@@ -94,6 +95,10 @@
     },
     "node_modules/@bastra-recall/daemon": {
       "resolved": "packages/daemon",
+      "link": true
+    },
+    "node_modules/@bastra-recall/eval": {
+      "resolved": "packages/eval",
       "link": true
     },
     "node_modules/@bastra-recall/statusline": {
@@ -2820,6 +2825,23 @@
         "bastra-recall-session-hook": "dist/session-hook.js",
         "bastra-recall-stop-hook": "dist/stop-hook.js",
         "bastra-recall-todo-hook": "dist/todo-hook.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.20",
+        "tsx": "^4.19.2",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "packages/eval": {
+      "name": "@bastra-recall/eval",
+      "version": "0.6.5-beta.1",
+      "license": "MIT",
+      "dependencies": {
+        "@bastra-recall/core": "0.6.5-beta.1",
+        "minisearch": "^7.1.1"
       },
       "devDependencies": {
         "@types/node": "^22.19.20",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   "workspaces": [
     "packages/core",
     "packages/daemon",
-    "packages/statusline"
+    "packages/statusline",
+    "packages/eval"
   ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "check:types": "npm run check:types --workspaces --if-present",
-    "test": "node --import tsx --test packages/core/__tests__/*.test.ts packages/daemon/__tests__/*.test.ts",
+    "test": "node --import tsx --test packages/core/__tests__/*.test.ts packages/daemon/__tests__/*.test.ts packages/eval/__tests__/*.test.ts",
+    "eval:lift": "npm run lift --workspace=@bastra-recall/eval",
     "test:update": "npm run test:update --workspace=@bastra-recall/daemon",
     "smoke": "npm run smoke --workspace=@bastra-recall/daemon",
     "smoke:telemetry": "npm run smoke:telemetry --workspace=@bastra-recall/daemon",

--- a/packages/eval/LICENSE
+++ b/packages/eval/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 zzallirog
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,0 +1,70 @@
+# @bastra-recall/eval — `recall_when` marginal-lift ablation
+
+Offline counterpart to the online USE-rate (#69). Where the M0 baseline
+(`scripts/eval.ts`) queries each memory with its **own** `recall_when` phrase —
+an upper bound that's circular by construction — this harness measures how
+**load-bearing** the trigger field actually is, under paraphrased queries.
+
+## What it measures
+
+Two BM25 indexes over the **same** vault, differing on exactly one dimension:
+
+| arm | `recall_when` |
+|---|---|
+| **control** | stripped from the searchable fields |
+| **treatment** | indexed at its production weight (core: `×5`) |
+
+Every other field weight + search option is pinned to
+[`core/src/search.ts`](../core/src/search.ts) (a drift-guard test fails if they
+diverge). Queries are **paraphrases** of each memory's trigger — held out,
+sharing as few literal tokens as is realistic — so we test whether a memory
+still surfaces when a future session phrases the situation in its own words.
+
+```
+marginal-lift@k = Recall@k(treatment) − Recall@k(control)
+```
+
+A no-trigger **anti** slice records the median top-1 score on off-vault queries,
+bounding false-positive surfacing — adding the trigger field must not inflate it.
+
+## Run it
+
+```bash
+# bundled synthetic vault + cases (self-contained, CI-runnable)
+npm run lift --workspace=@bastra-recall/eval
+# or, from repo root:
+npm run eval:lift
+
+# tune
+npm run lift -- --boost 5 --k 3
+
+# against a real vault with your own paraphrases:
+BASTRA_VAULT_PATH=/path/to/vault \
+  npm run lift -- --cases my-cases.json --out lift.json
+```
+
+## ⚠️ The bundled number is a mechanism demo, not the headline
+
+`fixtures/eval-vault` is a **tiny synthetic vault** (10 memories) whose only job
+is to make the harness self-contained and reproducible. The lift it reports
+shows the harness *computes correctly* — it is **not** evidence about the real
+lift on a production vault. A citable number comes from running the ablation on
+a real vault (e.g. the 59-memory vault behind the M0 baseline) with hand-written
+paraphrases. Treat the synthetic figure as a smoke test, not a result.
+
+## Cases format (`fixtures/cases.json`)
+
+```jsonc
+{
+  "paraphrased": [
+    { "id": "<memory id in the vault>", "label": "short handle",
+      "paraphrases": ["query phrased in different words", "..."] }
+  ],
+  "anti": [
+    { "query": "off-vault topic with no relevant memory", "note": "why" }
+  ]
+}
+```
+
+Unknown ids (a renamed/deleted memory) are reported and skipped, not counted as
+misses.

--- a/packages/eval/__tests__/boost-drift.test.ts
+++ b/packages/eval/__tests__/boost-drift.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { BASE_BOOST, TREATMENT_RECALL_WHEN_BOOST } from "../src/index-config.js";
+
+/**
+ * Drift guard. The ablation mirrors core's field weights by hand (the
+ * harness must be able to vary ONE knob, which means it can't just import
+ * core's hardcoded boost map). This test fails if core's SearchIndex boosts
+ * change without the mirror in index-config.ts being updated — so a stale
+ * ablation can't quietly report a lift against the wrong baseline.
+ */
+const searchSrc = readFileSync(
+  resolve(import.meta.dirname, "../../core/src/search.ts"),
+  "utf8",
+);
+
+test("ablation field weights stay in sync with core SearchIndex", () => {
+  const expected: Record<string, number> = {
+    recall_when_flat: TREATMENT_RECALL_WHEN_BOOST,
+    title: BASE_BOOST.title,
+    tags_flat: BASE_BOOST.tags_flat,
+    topic_path_flat: BASE_BOOST.topic_path_flat,
+    summary: BASE_BOOST.summary,
+    body: BASE_BOOST.body,
+  };
+  for (const [field, weight] of Object.entries(expected)) {
+    assert.match(
+      searchSrc,
+      new RegExp(`${field}:\\s*${weight}\\b`),
+      `core/src/search.ts should boost ${field} at ${weight} — update index-config.ts if core changed`,
+    );
+  }
+});

--- a/packages/eval/fixtures/cases.json
+++ b/packages/eval/fixtures/cases.json
@@ -1,0 +1,103 @@
+{
+  "_comment": "Paraphrased held-out queries for the synthetic eval-vault. Each paraphrase is phrased to share as few literal tokens with the memory's recall_when as is realistic, simulating how a future session describes the situation in its own words. The 'anti' set is off-vault: no memory should genuinely match.",
+  "paraphrased": [
+    {
+      "id": "git-rebase-autosquash-fixup",
+      "label": "tidy history before PR",
+      "paraphrases": [
+        "tidy my branch history before opening a pull request",
+        "fold a follow-up edit into an earlier commit automatically",
+        "combine small correction commits into one"
+      ]
+    },
+    {
+      "id": "css-flexbox-min-width-zero",
+      "label": "flex item won't shrink",
+      "paraphrases": [
+        "long string blows out the row width instead of shrinking",
+        "ellipsis never appears on a label in a horizontal layout",
+        "column refuses to get narrower than its content"
+      ]
+    },
+    {
+      "id": "postgres-index-type-mismatch",
+      "label": "full scan despite index",
+      "paraphrases": [
+        "database does a full table scan even though I added an index",
+        "explain shows the planner avoiding my index",
+        "a casting mismatch makes the optimizer skip the index"
+      ]
+    },
+    {
+      "id": "money-not-float",
+      "label": "decimal arithmetic drift",
+      "paraphrases": [
+        "summing decimal amounts gives a tiny error",
+        "currency arithmetic drifts by a fraction",
+        "my totals come out a penny off"
+      ]
+    },
+    {
+      "id": "docker-manifest-before-source",
+      "label": "deps reinstall every build",
+      "paraphrases": [
+        "every container build redownloads node modules",
+        "image takes forever to rebuild after editing one file",
+        "dependency install step never gets cached"
+      ]
+    },
+    {
+      "id": "debounce-vs-throttle",
+      "label": "limit event frequency",
+      "paraphrases": [
+        "autocomplete sends a request on every keystroke",
+        "run a handler at most once per interval",
+        "stop a frequently firing event from spamming"
+      ]
+    },
+    {
+      "id": "timestamps-store-utc",
+      "label": "wrong time across regions",
+      "paraphrases": [
+        "appointment shows a different time for users in another country",
+        "clock jumps an hour twice a year",
+        "schedule is wrong after moving servers"
+      ]
+    },
+    {
+      "id": "backoff-jitter",
+      "label": "synchronized retries",
+      "paraphrases": [
+        "everything reconnects simultaneously and overloads the server",
+        "synchronized reconnection attempts spike the backend",
+        "spread out reconnection attempts over time"
+      ]
+    },
+    {
+      "id": "secrets-in-env",
+      "label": "leaked credential",
+      "paraphrases": [
+        "committed a database password by mistake and need to rotate",
+        "safe place for credentials outside source control",
+        "a token ended up in version history"
+      ]
+    },
+    {
+      "id": "focus-ring-keyboard",
+      "label": "missing focus indicator",
+      "paraphrases": [
+        "hiding the outline broke tabbing through the form",
+        "no indicator showing which element is selected via keyboard",
+        "assistive tech users can't see where focus is"
+      ]
+    }
+  ],
+  "anti": [
+    { "query": "kubernetes ingress tls termination", "note": "no k8s content" },
+    { "query": "tensorflow learning rate scheduler", "note": "no ML content" },
+    { "query": "rust borrow checker lifetime error", "note": "no rust content" },
+    { "query": "kafka consumer group rebalance storm", "note": "no kafka content" },
+    { "query": "graphql resolver dataloader batching", "note": "no graphql content" },
+    { "query": "webrtc ice candidate stun turn negotiation", "note": "no webrtc content" }
+  ]
+}

--- a/packages/eval/fixtures/eval-vault/memories/backoff-jitter.md
+++ b/packages/eval/fixtures/eval-vault/memories/backoff-jitter.md
@@ -1,0 +1,29 @@
+---
+id: backoff-jitter
+title: "Add jitter to exponential backoff"
+type: lesson
+summary: "Exponential backoff alone still lets many clients retry on the same schedule; add randomized jitter so recovery traffic spreads out instead of spiking."
+topic_path: [reliability, retries]
+tags: [backoff, jitter, retry, resilience]
+scope: all-projects
+recall_when:
+  - thundering herd when a service recovers
+  - all clients retry at the same instant
+  - retries hammer the API in sync
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Randomize each retry delay within the backoff window.
+
+## Why
+Deterministic backoff keeps clients phase-locked, so they all hit the recovering service together.
+
+## How to apply
+Use full or decorrelated jitter on top of the exponential schedule.

--- a/packages/eval/fixtures/eval-vault/memories/css-flexbox-min-width-zero.md
+++ b/packages/eval/fixtures/eval-vault/memories/css-flexbox-min-width-zero.md
@@ -1,0 +1,29 @@
+---
+id: css-flexbox-min-width-zero
+title: "Flex children overflow until you set min-width:0"
+type: lesson
+summary: "A flex item defaults to min-width:auto, so its content can push the container wider than intended; set min-width:0 (or min-height:0) to let it shrink and truncate."
+topic_path: [css, flexbox]
+tags: [css, flexbox, overflow, layout]
+scope: all-projects
+recall_when:
+  - text not truncating inside a flex row
+  - child stretches container instead of ellipsis
+  - overflow ignored in flex layout
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Add `min-width: 0` to a flex child that should be allowed to shrink.
+
+## Why
+The implicit `min-width: auto` keeps the item at least as wide as its content, defeating `overflow: hidden`.
+
+## How to apply
+Set `min-width: 0` on the flex item (and `overflow: hidden; text-overflow: ellipsis` on the text).

--- a/packages/eval/fixtures/eval-vault/memories/debounce-vs-throttle.md
+++ b/packages/eval/fixtures/eval-vault/memories/debounce-vs-throttle.md
@@ -1,0 +1,29 @@
+---
+id: debounce-vs-throttle
+title: "Debounce to wait for settle, throttle to cap the rate"
+type: lesson
+summary: "Debounce delays a callback until input stops (good for search-as-you-type); throttle guarantees at most one call per interval (good for scroll/resize)."
+topic_path: [javascript, events]
+tags: [debounce, throttle, events, rate-limit]
+scope: all-projects
+recall_when:
+  - search box fires too many requests while typing
+  - scroll handler runs too often
+  - limit how often a callback runs
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Pick debounce when you want the final value, throttle when you want a steady cadence.
+
+## Why
+They solve different problems: settle-after-quiet vs. fixed maximum frequency.
+
+## How to apply
+Debounce the input handler for a search field; throttle the scroll/resize listener.

--- a/packages/eval/fixtures/eval-vault/memories/docker-manifest-before-source.md
+++ b/packages/eval/fixtures/eval-vault/memories/docker-manifest-before-source.md
@@ -1,0 +1,29 @@
+---
+id: docker-manifest-before-source
+title: "Copy the dependency manifest before source for cache reuse"
+type: lesson
+summary: "In a Dockerfile, COPY package.json + lockfile and install deps before COPYing the rest of the source, so editing code doesn't bust the dependency layer."
+topic_path: [docker, build]
+tags: [docker, layer-cache, dockerfile, build-speed]
+scope: all-projects
+recall_when:
+  - docker reinstalls deps on every build
+  - slow image rebuilds after a code change
+  - layer cache keeps invalidating
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Order Dockerfile steps from least- to most-frequently changing.
+
+## Why
+A COPY of changed source invalidates every layer after it, including a dependency install placed below it.
+
+## How to apply
+COPY the manifest + lockfile, run install, then COPY the rest of the source.

--- a/packages/eval/fixtures/eval-vault/memories/focus-ring-keyboard.md
+++ b/packages/eval/fixtures/eval-vault/memories/focus-ring-keyboard.md
@@ -1,0 +1,29 @@
+---
+id: focus-ring-keyboard
+title: "Keep a visible focus ring for keyboard users"
+type: lesson
+summary: "Don't blanket-remove `outline`; keyboard and assistive-tech users rely on a visible focus indicator. Use `:focus-visible` to style it instead of hiding it."
+topic_path: [accessibility, ui]
+tags: [a11y, focus, keyboard, outline]
+scope: all-projects
+recall_when:
+  - removed outline and keyboard nav disappeared
+  - tab navigation has no visible indicator
+  - accessibility focus state missing
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Style focus, don't delete it; prefer `:focus-visible`.
+
+## Why
+Without a focus indicator, keyboard-only users can't tell where they are on the page.
+
+## How to apply
+Replace `outline: none` with a `:focus-visible` ring that has sufficient contrast.

--- a/packages/eval/fixtures/eval-vault/memories/git-rebase-autosquash-fixup.md
+++ b/packages/eval/fixtures/eval-vault/memories/git-rebase-autosquash-fixup.md
@@ -1,0 +1,29 @@
+---
+id: git-rebase-autosquash-fixup
+title: "Use fixup commits + autosquash for review fixes"
+type: lesson
+summary: "Address review comments with `git commit --fixup <sha>` then `git rebase -i --autosquash`, so corrections fold into the commit they belong to instead of piling up at the end."
+topic_path: [git, workflow]
+tags: [git, rebase, commits, review]
+scope: all-projects
+recall_when:
+  - cleaning up commits before merge
+  - squashing review feedback into the right commit
+  - messy history before a PR
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Make a `--fixup` commit targeting the original, then autosquash on rebase.
+
+## Why
+Review fixes that sit as separate commits make the final history hard to read and bisect.
+
+## How to apply
+`git commit --fixup <sha>` while iterating, then `git rebase -i --autosquash <base>` before merging.

--- a/packages/eval/fixtures/eval-vault/memories/money-not-float.md
+++ b/packages/eval/fixtures/eval-vault/memories/money-not-float.md
@@ -1,0 +1,29 @@
+---
+id: money-not-float
+title: "Never store money as a binary float"
+type: lesson
+summary: "Represent money as integer minor units or a decimal type; binary floating point cannot represent most decimal fractions exactly, so sums drift."
+topic_path: [data, money]
+tags: [money, decimal, float, precision]
+scope: all-projects
+recall_when:
+  - rounding errors adding prices
+  - 0.1 plus 0.2 problem in totals
+  - cents off by one in invoices
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Store amounts as integer cents or a fixed-precision decimal.
+
+## Why
+IEEE-754 doubles round most base-10 fractions, and the error accumulates across additions.
+
+## How to apply
+Use a decimal type in the DB and integer minor units in code; only convert to a display string at the edge.

--- a/packages/eval/fixtures/eval-vault/memories/postgres-index-type-mismatch.md
+++ b/packages/eval/fixtures/eval-vault/memories/postgres-index-type-mismatch.md
@@ -1,0 +1,29 @@
+---
+id: postgres-index-type-mismatch
+title: "Planner skips an index when column types don't match"
+type: lesson
+summary: "If a predicate compares a column to a value of a different type (e.g. bigint column vs numeric literal), Postgres may not use the index; align the types or cast explicitly."
+topic_path: [postgres, performance]
+tags: [postgres, index, query-planner, sql]
+scope: all-projects
+recall_when:
+  - query ignores the index I created
+  - seq scan despite an index
+  - why is my index not used
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Match the predicate's type to the indexed column's type.
+
+## Why
+A type mismatch forces a coercion that the planner cannot satisfy with the existing index, so it falls back to a scan.
+
+## How to apply
+Check `EXPLAIN`, then cast the literal/parameter to the column type (or fix the column type).

--- a/packages/eval/fixtures/eval-vault/memories/secrets-in-env.md
+++ b/packages/eval/fixtures/eval-vault/memories/secrets-in-env.md
@@ -1,0 +1,29 @@
+---
+id: secrets-in-env
+title: "Keep secrets in the environment, never commit them"
+type: lesson
+summary: "Credentials belong in environment variables or a secret manager, not in source. If one is committed, rotate it — removing the file doesn't erase it from history."
+topic_path: [security, secrets]
+tags: [secrets, env, credentials, rotation]
+scope: all-projects
+recall_when:
+  - api key accidentally pushed to git
+  - rotating a leaked token
+  - where to put credentials safely
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+Secrets live in env/secret manager; a committed secret is a compromised secret.
+
+## Why
+Git history retains the value even after deletion, so the only safe response is rotation.
+
+## How to apply
+Load from env, add the file to `.gitignore`, and rotate immediately if one leaks.

--- a/packages/eval/fixtures/eval-vault/memories/timestamps-store-utc.md
+++ b/packages/eval/fixtures/eval-vault/memories/timestamps-store-utc.md
@@ -1,0 +1,29 @@
+---
+id: timestamps-store-utc
+title: "Persist timestamps in UTC, format only on display"
+type: lesson
+summary: "Store and compute in UTC; convert to a local zone only when rendering. Storing local time loses the offset and breaks across DST and regions."
+topic_path: [time, data]
+tags: [timezone, utc, datetime, dst]
+scope: all-projects
+recall_when:
+  - times shift after deploy to another region
+  - daylight saving breaks scheduling
+  - wrong hour shown to users abroad
+related: []
+related_via: []
+sensitivity: public
+source: "synthetic eval fixture"
+confidence: 0.85
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+## Rule
+UTC at rest and in logic; local zone only at the presentation edge.
+
+## Why
+A naive local timestamp can't be compared or re-localized once the offset is gone.
+
+## How to apply
+Store `timestamptz`/epoch UTC, keep the user's zone separately, format with it on output.

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bastra-recall/eval",
-  "version": "0.6.5-beta.1",
+  "version": "0.6.6-beta.1",
   "description": "Offline ablation harness: marginal lift of the recall_when field under paraphrased held-out queries (control: stripped vs treatment: x5).",
   "private": true,
   "type": "module",
@@ -13,7 +13,7 @@
     "check:types": "tsc --noEmit"
   },
   "dependencies": {
-    "@bastra-recall/core": "0.6.5-beta.1",
+    "@bastra-recall/core": "0.6.6-beta.1",
     "minisearch": "^7.1.1"
   },
   "devDependencies": {

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@bastra-recall/eval",
+  "version": "0.6.5-beta.1",
+  "description": "Offline ablation harness: marginal lift of the recall_when field under paraphrased held-out queries (control: stripped vs treatment: x5).",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "lift": "tsx src/marginal-lift.ts",
+    "check:types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bastra-recall/core": "0.6.5-beta.1",
+    "minisearch": "^7.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.20",
+    "tsx": "^4.19.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/eval/src/index-config.ts
+++ b/packages/eval/src/index-config.ts
@@ -1,0 +1,95 @@
+import MiniSearch from "minisearch";
+import type { Memory } from "@bastra-recall/core";
+
+/**
+ * Field-weight map mirrored by hand from @bastra-recall/core `SearchIndex`
+ * (packages/core/src/search.ts -> searchOptions.boost). The ONLY knob this
+ * harness varies between control and treatment is the `recall_when` field, so
+ * the two indexes differ on exactly one dimension and nothing else. If the
+ * boosts in core ever change, update them here too — there is a guard test
+ * that fails if the two drift apart.
+ */
+export const BASE_BOOST = {
+  title: 4,
+  tags_flat: 3,
+  topic_path_flat: 2,
+  summary: 2,
+  body: 1,
+} as const;
+
+/** core's production weight for the dedicated trigger field. */
+export const TREATMENT_RECALL_WHEN_BOOST = 5;
+
+/** Search options pinned to core so the ablation is apples-to-apples. */
+const SEARCH_OPTIONS = {
+  fuzzy: 0.2,
+  prefix: true,
+  combineWith: "OR" as const,
+};
+
+interface IndexDoc {
+  id: string;
+  title: string;
+  summary: string;
+  tags_flat: string;
+  recall_when_flat: string;
+  topic_path_flat: string;
+  body: string;
+}
+
+/** Flatten a Memory into the BM25 doc, mirroring core `indexOne()`. */
+function toDoc(m: Memory): IndexDoc {
+  const fm = m.fm;
+  return {
+    id: fm.id,
+    title: fm.title,
+    summary: fm.summary,
+    tags_flat: fm.tags.join(" "),
+    recall_when_flat: fm.recall_when.join(" \n "),
+    topic_path_flat: fm.topic_path.join(" "),
+    body: m.body,
+  };
+}
+
+export type Arm =
+  | { kind: "control" } // recall_when removed from the searchable fields
+  | { kind: "treatment"; boost: number }; // recall_when indexed at `boost`
+
+/**
+ * Build a BM25 index over `memories`.
+ *
+ * - control:   `recall_when` is NOT a searchable field at all (stripped). A
+ *   query term that lives only in recall_when cannot retrieve the doc.
+ * - treatment: `recall_when` indexed and boosted at `boost` (core uses 5),
+ *   every other field weight identical to control.
+ *
+ * Stripping the field outright (rather than zero-weighting it) avoids the
+ * MiniSearch quirk where a boost of 0 still lets the doc surface at score 0.
+ */
+export function buildIndex(memories: Memory[], arm: Arm): MiniSearch<IndexDoc> {
+  const fields = ["title", "summary", "tags_flat", "topic_path_flat", "body"];
+  const boost: Record<string, number> = { ...BASE_BOOST };
+  if (arm.kind === "treatment") {
+    fields.push("recall_when_flat");
+    boost.recall_when_flat = arm.boost;
+  }
+
+  const mini = new MiniSearch<IndexDoc>({
+    fields,
+    storeFields: ["id"],
+    searchOptions: { boost, ...SEARCH_OPTIONS },
+  });
+  mini.addAll(memories.map(toDoc));
+  return mini;
+}
+
+/** 1-based rank of `goldId` in results; 0 means not found. */
+export function rankOf(results: { id: string }[], goldId: string): number {
+  const i = results.findIndex((r) => r.id === goldId);
+  return i === -1 ? 0 : i + 1;
+}
+
+/** Top-1 raw score (or 0 if nothing matched) — used by the anti-trigger slice. */
+export function topScore(results: { score: number }[]): number {
+  return results.length > 0 ? results[0].score : 0;
+}

--- a/packages/eval/src/marginal-lift.ts
+++ b/packages/eval/src/marginal-lift.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env tsx
+/**
+ * Offline ablation — marginal lift of `recall_when` (Issue #89).
+ *
+ * The M0 baseline (scripts/eval.ts) queries each memory with its OWN
+ * `recall_when` phrase. That's an upper bound, not a recall measurement: the
+ * trigger text lives in the doc, so it retrieves the doc almost by
+ * construction. It cannot answer the question a user actually cares about —
+ * *how load-bearing is the dedicated trigger field?*
+ *
+ * This harness isolates that with a controlled ablation over the SAME vault:
+ *
+ *   - control   : `recall_when` stripped from the searchable fields
+ *   - treatment : `recall_when` indexed at its production weight (core: x5)
+ *
+ * Every other field weight + search option is pinned to core (see
+ * index-config.ts), so the two arms differ on exactly one dimension. Queries
+ * are PARAPHRASES of each memory's trigger — held out, ideally sharing zero
+ * literal tokens — simulating how a future session phrases the situation in
+ * its own words rather than the author's.
+ *
+ *   marginal-lift@k = Recall@k(treatment) - Recall@k(control)
+ *
+ * A no-trigger ("anti") slice bounds false-positive surfacing: queries with no
+ * relevant memory should NOT score high, and adding the trigger field must not
+ * inflate that.
+ *
+ * IMPORTANT — read before citing a number:
+ *   The bundled `fixtures/eval-vault` is a tiny SYNTHETIC vault. Its purpose is
+ *   to make the harness self-contained and CI-runnable, NOT to be the headline
+ *   result. A real, citable marginal-lift number comes from pointing this at a
+ *   real vault with hand-written paraphrases:
+ *     BASTRA_VAULT_PATH=/path/to/vault npm run lift -- --cases my-cases.json
+ *
+ * Usage:
+ *   npm run lift                          # bundled synthetic vault + cases
+ *   npm run lift -- --boost 5 --k 3       # tune the treatment weight / @k
+ *   BASTRA_VAULT_PATH=/v npm run lift -- --cases cases.json --out lift.json
+ *
+ * Exit code: 0 always (this is a measurement, not a pass/fail gate).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Vault } from "@bastra-recall/core";
+import type { Memory } from "@bastra-recall/core";
+import {
+  buildIndex,
+  rankOf,
+  topScore,
+  TREATMENT_RECALL_WHEN_BOOST,
+} from "./index-config.js";
+
+// ── Case fixtures ──────────────────────────────────────────────
+
+interface ParaphrasedCase {
+  /** Existing memory id in the vault (the gold target). */
+  id: string;
+  /** Short handle for the report. */
+  label: string;
+  /** Paraphrases of the memory's recall_when trigger (held-out queries). */
+  paraphrases: string[];
+}
+
+interface AntiCase {
+  /** Off-vault query — no memory should genuinely match. */
+  query: string;
+  note?: string;
+}
+
+interface CaseFile {
+  paraphrased: ParaphrasedCase[];
+  anti: AntiCase[];
+}
+
+// ── CLI ────────────────────────────────────────────────────────
+
+interface Args {
+  vault: string;
+  cases: string;
+  out: string | null;
+  boost: number;
+  k: number;
+}
+
+const DEFAULT_VAULT = resolve(import.meta.dirname, "../fixtures/eval-vault");
+const DEFAULT_CASES = resolve(import.meta.dirname, "../fixtures/cases.json");
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    vault: process.env.BASTRA_VAULT_PATH ?? DEFAULT_VAULT,
+    cases: DEFAULT_CASES,
+    out: null,
+    boost: TREATMENT_RECALL_WHEN_BOOST,
+    k: 3,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--vault") {
+      args.vault = req(argv[++i], "--vault");
+    } else if (a === "--cases") {
+      args.cases = req(argv[++i], "--cases");
+    } else if (a === "--out") {
+      args.out = req(argv[++i], "--out");
+    } else if (a === "--boost") {
+      args.boost = num(argv[++i], "--boost");
+    } else if (a === "--k") {
+      args.k = num(argv[++i], "--k");
+    } else if (a === "-h" || a === "--help") {
+      console.log(
+        "marginal-lift — recall_when ablation\n" +
+          "  --vault <path>  vault to index (or BASTRA_VAULT_PATH)\n" +
+          "  --cases <path>  paraphrased + anti cases JSON\n" +
+          "  --boost <n>     treatment recall_when weight (default 5)\n" +
+          "  --k <n>         Recall@k (default 3)\n" +
+          "  --out <path>    also write a JSON report",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`unknown flag: ${a}`);
+    }
+  }
+  return args;
+}
+
+function req(v: string | undefined, flag: string): string {
+  if (!v) throw new Error(`${flag} needs a value`);
+  return v;
+}
+
+function num(v: string | undefined, flag: string): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) throw new Error(`${flag} must be a number`);
+  return n;
+}
+
+// ── Metrics ────────────────────────────────────────────────────
+
+interface ArmStats {
+  queries: number;
+  recallAt1: number;
+  recallAtK: number;
+  mrr: number;
+}
+
+interface PerArmRun {
+  hit1: number;
+  hitK: number;
+  reciprocalRankSum: number;
+  total: number;
+}
+
+function emptyRun(): PerArmRun {
+  return { hit1: 0, hitK: 0, reciprocalRankSum: 0, total: 0 };
+}
+
+function record(run: PerArmRun, rank: number, k: number): void {
+  run.total++;
+  if (rank === 1) run.hit1++;
+  if (rank >= 1 && rank <= k) run.hitK++;
+  if (rank > 0) run.reciprocalRankSum += 1 / rank;
+}
+
+function finalize(run: PerArmRun): ArmStats {
+  const n = run.total || 1;
+  return {
+    queries: run.total,
+    recallAt1: run.hit1 / n,
+    recallAtK: run.hitK / n,
+    mrr: run.reciprocalRankSum / n,
+  };
+}
+
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}
+
+// ── Main ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const caseFile = JSON.parse(readFileSync(args.cases, "utf8")) as CaseFile;
+
+  const vault = new Vault(args.vault);
+  const { loaded, skipped } = await vault.init();
+  if (skipped.length) {
+    for (const s of skipped) console.error(`  skipped ${s.path}: ${s.err}`);
+  }
+  const memories: Memory[] = vault.list().filter((m) => !m.fm.obsolete);
+  const known = new Set(memories.map((m) => m.fm.id));
+
+  const control = buildIndex(memories, { kind: "control" });
+  const treatment = buildIndex(memories, { kind: "treatment", boost: args.boost });
+
+  // ── paraphrased slice ──
+  const controlRun = emptyRun();
+  const treatmentRun = emptyRun();
+  const rescued: { id: string; query: string; ctrlRank: number; treatRank: number }[] = [];
+  const unknownIds: string[] = [];
+
+  for (const c of caseFile.paraphrased) {
+    if (!known.has(c.id)) {
+      unknownIds.push(c.id);
+      continue;
+    }
+    for (const q of c.paraphrases) {
+      const cRank = rankOf(control.search(q), c.id);
+      const tRank = rankOf(treatment.search(q), c.id);
+      record(controlRun, cRank, args.k);
+      record(treatmentRun, tRank, args.k);
+      // "rescued" = buried/missed by control, pulled into top-k by treatment.
+      const ctrlBuried = cRank === 0 || cRank > args.k;
+      const treatHit = tRank >= 1 && tRank <= args.k;
+      if (ctrlBuried && treatHit) {
+        rescued.push({ id: c.id, query: q, ctrlRank: cRank, treatRank: tRank });
+      }
+    }
+  }
+
+  const ctrl = finalize(controlRun);
+  const treat = finalize(treatmentRun);
+  const lift1 = treat.recallAt1 - ctrl.recallAt1;
+  const liftK = treat.recallAtK - ctrl.recallAtK;
+
+  // ── anti-trigger slice (false-positive band) ──
+  const antiControl: number[] = [];
+  const antiTreatment: number[] = [];
+  for (const a of caseFile.anti) {
+    antiControl.push(topScore(control.search(a.query)));
+    antiTreatment.push(topScore(treatment.search(a.query)));
+  }
+  const antiCtrlMed = median(antiControl);
+  const antiTreatMed = median(antiTreatment);
+
+  // ── report ──
+  const lines: string[] = [];
+  lines.push("# recall_when — Marginal-Lift Ablation\n");
+  lines.push(
+    `Vault: **${loaded}** memorys  ·  paraphrased queries: **${treat.queries}**  ·  ` +
+      `treatment boost: **x${args.boost}**  ·  k = **${args.k}**\n`,
+  );
+  lines.push("## Recall (paraphrased held-out queries)\n");
+  lines.push("| metric | control (stripped) | treatment (x" + args.boost + ") | marginal lift |");
+  lines.push("|---|---|---|---|");
+  lines.push(
+    `| Recall@1 | ${pct(ctrl.recallAt1)} | ${pct(treat.recallAt1)} | **${signed(lift1)}** |`,
+  );
+  lines.push(
+    `| Recall@${args.k} | ${pct(ctrl.recallAtK)} | ${pct(treat.recallAtK)} | **${signed(liftK)}** |`,
+  );
+  lines.push(`| MRR | ${ctrl.mrr.toFixed(3)} | ${treat.mrr.toFixed(3)} | ${signedRaw(treat.mrr - ctrl.mrr)} |`);
+  lines.push("");
+  lines.push(
+    `**marginal-lift@${args.k} = ${signed(liftK)}** ` +
+      `(${rescued.length}/${treat.queries} queries rescued from outside top-${args.k})\n`,
+  );
+
+  lines.push("## False-positive band (no-trigger control)\n");
+  lines.push(
+    `Median top-1 score on ${caseFile.anti.length} off-vault queries — ` +
+      `control: **${antiCtrlMed.toFixed(1)}**, treatment: **${antiTreatMed.toFixed(1)}**. ` +
+      `Adding the trigger field ${antiTreatMed > antiCtrlMed + 1 ? "RAISES" : "does not raise"} ` +
+      `false-positive surfacing.\n`,
+  );
+
+  if (rescued.length > 0) {
+    lines.push(`## Rescued by recall_when (top ${Math.min(rescued.length, 15)})\n`);
+    lines.push("| gold id | paraphrase | control rank | treatment rank |");
+    lines.push("|---|---|---|---|");
+    for (const r of rescued.slice(0, 15)) {
+      lines.push(`| ${r.id} | ${trunc(r.query, 48)} | ${r.ctrlRank || "miss"} | ${r.treatRank} |`);
+    }
+    lines.push("");
+  }
+
+  if (unknownIds.length > 0) {
+    lines.push(
+      `> ⚠️ ${unknownIds.length} case id(s) not in vault (skipped): ${unknownIds.join(", ")}\n`,
+    );
+  }
+
+  const report = lines.join("\n");
+  console.log(report);
+
+  if (args.out) {
+    const json = {
+      vault: args.vault,
+      vaultSize: loaded,
+      boost: args.boost,
+      k: args.k,
+      control: ctrl,
+      treatment: treat,
+      marginalLiftAt1: lift1,
+      marginalLiftAtK: liftK,
+      rescued: rescued.length,
+      antiFalsePositive: { controlMedian: antiCtrlMed, treatmentMedian: antiTreatMed },
+      unknownIds,
+    };
+    writeFileSync(args.out, JSON.stringify(json, null, 2));
+    console.error(`\n[lift] JSON written to ${args.out}`);
+  }
+}
+
+function signed(x: number): string {
+  return `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)} pp`;
+}
+
+function signedRaw(x: number): string {
+  return `${x >= 0 ? "+" : ""}${x.toFixed(3)}`;
+}
+
+function trunc(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/eval/tsconfig.json
+++ b/packages/eval/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "rootDir": "./src",
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Closes the offline half of #89.

This adds `@bastra-recall/eval` — a controlled ablation that isolates the
**marginal lift** of the `recall_when` field, the number the own-trigger M0
baseline can't give (the trigger lives in the doc, so M0 is an upper bound by
construction).

### What it does

Two BM25 indexes over the **same** vault, differing on exactly one dimension:

| arm | `recall_when` |
|---|---|
| control | stripped from the searchable fields |
| treatment | indexed at its production weight (core `×5`) |

Every other field weight + search option is pinned to `core/src/search.ts`, with
a drift-guard test that fails if they diverge. Queries are **paraphrases** of
each memory's trigger (held out, minimal literal overlap), so it measures recall
when a future session uses its own words. A no-trigger **anti** slice bounds
false-positive surfacing.

```
marginal-lift@k = Recall@k(treatment) − Recall@k(control)
```

### Addressing the asks from the issue thread

- **Self-contained + own license/header.** New `packages/eval/` workspace, its
  own MIT `LICENSE`, independently authored here — no code lifted from
  `weighted-compact`, only the methodology (which was already laid out in #89).
- **control / treatment as configs over the same vault** — exactly the shape
  described; `recall_when` stripped vs intact at `×5`, paraphrased held-out
  queries, plus the no-trigger control set.
- **`marginal-lift` line that reads alongside the USE-rate (#69).** Emitted as a
  headline line; `--out` also writes a JSON report for pairing with online
  numbers.

### On the number

The bundled `fixtures/eval-vault` is a tiny **synthetic** 10-memory vault. On it
the harness reports Recall@3 83.3% → 96.7% (**marginal-lift@3 = +13.3 pp**,
4/30 paraphrases rescued from outside top-3), and the anti slice shows the
trigger field does **not** inflate false positives (median top-1 2.5 → 2.7).

That figure exists to prove the harness *computes correctly* and to give CI
something to run — **it is not a headline result**. A citable number comes from
pointing it at a real vault:

```bash
BASTRA_VAULT_PATH=/path/to/vault npm run lift -- --cases my-cases.json --out lift.json
```

I deliberately did not tune the synthetic vault to manufacture lift; reporting a
near-zero result would be a valid outcome of the same harness. The point is a
number you can *cite* instead of assert — including, honestly, if `×5` turns out
closer to decorative than load-bearing on the real vault.

### Verify

```bash
npm install
npm run build --workspace=@bastra-recall/core
npm run eval:lift
node --import tsx --test packages/eval/__tests__/*.test.ts
```
