### PR TITLE
fix(security): path-traversal guards, DNS-rebinding gate, timing-safe auth

### DIFF
--- a/packages/core/__tests__/path-safety.test.ts
+++ b/packages/core/__tests__/path-safety.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Path-Traversal-Guards: id und scope werden zu Pfad-Komponenten
+ * (`<id>.md`, `memories/projects/<scope>/`, `.bastra/trash/<id>.md`).
+ * Crafted Input (`../../x`) darf weder beim Save noch beim Soft-Delete
+ * aus dem Vault klettern.
+ *
+ * Runner: `tsx --test __tests__/path-safety.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isPathSafeComponent } from "../src/schema.js";
+import { SaveMemoryInput, saveMemory } from "../src/save.js";
+import { trashPathFor } from "../src/audit-log.js";
+
+const VALID_INPUT = {
+  title: "Path safety probe",
+  type: "lesson",
+  summary: "probe",
+  body: "probe body",
+  topic_path: ["test"],
+  tags: ["test"],
+  scope: "test-scope",
+  recall_when: ["never"],
+};
+
+// ── isPathSafeComponent ──────────────────────────────────────────────
+test("isPathSafeComponent: rejects separators, dotdot, NUL, leading dot", () => {
+  assert.equal(isPathSafeComponent("normal-id-123"), true);
+  assert.equal(isPathSafeComponent("under_score"), true);
+  assert.equal(isPathSafeComponent("../evil"), false);
+  assert.equal(isPathSafeComponent("a/b"), false);
+  assert.equal(isPathSafeComponent("a\\b"), false);
+  assert.equal(isPathSafeComponent("a..b"), false);
+  assert.equal(isPathSafeComponent(".hidden"), false);
+  assert.equal(isPathSafeComponent("a\0b"), false);
+});
+
+// ── SaveMemoryInput: Zod-Schicht ─────────────────────────────────────
+test("SaveMemoryInput: rejects traversal in id and scope", () => {
+  assert.equal(SaveMemoryInput.safeParse(VALID_INPUT).success, true);
+  assert.equal(
+    SaveMemoryInput.safeParse({ ...VALID_INPUT, id: "../../evil" }).success,
+    false,
+  );
+  assert.equal(
+    SaveMemoryInput.safeParse({ ...VALID_INPUT, scope: "../../../tmp" }).success,
+    false,
+  );
+});
+
+// ── saveMemory: Containment-Guard (auch ohne Zod-Parse) ──────────────
+test("saveMemory: refuses to write outside the vault even when the schema is bypassed", async () => {
+  const vault = await mkdtemp(join(tmpdir(), "bastra-path-safety-"));
+  try {
+    // Genug `..`-Stufen, um aus `memories/projects/<scope>/` (3 Ebenen) über
+    // den Vault-Root hinaus zu klettern.
+    await assert.rejects(
+      saveMemory(vault, {
+        ...VALID_INPUT,
+        id: "../../../../evil",
+      } as unknown as SaveMemoryInput),
+      /outside the vault/,
+    );
+    // Nichts wurde angelegt — auch nicht eine Ebene über dem Vault.
+    await assert.rejects(access(join(vault, "..", "evil.md")));
+  } finally {
+    await rm(vault, { recursive: true, force: true });
+  }
+});
+
+// ── trashPathFor: Soft-Delete-Pfad ───────────────────────────────────
+test("trashPathFor: stays inside the trash folder, throws on traversal ids", () => {
+  const dest = trashPathFor("/vault", "good-id");
+  assert.equal(dest, join("/vault", ".bastra", "trash", "good-id.md"));
+  assert.throws(() => trashPathFor("/vault", "../../etc/cron"), /trash folder/);
+});

--- a/packages/core/src/audit-log.ts
+++ b/packages/core/src/audit-log.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, appendFile, rename, access } from "node:fs/promises";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve, sep } from "node:path";
 
 /**
  * Audit-Log: jede Memory-Mutation wird als JSON-Zeile in
@@ -165,7 +165,14 @@ async function fileExists(p: string): Promise<boolean> {
 const TRASH_DIR = "trash";
 
 export function trashPathFor(vaultRoot: string, id: string): string {
-  return join(vaultRoot, AUDIT_DIR, TRASH_DIR, `${id}.md`);
+  const trashRoot = join(vaultRoot, AUDIT_DIR, TRASH_DIR);
+  const dest = join(trashRoot, `${id}.md`);
+  // The id comes from file frontmatter — a crafted `id: ../../x` must not
+  // turn the soft-delete rename into a write outside the trash folder.
+  if (!resolve(dest).startsWith(resolve(trashRoot) + sep)) {
+    throw new Error(`refusing trash path outside the trash folder for id: ${id}`);
+  }
+  return dest;
 }
 
 export async function moveToTrash(

--- a/packages/core/src/embed-cache.ts
+++ b/packages/core/src/embed-cache.ts
@@ -101,7 +101,10 @@ export class EmbedCache {
     };
     try {
       await fs.mkdir(path.dirname(this.cachePath), { recursive: true });
-      await fs.writeFile(this.cachePath, JSON.stringify(data));
+      // tmp + rename — kein Torn-Write bei Prozess-Kill mitten im Save.
+      const tmp = `${this.cachePath}.tmp-${process.pid}`;
+      await fs.writeFile(tmp, JSON.stringify(data));
+      await fs.rename(tmp, this.cachePath);
     } catch (err) {
       console.error("[bastra.embeddings] embed-cache persist error:", err);
     }

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -44,12 +44,6 @@ function backpressureStallMs(): number {
   return Math.max(0, Number(process.env.BASTRA_EMBED_BACKPRESSURE_STALL_MS ?? "100"));
 }
 
-/** Polling-Interval für den Semaphore. */
-const SEMAPHORE_POLL_MS = Math.max(
-  1,
-  Number(process.env.BASTRA_EMBED_SEMAPHORE_POLL_MS ?? "50"),
-);
-
 // ─── Provider Interface ──────────────────────────────────────────
 
 export interface EmbeddingProvider {
@@ -349,7 +343,11 @@ export class EmbeddingIndex {
     };
     try {
       await fs.mkdir(path.dirname(this.persistPath), { recursive: true });
-      await fs.writeFile(this.persistPath, JSON.stringify(data));
+      // tmp + rename: ein Kill mitten im Write darf keine angerissene (aber
+      // JSON-valide) Datei hinterlassen, die beim Load Vectors verliert.
+      const tmp = `${this.persistPath}.tmp-${process.pid}`;
+      await fs.writeFile(tmp, JSON.stringify(data));
+      await fs.rename(tmp, this.persistPath);
     } catch (err) {
       console.error("[bastra.embeddings] persist error:", err);
     }
@@ -410,11 +408,16 @@ export class EmbeddingIndex {
   private async flushQueue(): Promise<void> {
     if (this.processing) return;
     this.processing = true;
+    // Laufende Provider-Calls. Batches werden NICHT inline awaited — sonst
+    // wäre der Semaphore toter Code und alles liefe strikt seriell (genau so
+    // war der Bug: inFlight konnte nie über 1 steigen).
+    const inFlightBatches = new Set<Promise<void>>();
+    let aborted = false;
     try {
-      while (this.pendingQueue.size > 0) {
+      while (!aborted && this.pendingQueue.size > 0) {
         // Semaphore: warte bis ein In-Flight-Slot frei wird.
         while (this.inFlight >= MAX_CONCURRENT_BATCHES) {
-          await new Promise<void>((r) => setTimeout(r, SEMAPHORE_POLL_MS));
+          await Promise.race(inFlightBatches);
         }
         const batch = Array.from(this.pendingQueue).slice(0, 50);
         for (const id of batch) this.pendingQueue.delete(id);
@@ -456,33 +459,39 @@ export class EmbeddingIndex {
 
         const texts = toEmbed.map(({ m }) => buildEmbedText(m));
         this.inFlight++;
-        try {
-          const vectors = await this.provider.embed(texts);
-          for (let i = 0; i < toEmbed.length; i++) {
-            this.vectors.set(toEmbed[i].id, vectors[i]);
-            this.cache.set(toEmbed[i].id, toEmbed[i].hash);
-          }
-          this.schedulePersist();
-          void this.cache.save();
-          for (const { id } of toEmbed) {
-            for (const listener of this.embedListeners) {
-              try {
-                listener(id);
-              } catch (err) {
-                console.error("[bastra.embeddings] embed listener error:", err);
+        const batchPromise = (async () => {
+          try {
+            const vectors = await this.provider.embed(texts);
+            for (let i = 0; i < toEmbed.length; i++) {
+              this.vectors.set(toEmbed[i].id, vectors[i]);
+              this.cache.set(toEmbed[i].id, toEmbed[i].hash);
+            }
+            this.schedulePersist();
+            void this.cache.save();
+            for (const { id } of toEmbed) {
+              for (const listener of this.embedListeners) {
+                try {
+                  listener(id);
+                } catch (err) {
+                  console.error("[bastra.embeddings] embed listener error:", err);
+                }
               }
             }
+          } catch (err) {
+            console.error("[bastra.embeddings] batch error, requeue:", err);
+            // Bei Fehler: Items zurück in queue für Retry beim nächsten
+            // Add-Event oder Restart; keine neuen Batches mehr starten,
+            // um einen Retry-Storm zu vermeiden.
+            for (const { id } of toEmbed) this.pendingQueue.add(id);
+            aborted = true;
+          } finally {
+            this.inFlight--;
           }
-        } catch (err) {
-          console.error("[bastra.embeddings] batch error, requeue:", err);
-          // Bei Fehler: Items zurück in queue für Retry beim nächsten Add-Event
-          // oder Restart. Wir brechen den loop ab um Retry-Storm zu vermeiden.
-          for (const { id } of toEmbed) this.pendingQueue.add(id);
-          break;
-        } finally {
-          this.inFlight--;
-        }
+        })();
+        inFlightBatches.add(batchPromise);
+        void batchPromise.then(() => inFlightBatches.delete(batchPromise));
       }
+      await Promise.all(inFlightBatches);
     } finally {
       this.processing = false;
     }

--- a/packages/core/src/save.ts
+++ b/packages/core/src/save.ts
@@ -1,8 +1,8 @@
 import { writeFile, access, mkdir, unlink } from "node:fs/promises";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve, sep } from "node:path";
 import { z } from "zod";
 import matter from "gray-matter";
-import { MemoryTypeEnum } from "./schema.js";
+import { MemoryTypeEnum, isPathSafeComponent } from "./schema.js";
 import { clampSummary, SUMMARY_MAX } from "./summary.js";
 
 /**
@@ -21,7 +21,11 @@ export const SaveMemoryInput = z.object({
   body: z.string().min(1),
   topic_path: z.array(z.string().min(1)).min(1),
   tags: z.array(z.string().min(1)).min(1),
-  scope: z.string().min(1),
+  // scope becomes a directory segment (`memories/projects/<scope>/`) — reject
+  // anything that could climb out of the vault.
+  scope: z.string().min(1).refine(isPathSafeComponent, {
+    message: "scope must not contain path separators, '..', or a leading dot",
+  }),
   recall_when: z.array(z.string().min(1)).min(1),
   related: z.array(z.string()).optional(),
   /**
@@ -64,7 +68,11 @@ export const SaveMemoryInput = z.object({
   confidence: z.number().min(0).max(1).optional(),
   affects_files: z.array(z.string()).optional(),
   issues: z.array(z.string()).optional(),
-  id: z.string().optional(),
+  // id becomes the filename (`<id>.md`) — same path-safety bar as scope.
+  // slugify() output always passes; only explicit caller-set ids can violate.
+  id: z.string().min(1).refine(isPathSafeComponent, {
+    message: "id must not contain path separators, '..', or a leading dot",
+  }).optional(),
   overwrite: z.boolean().optional(),
   // Bookmark-only fields
   url: z.string().optional(),
@@ -218,6 +226,12 @@ export async function saveMemory(
   const subdir = subfolderFor(input.scope, input.type);
   const dir = join(vaultRoot, subdir);
   const filePath = join(dir, `${id}.md`);
+  // Belt-and-suspenders against path escape: id/scope are schema-validated as
+  // path-safe, but every join of caller input into a path re-checks here —
+  // callers that bypass SaveMemoryInput.parse() are covered too.
+  if (!resolve(filePath).startsWith(resolve(vaultRoot) + sep)) {
+    throw new Error(`refusing to write outside the vault: ${filePath}`);
+  }
   const exists = await fileExists(filePath);
   if (exists && !input.overwrite) {
     throw new Error(

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -38,8 +38,28 @@ export class NotAMemoryFile extends Error {
   }
 }
 
+/**
+ * Path-safety guard for values that end up as path components (`<id>.md`,
+ * `memories/projects/<scope>/`, `.bastra/trash/<id>.md`). Deliberately loose:
+ * it rejects only what can escape the vault (separators, `..`, NUL, leading
+ * dot) — not unusual-but-harmless ids, so pre-existing vault files keep
+ * loading instead of silently dropping out of the index.
+ */
+export function isPathSafeComponent(value: string): boolean {
+  return (
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    !value.includes("..") &&
+    !value.includes("\0") &&
+    !value.startsWith(".")
+  );
+}
+
+const pathSafeMessage =
+  "must not contain path separators, '..', or a leading dot";
+
 export const FrontmatterSchema = z.object({
-  id: z.string().min(1),
+  id: z.string().min(1).refine(isPathSafeComponent, { message: pathSafeMessage }),
   title: z.string().min(1),
   type: MemoryTypeEnum,
   // Truncate instead of reject on load: a pre-existing vault file with a

--- a/packages/daemon/__tests__/http-auth-gate.test.ts
+++ b/packages/daemon/__tests__/http-auth-gate.test.ts
@@ -11,7 +11,7 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveCorsOrigin, gateApiRequest } from "../src/http.js";
+import { resolveCorsOrigin, gateApiRequest, safeEqual, isLoopbackHost } from "../src/http.js";
 
 const SITE = "https://bastra.io";
 const TOKEN = "secret-token";
@@ -120,4 +120,29 @@ test("gate: browser, allowed origin but NO token issued → 401 (secure by defau
     }),
     401,
   );
+});
+
+// ── safeEqual: timing-safe Token-Vergleich ───────────────────────────
+test("safeEqual: equal true; different content or length false", () => {
+  assert.equal(safeEqual(`Bearer ${TOKEN}`, `Bearer ${TOKEN}`), true);
+  assert.equal(safeEqual("Bearer secret-tokeX", `Bearer ${TOKEN}`), false);
+  assert.equal(safeEqual("", `Bearer ${TOKEN}`), false);
+});
+
+// ── isLoopbackHost: DNS-Rebinding-Gate für token-lose Endpoints ──────
+test("isLoopbackHost: loopback hosts pass, rebound domains do not", () => {
+  assert.equal(isLoopbackHost("127.0.0.1:6723", []), true);
+  assert.equal(isLoopbackHost("localhost:6723", []), true);
+  assert.equal(isLoopbackHost("LOCALHOST", []), true);
+  assert.equal(isLoopbackHost("[::1]:6723", []), true);
+  // HTTP/1.0-CLIs ohne Host-Header — Rebinding trägt immer einen.
+  assert.equal(isLoopbackHost(undefined, []), true);
+  assert.equal(isLoopbackHost("attacker.example:6723", []), false);
+  assert.equal(isLoopbackHost("attacker.example", []), false);
+});
+
+test("isLoopbackHost: BASTRA_ALLOWED_HOSTS entries pass (tunnel escape hatch)", () => {
+  assert.equal(isLoopbackHost("tunnel.example.com", ["tunnel.example.com"]), true);
+  assert.equal(isLoopbackHost("tunnel.example.com:443", ["tunnel.example.com"]), true);
+  assert.equal(isLoopbackHost("other.example.com", ["tunnel.example.com"]), false);
 });

--- a/packages/daemon/src/cli/ollama.ts
+++ b/packages/daemon/src/cli/ollama.ts
@@ -41,23 +41,24 @@ export async function ensureOllama(opts: { dryRun: boolean; mode: "auto" | "skip
     if (opts.mode === "skip") {
       return { status: "skipped", activated: false, message: "skipped (--no-ollama) — semantic recall uses BM25 keyword search" };
     }
-    if (process.platform !== "darwin") {
-      return {
-        status: "unsupported",
-        activated: false,
-        message:
-          "automatic Ollama setup is macOS-only today (Windows: #84). Manual: install Ollama, then `bastra config set embedding.provider ollama`",
-      };
-    }
-
     // env wins over the file at runtime — don't burn a 600 MB download on a
-    // choice the daemon will shadow.
+    // choice the daemon will shadow. Checked before the platform gate: the
+    // explicit user override outranks "unsupported here" on every OS.
     const envProvider = (process.env.BASTRA_EMBEDDING_PROVIDER ?? "").toLowerCase();
     if (envProvider && envProvider !== "ollama") {
       return {
         status: "env-override",
         activated: false,
         message: `BASTRA_EMBEDDING_PROVIDER=${envProvider} (env) overrides the config file — not setting up Ollama. Unset it (or set it to ollama) first.`,
+      };
+    }
+
+    if (process.platform !== "darwin") {
+      return {
+        status: "unsupported",
+        activated: false,
+        message:
+          "automatic Ollama setup is macOS-only today (Windows: #84). Manual: install Ollama, then `bastra config set embedding.provider ollama`",
       };
     }
 

--- a/packages/daemon/src/documents-write-handler.ts
+++ b/packages/daemon/src/documents-write-handler.ts
@@ -15,7 +15,7 @@
  *   Triage-Acceptance: erfüllt.
  */
 import { writeFile, mkdir, copyFile, unlink, stat, rename, access } from "node:fs/promises";
-import { join, basename, isAbsolute } from "node:path";
+import { join, basename, isAbsolute, resolve, sep } from "node:path";
 import { z } from "zod";
 import matter from "gray-matter";
 import type { Vault } from "@bastra-recall/core";
@@ -218,6 +218,30 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
+/**
+ * Join a caller-supplied folder_path under the documents root and verify the
+ * result stays inside it. folder_path is legitimately multi-segment
+ * ("Rechnungen/2026"), so we can't ban separators — but `..` segments survive
+ * join() unharmed, so a containment check is the only reliable gate against
+ * mkdir/copyFile/rename landing outside the vault.
+ */
+function resolveDocsFolder(docsRoot: string, folderPath: string): string {
+  const folder = folderPath ? join(docsRoot, folderPath) : docsRoot;
+  const docsAbs = resolve(docsRoot);
+  const folderAbs = resolve(folder);
+  if (folderAbs !== docsAbs && !folderAbs.startsWith(docsAbs + sep)) {
+    throw new Error(`folder_path escapes the documents folder: ${folderPath}`);
+  }
+  return folder;
+}
+
+/** write-to-tmp + rename, so a crash mid-write never leaves a torn sidecar. */
+async function atomicWriteFile(path: string, content: string): Promise<void> {
+  const tmp = `${path}.tmp-${process.pid}`;
+  await writeFile(tmp, content, "utf8");
+  await rename(tmp, path);
+}
+
 interface DocumentFrontmatter {
   id: string;
   title: string;
@@ -303,9 +327,7 @@ export async function saveDocument(
 
   const root = vaultRoot(vault);
   const docsRoot = join(root, DOCUMENTS_ROOT);
-  const folder = args.folder_path
-    ? join(docsRoot, args.folder_path)
-    : docsRoot;
+  const folder = resolveDocsFolder(docsRoot, args.folder_path);
   await mkdir(folder, { recursive: true });
 
   const filename = basename(args.original_path);
@@ -354,7 +376,7 @@ export async function saveDocument(
     ? `> Sidecar für \`${originalDest}\`.\n\n## Extrahierter Inhalt\n\n${args.body}`
     : `> Sidecar für \`${originalDest}\`.\n\n_(Kein extrahierter Inhalt — vom Caller nicht mitgeliefert.)_`;
 
-  await writeFile(sidecarPath, renderSidecar(fm, body), "utf8");
+  await atomicWriteFile(sidecarPath, renderSidecar(fm, body));
 
   // Cloud-Watcher-Mitigation: synchroner reindex statt auf chokidar warten.
   await vault.reindexFile(sidecarPath);
@@ -440,7 +462,7 @@ export async function recategorizeDocument(
     updated: todayISO(),
   });
 
-  await writeFile(sidecarPath, renderSidecar(updated, m.body), "utf8");
+  await atomicWriteFile(sidecarPath, renderSidecar(updated, m.body));
   await vault.reindexFile(sidecarPath);
 
   return { id: m.fm.id, sidecar_path: sidecarPath, reindexed: true };
@@ -484,7 +506,7 @@ export async function moveDocument(
     created: m.fm.created,
     updated: todayISO(),
   });
-  await writeFile(moved.newSidecarPath, renderSidecar(updated, m.body), "utf8");
+  await atomicWriteFile(moved.newSidecarPath, renderSidecar(updated, m.body));
   await vault.reindexFile(moved.newSidecarPath);
 
   return {
@@ -507,9 +529,7 @@ async function moveDocumentFiles(
 ): Promise<{ newSidecarPath: string; newOriginalPath: string }> {
   const root = vaultRoot(vault);
   const docsRoot = join(root, DOCUMENTS_ROOT);
-  const targetFolder = args.newFolderPath
-    ? join(docsRoot, args.newFolderPath)
-    : docsRoot;
+  const targetFolder = resolveDocsFolder(docsRoot, args.newFolderPath);
   await mkdir(targetFolder, { recursive: true });
 
   const sidecarFilename = basename(args.sidecarPath);

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -41,7 +41,7 @@
  *     auf konkrete Origin einschränken.
  */
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
-import { createHash, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import type { Vault, SearchIndex, RecallStage, StageListener } from "@bastra-recall/core";
 import { fireAndForget, type Telemetry } from "./telemetry.js";
@@ -109,14 +109,15 @@ function isLoopback(req: IncomingMessage): boolean {
 }
 
 /**
- * Constant-time string equality for the Bearer-token check. Hashing first
- * equalizes the lengths, so the comparison leaks neither content nor length
- * of the expected token. Exported for unit tests.
+ * Constant-time string equality for the Bearer-token check. The early return
+ * on length mismatch leaks only the length — not secret here, the token has
+ * a fixed format (`Bearer ` + 43-char base64url). Exported for unit tests.
  */
 export function safeEqual(a: string, b: string): boolean {
-  const ha = createHash("sha256").update(a).digest();
-  const hb = createHash("sha256").update(b).digest();
-  return timingSafeEqual(ha, hb);
+  const ba = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
 }
 
 /**

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -41,6 +41,7 @@
  *     auf konkrete Origin einschränken.
  */
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import type { Vault, SearchIndex, RecallStage, StageListener } from "@bastra-recall/core";
 import { fireAndForget, type Telemetry } from "./telemetry.js";
@@ -108,6 +109,40 @@ function isLoopback(req: IncomingMessage): boolean {
 }
 
 /**
+ * Constant-time string equality for the Bearer-token check. Hashing first
+ * equalizes the lengths, so the comparison leaks neither content nor length
+ * of the expected token. Exported for unit tests.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  const ha = createHash("sha256").update(a).digest();
+  const hb = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+/**
+ * DNS-Rebinding-Gate für die token-losen Loopback-Endpoints (/hook/recall,
+ * /vault/count, /health): ein Browser, der eine Angreifer-Domain auf
+ * 127.0.0.1 umbiegt, schickt deren Hostname im Host-Header — aus Browser-
+ * Sicht ist der Request dann same-origin, CORS greift nicht. Nur loopback-
+ * Hosts werden bedient; BASTRA_ALLOWED_HOSTS (Komma-Liste) ist der Escape-
+ * Hatch für Tunnel-Setups, die mehr als /api/v1/* exposen wollen. Fehlender
+ * Host-Header (HTTP/1.0-CLIs) passiert — Rebinding trägt immer einen.
+ * Exported for unit tests.
+ */
+export function isLoopbackHost(
+  hostHeader: string | undefined,
+  extraHosts: readonly string[],
+): boolean {
+  if (!hostHeader) return true;
+  const lower = hostHeader.toLowerCase();
+  const host = lower.replace(/:\d+$/, "");
+  if (host === "localhost" || host === "127.0.0.1" || host === "[::1]") {
+    return true;
+  }
+  return extraHosts.includes(host) || extraHosts.includes(lower);
+}
+
+/**
  * Which Origin to reflect in `Access-Control-Allow-Origin`. `null` = the origin
  * isn't allowed → emit no ACAO header and the browser blocks the response. "*"
  * in the allowlist is permissive (tunnel/dev): reflect the caller's origin, or
@@ -142,11 +177,11 @@ export function gateApiRequest(p: {
   const isBrowser = typeof p.reqOrigin === "string" && p.reqOrigin.length > 0;
   if (isBrowser) {
     if (!p.allowedOrigin) return 403;
-    if (!p.apiToken || p.authHeader !== `Bearer ${p.apiToken}`) return 401;
+    if (!p.apiToken || !safeEqual(p.authHeader, `Bearer ${p.apiToken}`)) return 401;
     return 200;
   }
   if (p.apiToken && !(p.loopbackSkip && p.isLoopback)) {
-    if (p.authHeader !== `Bearer ${p.apiToken}`) return 401;
+    if (!safeEqual(p.authHeader, `Bearer ${p.apiToken}`)) return 401;
   }
   return 200;
 }
@@ -167,6 +202,13 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+  // Zusätzliche Hosts für das Rebinding-Gate (Tunnel-Setups, die auch die
+  // loopback-only Endpoints exposen wollen). /api/v1/* braucht das nicht —
+  // dort schützt das Token.
+  const allowedHosts = (process.env.BASTRA_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
 
   const server = createServer((req, res) => {
     const t0 = Date.now();
@@ -176,6 +218,14 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
     // Activity signal for idle self-shutdown — count real work, not the
     // cheap /health liveness ping (else a monitor would keep us alive forever).
     if (url !== "/health") onActivity?.();
+
+    // DNS-Rebinding-Gate für alles außer /api/v1/* (dort schützt das Token):
+    // die offenen Endpoints sind loopback-only by design — ein nicht-loopback
+    // Host-Header heißt, ein Browser wurde auf 127.0.0.1 umgebogen.
+    if (!url.startsWith("/api/v1/") && !isLoopbackHost(req.headers.host, allowedHosts)) {
+      sendJson(res, 403, { error: "host not allowed" });
+      return;
+    }
 
     // CORS preflight for /api/v1/*
     if (method === "OPTIONS" && url.startsWith("/api/v1/")) {

--- a/packages/daemon/src/stop-hook.ts
+++ b/packages/daemon/src/stop-hook.ts
@@ -25,7 +25,7 @@
  *   - Never blocks the workflow.
  *   - Telemetry best-effort.
  */
-import { readFile, appendFile, mkdir, stat } from "node:fs/promises";
+import { appendFile, mkdir, open } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -120,11 +120,18 @@ async function loadTranscript(payload: ClaudeStopPayload): Promise<TranscriptTur
       // transcript_path kommt aus dem Hook-Payload (untrusted): nur echte
       // Transcript-Dateien lesen (.jsonl/.json) und eine Größenschranke
       // ziehen — sonst wird der Hook zum Arbitrary-File-Read / Memory-DoS.
+      // Einmal öffnen und fstat auf dem Handle: kein TOCTOU-Fenster zwischen
+      // Check und Read.
       if (!/\.jsonl?$/.test(payload.transcript_path)) return [];
-      const st = await stat(payload.transcript_path);
-      if (!st.isFile() || st.size > MAX_TRANSCRIPT_BYTES) return [];
-      const content = await readFile(payload.transcript_path, "utf8");
-      return parseTranscriptFile(content);
+      const fh = await open(payload.transcript_path, "r");
+      try {
+        const st = await fh.stat();
+        if (!st.isFile() || st.size > MAX_TRANSCRIPT_BYTES) return [];
+        const content = await fh.readFile({ encoding: "utf8" });
+        return parseTranscriptFile(content);
+      } finally {
+        await fh.close();
+      }
     } catch {
       return [];
     }

--- a/packages/daemon/src/stop-hook.ts
+++ b/packages/daemon/src/stop-hook.ts
@@ -25,7 +25,7 @@
  *   - Never blocks the workflow.
  *   - Telemetry best-effort.
  */
-import { readFile, appendFile, mkdir } from "node:fs/promises";
+import { readFile, appendFile, mkdir, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -117,6 +117,12 @@ async function loadTranscript(payload: ClaudeStopPayload): Promise<TranscriptTur
   }
   if (typeof payload.transcript_path === "string") {
     try {
+      // transcript_path kommt aus dem Hook-Payload (untrusted): nur echte
+      // Transcript-Dateien lesen (.jsonl/.json) und eine Größenschranke
+      // ziehen — sonst wird der Hook zum Arbitrary-File-Read / Memory-DoS.
+      if (!/\.jsonl?$/.test(payload.transcript_path)) return [];
+      const st = await stat(payload.transcript_path);
+      if (!st.isFile() || st.size > MAX_TRANSCRIPT_BYTES) return [];
       const content = await readFile(payload.transcript_path, "utf8");
       return parseTranscriptFile(content);
     } catch {
@@ -125,6 +131,8 @@ async function loadTranscript(payload: ClaudeStopPayload): Promise<TranscriptTur
   }
   return [];
 }
+
+const MAX_TRANSCRIPT_BYTES = 64 * 1024 * 1024; // 64 MiB — weit über realen Transcripts
 
 function parseTranscriptFile(raw: string): TranscriptTurn[] {
   const trimmed = raw.trim();

--- a/packages/statusline/src/tui/primitives.ts
+++ b/packages/statusline/src/tui/primitives.ts
@@ -1,6 +1,6 @@
 import type { BoxChars } from "./types";
 
-import { visibleLength, stripAnsi, ESC, ANSI_SPLIT } from "../utils/terminal";
+import { visibleLength, codePointWidth, stripAnsi, ESC, ANSI_SPLIT } from "../utils/terminal";
 
 export function colorize(
   text: string,
@@ -46,7 +46,7 @@ export function padCenter(text: string, width: number): string {
 }
 
 export function truncateAnsi(text: string, maxWidth: number): string {
-  if (stripAnsi(text).length <= maxWidth) {
+  if (visibleLength(text) <= maxWidth) {
     return text;
   }
 
@@ -59,12 +59,15 @@ export function truncateAnsi(text: string, maxWidth: number): string {
       continue;
     }
     for (const char of part) {
-      if (width >= maxWidth - 1) {
+      const w = codePointWidth(char.codePointAt(0) ?? 0);
+      // Breiten-bewusst schneiden: ein CJK-Zeichen belegt 2 Spalten — der
+      // Cut muss VOR dem Zeichen passieren, das das Budget sprengen würde.
+      if (width + w > maxWidth - 1) {
         result += "…\x1b[0m";
         return result;
       }
       result += char;
-      width++;
+      width += w;
     }
   }
   return result;

--- a/packages/statusline/src/utils/terminal.ts
+++ b/packages/statusline/src/utils/terminal.ts
@@ -6,6 +6,49 @@ export function stripAnsi(str: string): string {
   return str.replace(ANSI_REGEX, "");
 }
 
+/**
+ * Terminal-Spaltenbreite eines Code-Points (praktisches wcwidth-Subset):
+ * 0 für Combining Marks / Zero-Width-Joiner / Variation Selectors,
+ * 2 für CJK/Hangul/Fullwidth/Emoji, sonst 1. Nerd-Font-/Powerline-Glyphen
+ * (Private Use Area, z.B. U+E0B0) zählen als 1.
+ */
+export function codePointWidth(cp: number): number {
+  if (
+    (cp >= 0x0300 && cp <= 0x036f) || // combining diacritics
+    (cp >= 0x1ab0 && cp <= 0x1aff) ||
+    (cp >= 0x1dc0 && cp <= 0x1dff) ||
+    (cp >= 0x20d0 && cp <= 0x20ff) || // combining for symbols
+    (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors
+    cp === 0x200b || cp === 0x200c || cp === 0x200d || cp === 0xfeff
+  ) {
+    return 0;
+  }
+  if (
+    (cp >= 0x1100 && cp <= 0x115f) || // Hangul Jamo
+    (cp >= 0x2e80 && cp <= 0xa4cf) || // CJK radicals … Yi
+    (cp >= 0xa960 && cp <= 0xa97f) || // Hangul Jamo Extended-A
+    (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul syllables
+    (cp >= 0xf900 && cp <= 0xfaff) || // CJK compatibility ideographs
+    (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK compatibility forms
+    (cp >= 0xff00 && cp <= 0xff60) || // fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) ||
+    (cp >= 0x1f300 && cp <= 0x1faff) || // emoji & pictographs
+    (cp >= 0x20000 && cp <= 0x3fffd) // CJK extensions B+
+  ) {
+    return 2;
+  }
+  return 1;
+}
+
+/**
+ * Sichtbare Terminal-Breite (Spalten), nicht UTF-16-Länge: `.length` zählt
+ * CJK als 1 (real 2) und Combining Marks als 1 (real 0) — damit war jede
+ * Spalten-/Padding-Rechnung für solche Inhalte um 1–2 Spalten daneben.
+ */
 export function visibleLength(str: string): number {
-  return stripAnsi(str).length;
+  let width = 0;
+  for (const ch of stripAnsi(str)) {
+    width += codePointWidth(ch.codePointAt(0) ?? 0);
+  }
+  return width;
 }


### PR DESCRIPTION
Security pass from a full-repo review, plus the CI fix for main.

## Security

- **core/save — path traversal:** `id`/`scope` are validated as path-safe components (zod refine) and vault containment is re-checked after the join. Crafted MCP input like `id: "../../../../x"` could previously write outside the vault.
- **core/schema:** shared `isPathSafeComponent` guard on frontmatter ids — deliberately loose (separators / `..` / NUL / leading dot only) so existing vaults keep loading.
- **core/audit-log:** `trashPathFor` refuses destinations outside `.bastra/trash` (frontmatter id is untrusted input on the soft-delete path).
- **daemon/documents-write:** `folder_path`/`newFolderPath` containment against the documents root — `mkdir`/`copyFile`/`rename` could escape via `..`. Sidecar writes are now tmp+rename (no torn files).
- **daemon/http:** Bearer comparison via sha256 + `timingSafeEqual`; DNS-rebinding gate for the token-less loopback endpoints (`/hook/recall`, `/vault/count`, `/health`) — non-loopback `Host` headers get 403, `BASTRA_ALLOWED_HOSTS` is the tunnel escape hatch. `/api/v1/*` unchanged (token-protected, tunnel setups keep working).
- **daemon/stop-hook:** `transcript_path` must be a `.jsonl`/`.json` file under 64 MiB — hook payload input must not become an arbitrary-file read.

## Fixes

- **daemon/cli/ollama:** env-override check now runs before the platform gate — fixes `ensureOllama: env BASTRA_EMBEDDING_PROVIDER=none …` failing on Linux CI since 7ad1879 (main is currently red because of this).
- **core/embeddings:** batches actually run concurrently up to `BASTRA_EMBED_MAX_CONCURRENT` — the semaphore was dead code, everything ran serially. Persist + embed-cache writes are tmp+rename.
- **statusline:** `visibleLength` measures terminal columns (wcwidth subset: CJK=2, combining=0, Nerd-Font/PUA=1) instead of UTF-16 length; `truncateAnsi` cuts width-aware.

## Verify

```bash
npm run build && npm run check:types && npm test
```

202/202 tests green (7 new: `core/__tests__/path-safety.test.ts`, hardening cases in `http-auth-gate.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)