### PR TITLE
feat(taxonomy): self-learning memory taxonomy — conventions, hook injection, drift detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ confidence: 0.95
 
 The `recall_when` field is the bridge between save and recall: when saving, the AI declares the contexts under which future-sessions should be reminded. See [docs/memory-schema.md](./docs/memory-schema.md) for full field semantics and six example memories covering `lesson`, `preference`, `project-fact`, `meta-working`, `decision`, `workflow`.
 
+### Self-learning taxonomy
+
+The vault grows its own structure. When recent memories keep forming the same ad-hoc cluster (people, places, tools, …) without a home, the stop hook suggests recording a **convention** — a memory in the reserved scope `taxonomy` that fixes the cluster's folder, `topic_path` shape and tags. Active conventions are injected at session start and are binding for future saves. `save_memory` takes a `folder` argument so cluster members get a real folder (e.g. `memories/people/`), and re-saving with a changed folder *moves* the file (the old copy lands in the vault trash, recoverable). All of it lives per-vault on the free axes — the `type` schema stays fixed. Details: [docs/taxonomy.md](./docs/taxonomy.md).
+
 ### Install
 
 Three paths, in order of friction. bastra-recall is self-contained: the daemon, the MCP server, the REST gateway, the `bastra` CLI, and the Skill all ship in this repo — nothing else needed for full vault functionality.
@@ -222,6 +226,7 @@ Auth and CORS:
 - **Local tools** (CLI, MCP-forwarder — no `Origin` header) reach `/api/v1/*` over loopback without a token. Set `BASTRA_AUTH_LOOPBACK_SKIP=0` to require the token even for them.
 - **Browser clients** (any request *with* an `Origin` header) must always present the token **and** be on the CORS allowlist — even over loopback, since the user's browser shares `127.0.0.1` with the daemon and only the `Origin` header tells a real site from a stray one.
 - **CORS** is permissive by default (`Access-Control-Allow-Origin: *`). For a hosted web app, set an allowlist: `BASTRA_CORS_ORIGIN=https://your.host` (comma-separated for several) — the daemon then reflects only listed origins and a browser blocks the rest.
+- **DNS rebinding** is blocked: the token-less loopback endpoints (`/health`, `/hook/*`, `/vault/count`) only answer requests whose `Host` header is loopback (`127.0.0.1` / `localhost` / `[::1]`). `/api/v1/*` is unaffected (the token protects it). Tunnel setups that need more than `/api/v1/*` can allowlist hosts via `BASTRA_ALLOWED_HOSTS` (comma-separated).
 
 To reach this daemon from a hosted web app (e.g. a site's admin talking to the user's *local* vault from the browser), set `BASTRA_CORS_ORIGIN` to the site origin, run `bastra token`, and paste the token into the site. For a server-side client like ChatGPT, point a tunnel (Cloudflare Tunnel / ngrok / your own reverse proxy) at `127.0.0.1:6723` and configure it with the tunnel URL + your token. An OpenAPI 3.0 starter spec lives in [docs/openapi.yaml](./docs/openapi.yaml).
 
@@ -355,6 +360,10 @@ confidence: 0.95
 
 Das `recall_when`-Feld ist die Brücke zwischen Save und Recall: beim Speichern deklariert die AI die Kontexte, in denen die spätere Sitzung daran erinnert werden soll. Siehe [docs/memory-schema.md](./docs/memory-schema.md) für die vollständige Feld-Semantik und sechs Beispiel-Memories für `lesson`, `preference`, `project-fact`, `meta-working`, `decision`, `workflow`.
 
+### Selbstlernende Taxonomie
+
+Der Vault baut sich seine Struktur selbst. Wenn jüngste Memories wiederholt dasselbe Ad-hoc-Cluster bilden (Personen, Orte, Tools, …), ohne dass es eine Heimat hat, schlägt der Stop-Hook vor, eine **Konvention** festzuhalten — ein Memory im reservierten Scope `taxonomy`, das Ordner, `topic_path`-Form und Tags des Clusters festlegt. Aktive Konventionen werden bei Session-Start injiziert und sind für künftige Saves bindend. `save_memory` nimmt ein `folder`-Argument, damit Cluster-Mitglieder einen echten Ordner bekommen (z.B. `memories/people/`); ein erneutes Speichern mit geändertem Ordner *verschiebt* die Datei (die alte Kopie landet recoverbar im Vault-Trash). Alles lebt pro Vault auf den freien Achsen — das `type`-Schema bleibt fix. Details: [docs/taxonomy.md](./docs/taxonomy.md).
+
 ### Installation
 
 Drei Wege, nach Aufwand sortiert. bastra-recall ist eigenständig: Daemon, MCP-Server, REST-Gateway, `bastra`-CLI und Skill liegen alle in diesem Repo — mehr braucht es nicht für die volle Vault-Funktionalität.
@@ -470,6 +479,7 @@ Auth und CORS:
 - **Lokale Tools** (CLI, MCP-Forwarder — kein `Origin`-Header) erreichen `/api/v1/*` über Loopback ohne Token. Mit `BASTRA_AUTH_LOOPBACK_SKIP=0` wird das Token auch von ihnen verlangt.
 - **Browser-Clients** (jeder Request *mit* `Origin`-Header) müssen immer das Token tragen **und** auf der CORS-Allowlist stehen — auch über Loopback, denn der Browser des Users teilt sich `127.0.0.1` mit dem Daemon und nur der `Origin`-Header trennt eine echte Seite von einer fremden.
 - **CORS** ist per Default permissiv (`Access-Control-Allow-Origin: *`). Für eine gehostete Web-App eine Allowlist setzen: `BASTRA_CORS_ORIGIN=https://dein.host` (kommagetrennt für mehrere) — der Daemon spiegelt dann nur gelistete Origins zurück, den Rest blockt der Browser.
+- **DNS-Rebinding** wird geblockt: Die token-losen Loopback-Endpoints (`/health`, `/hook/*`, `/vault/count`) antworten nur auf Requests, deren `Host`-Header loopback ist (`127.0.0.1` / `localhost` / `[::1]`). `/api/v1/*` ist nicht betroffen (dort schützt das Token). Tunnel-Setups, die mehr als `/api/v1/*` brauchen, können Hosts via `BASTRA_ALLOWED_HOSTS` (kommagetrennt) freischalten.
 
 Um diesen Daemon aus einer gehosteten Web-App zu erreichen (z.B. das Admin einer Seite, das aus dem Browser auf den *lokalen* Vault des Users zugreift): `BASTRA_CORS_ORIGIN` auf die Seiten-Origin setzen, `bastra token` ausführen und das Token in der Seite hinterlegen. Für einen serverseitigen Client wie ChatGPT: einen Tunnel (Cloudflare Tunnel / ngrok / eigener Reverse-Proxy) auf `127.0.0.1:6723` legen und mit Tunnel-URL + Token konfigurieren. Eine OpenAPI-3.0-Starter-Spec liegt in [docs/openapi.yaml](./docs/openapi.yaml).
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -173,8 +173,22 @@ Output is one or more multi-line `<save-eval>` blocks suggesting title/type/body
 hook **never calls `save_memory` itself** — only the agent does, in the next
 turn, if it agrees with the suggestion.
 
+Additionally the stop hook asks the daemon's drift detector (`GET /hook/drift`,
+budget 250 ms, fail-silent) whether recent memories form a recurring cluster
+with no taxonomy convention covering it, and surfaces at most two clusters as a
+`<taxonomy-drift>` suggestion — see [taxonomy.md](taxonomy.md). Same contract:
+suggestion only, the agent decides.
+
 Budget 1000 ms. Telemetry: `save_eval_call` with `heuristic, suggested_count,
-turn_count, latency_ms_total`.
+drift_clusters, turn_count, latency_ms_total`.
+
+### Taxonomy injection (session hook, #66)
+
+The session hook also fetches `GET /hook/taxonomy` (budget 150 ms within the
+overall hook budget, fail-silent) and appends a `<vault-taxonomy>` block with
+the active convention memories (reserved scope `taxonomy`, newest first, cap
+6 rendered). Conventions are binding save-rules — see
+[taxonomy.md](taxonomy.md). Telemetry gains `convention_count`.
 
 ## Environment overrides
 
@@ -186,5 +200,7 @@ turn_count, latency_ms_total`.
 | `BASTRA_PROMPT_HOOK_MODE`     | `retrieval-only` | `retrieval-only` or `all` — only the prompt-hook reads this   |
 | `BASTRA_TELEMETRY`            | `on`             | `off` to disable JSONL telemetry writes                       |
 | `BASTRA_LOG_PATH`             | `~/.bastra/logs` | Telemetry log directory                                       |
+| `BASTRA_DRIFT_WINDOW_DAYS`    | `14`             | Drift detector: how far back "recent memories" reaches        |
+| `BASTRA_DRIFT_MIN_CLUSTER`    | `3`              | Drift detector: distinct memories before a cluster is flagged |
 
 All `BASTRA_*` vars accept a legacy `NEXUS_*` fallback for migration.

--- a/docs/taxonomy.md
+++ b/docs/taxonomy.md
@@ -1,0 +1,97 @@
+# Self-learning taxonomy (#64)
+
+bastra-recall's category system has two kinds of axes:
+
+- **Hard axis — `type`**: a closed enum (`lesson`, `decision`, …). Stable
+  behavioural vocabulary, manually curated, never mutated at runtime.
+- **Free axes — `scope`, `topic_path`, `tags`, `recall_when`, `folder`**: open
+  strings. This is where the vault can *learn* new categories.
+
+The learning loop closes in three steps: **notice** (drift detector) →
+**record** (convention memory) → **apply** (hook injection + `folder` routing).
+Everything lives per-vault: one user's vault can grow a `people/` taxonomy
+while another never does. The shared `type` schema is untouched.
+
+## 1. Convention memories — the contract (#65)
+
+A *convention* is a regular memory that fixes how a recurring cluster is
+stored. Reserved home:
+
+| field | value |
+|---|---|
+| `scope` | `taxonomy` (reserved — routes to `memories/taxonomy/`) |
+| `type` | `workflow` |
+| `tags` | must include `convention`, plus the cluster key (e.g. `person`) |
+| `recall_when` | concrete save-moments, e.g. "about to save a memory about a person" |
+
+The **body** states the rule, machine-followable:
+
+```markdown
+## Cluster
+What belongs to this cluster (and what does not).
+
+## Rule
+- folder: memories/people
+- topic_path: [people, <handle>]
+- tags: [person, <role…>]
+- id/title shape: <handle> — <real name>
+- body shape: handle, name, role/relationship, first-seen, signals,
+  interaction log as [[wikilinks]], sensitivity.
+
+## Example
+One worked example entry (frontmatter + body sketch).
+```
+
+A convention is updated with `overwrite=true` (refresh, don't fork
+`convention-v2`). Retire one by setting it `obsolete` — covered clusters go
+silent in the drift detector either way.
+
+## 2. Applying conventions (#66)
+
+- The **session hook** fetches `GET /hook/taxonomy` (all non-obsolete
+  memories in scope `taxonomy`, newest first, cap 12) and injects a
+  `<vault-taxonomy>` block at session start. Conventions are **binding**: a
+  save into a covered cluster follows the convention's folder/topic_path/tags
+  instead of inventing variants.
+- `save_memory` accepts a **`folder`** argument (relative to the vault root,
+  path-safe, containment-checked) so conventions can place members in real
+  structure — e.g. `memories/people/`. The vault scans recursively; any folder
+  indexes.
+- **Re-filing**: `overwrite=true` with a changed folder *moves* the memory —
+  the new file is written, the old file goes to the vault trash
+  (`.bastra/trash/`, recoverable), and the index is updated immediately. This
+  is how existing memories migrate under a new convention.
+
+## 3. Noticing drift (#67)
+
+The daemon's drift detector (`GET /hook/drift`, implemented in
+`packages/daemon/src/taxonomy.ts`) looks at memories updated in the last
+`BASTRA_DRIFT_WINDOW_DAYS` (default 14) and flags clusters of at least
+`BASTRA_DRIFT_MIN_CLUSTER` (default 3) distinct memories sharing a tag or a
+sub-project `topic_path` segment — **unless** a convention already covers that
+key (mentioned in a convention's tags, topic_path or title). Scope names and
+memory types never count (structural, not drift).
+
+The **stop hook** surfaces at most two clusters as a `<taxonomy-drift>`
+suggestion. Suggestion only: the agent weighs it next turn, asks the user if
+unsure, and never bulk-moves silently.
+
+## Worked example — `person` (#68)
+
+The pilot convention that established `memories/people/`:
+
+```yaml
+id: konvention-person
+scope: taxonomy
+type: workflow
+tags: [convention, person, people]
+recall_when:
+  - "about to save a memory about a person"
+  - "contributor, peer or contact shows up in conversation"
+```
+
+Rule: people live in `folder: memories/people`, `topic_path: [people,
+<handle>]`, tag `person`, one memory per person (no collection memos), body
+shape: handle, name, role/relationship, first-seen, signals/trust, interaction
+log as `[[wikilinks]]`, sensitivity. Project memories link people by
+`[[<handle>]]` instead of restating their story.

--- a/packages/core/src/save.ts
+++ b/packages/core/src/save.ts
@@ -73,6 +73,17 @@ export const SaveMemoryInput = z.object({
   id: z.string().min(1).refine(isPathSafeComponent, {
     message: "id must not contain path separators, '..', or a leading dot",
   }).optional(),
+  /**
+   * Selbstlernende Taxonomie (#64/#65): optionaler Ziel-Ordner relativ zum
+   * Vault-Root (z.B. "memories/people"). Überschreibt das scope/type-Routing
+   * von subfolderFor() — damit kann eine Taxonomie-Konvention neue physische
+   * Strukturen im Vault etablieren, ohne dass core sie kennen muss. Der Vault
+   * scannt rekursiv, jeder Ordner wird indexiert.
+   */
+  folder: z.string().min(1).refine(isPathSafeFolder, {
+    message:
+      "folder must be a relative path without '..', '\\', or dot-segments (e.g. \"memories/people\")",
+  }).optional(),
   overwrite: z.boolean().optional(),
   // Bookmark-only fields
   url: z.string().optional(),
@@ -93,6 +104,21 @@ export interface SaveMemoryResult {
 }
 
 const SLUG_MAX_LEN = 80;
+
+/**
+ * Folder-Werte sind legitim mehrsegmentig ("memories/people/extern") — kein
+ * Charset-Verbot wie bei id/scope, aber jedes Segment muss harmlos sein:
+ * kein "..", kein ".", kein führender Punkt, keine Backslashes/NUL, nicht
+ * absolut. Der Containment-Assert in saveMemory() bleibt als zweite Schicht.
+ */
+function isPathSafeFolder(value: string): boolean {
+  if (value.includes("\0") || value.includes("\\") || value.startsWith("/")) {
+    return false;
+  }
+  const segments = value.split("/").filter((s) => s.length > 0);
+  if (segments.length === 0) return false;
+  return segments.every((s) => s !== ".." && s !== "." && !s.startsWith("."));
+}
 
 /**
  * Marker-Kommentare, zwischen denen der RelatedEnricher die Auto-Wikilink-
@@ -211,6 +237,11 @@ function subfolderFor(scope: string, type: string): string {
   if (type === "doc") return `dokumentationen/${scope}`;
   if (scope === "user-preference") return "memories/user";
   if (scope === "all-projects") return "memories/all-projects";
+  // Reservierter Ort für selbst-etablierte Taxonomie-Konventionen (#65):
+  // Regeln, die beschreiben, wie der Vault künftig strukturiert wird
+  // ("Personen nach memories/people/, Tag person, …"). Die Hooks laden
+  // diesen Scope bei Session-Start und injizieren ihn als Kontext.
+  if (scope === "taxonomy") return "memories/taxonomy";
   return `memories/projects/${scope}`;
 }
 
@@ -223,7 +254,9 @@ export async function saveMemory(
   input: SaveMemoryInput,
 ): Promise<SaveMemoryResult> {
   const id = input.id ?? slugify(input.title);
-  const subdir = subfolderFor(input.scope, input.type);
+  // Konventions-getriebener Ziel-Ordner gewinnt über das scope/type-Routing —
+  // so kann der Vault neue Strukturen lernen (z.B. memories/people/).
+  const subdir = input.folder ?? subfolderFor(input.scope, input.type);
   const dir = join(vaultRoot, subdir);
   const filePath = join(dir, `${id}.md`);
   // Belt-and-suspenders against path escape: id/scope are schema-validated as

--- a/packages/core/src/vault.ts
+++ b/packages/core/src/vault.ts
@@ -147,6 +147,15 @@ export class Vault {
     return () => this.listeners.delete(listener);
   }
 
+  /**
+   * Drop a file's index entry without touching disk — for callers that moved
+   * or trashed the file themselves (e.g. a convention-driven re-file on save)
+   * and can't wait for the cloud-unreliable watcher to notice the unlink.
+   */
+  forgetFile(filePath: string): void {
+    this.handleRemove(filePath);
+  }
+
   list(): Memory[] {
     return [...this.memorys.values()];
   }

--- a/packages/daemon/__tests__/taxonomy.test.ts
+++ b/packages/daemon/__tests__/taxonomy.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests für die selbstlernende Taxonomie (#64):
+ * - listConventions (#65/#66): reservierter Scope "taxonomy", obsolete raus,
+ *   neueste zuerst.
+ * - detectTaxonomyDrift (#67): wiederkehrendes Cluster ohne Konvention feuert,
+ *   gedeckte Cluster und alte Memories bleiben still.
+ * - folder-Routing + Re-Filing (#64-Enabler): save_memory mit `folder` legt
+ *   die Datei dort ab; overwrite mit geändertem folder VERSCHIEBT (alte Datei
+ *   in den Trash); ohne overwrite wird abgelehnt.
+ *
+ * Runner: `tsx --test __tests__/taxonomy.test.ts`
+ * Echtes File-Vault, kein Mocking.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm, mkdir, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+import { Telemetry } from "../src/telemetry.js";
+import { saveMemoryHandler, type ToolDeps } from "../src/tool-handlers.js";
+import { listConventions, detectTaxonomyDrift } from "../src/taxonomy.js";
+
+function memoryFile(opts: {
+  id: string;
+  title: string;
+  scope: string;
+  tags: string[];
+  topicPath?: string[];
+  updated?: string;
+  obsolete?: boolean;
+}): string {
+  const day = opts.updated ?? new Date().toISOString().slice(0, 10);
+  return [
+    "---",
+    `id: ${opts.id}`,
+    `title: ${opts.title}`,
+    "type: lesson",
+    `summary: ${opts.title} summary`,
+    "topic_path:",
+    ...(opts.topicPath ?? ["test"]).map((s) => `  - ${s}`),
+    "tags:",
+    ...opts.tags.map((t) => `  - ${t}`),
+    `scope: ${opts.scope}`,
+    ...(opts.obsolete ? ["obsolete: true"] : []),
+    "recall_when:",
+    `  - ${opts.title}`,
+    `created: ${day}`,
+    `updated: ${day}`,
+    "---",
+    "",
+    `Body for ${opts.title}.`,
+    "",
+  ].join("\n");
+}
+
+async function makeVault(files: Array<{ rel: string; content: string }>): Promise<{
+  vault: Vault;
+  dir: string;
+  close: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-taxonomy-test-"));
+  for (const f of files) {
+    const p = join(dir, f.rel);
+    await mkdir(join(p, ".."), { recursive: true });
+    await writeFile(p, f.content, "utf8");
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  return {
+    vault,
+    dir,
+    close: async () => {
+      await vault.stop?.();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+const OLD_DAY = "2020-01-01";
+
+// ── listConventions ──────────────────────────────────────────────────
+
+test("listConventions: only scope taxonomy, obsolete excluded, newest first", async () => {
+  const { vault, close } = await makeVault([
+    { rel: "a.md", content: memoryFile({ id: "not-a-convention", title: "regular", scope: "proj", tags: ["x"] }) },
+    {
+      rel: "memories/taxonomy/conv-person.md",
+      content: memoryFile({ id: "conv-person", title: "person convention", scope: "taxonomy", tags: ["convention", "person"] }),
+    },
+    {
+      rel: "memories/taxonomy/conv-old.md",
+      content: memoryFile({ id: "conv-old", title: "older convention", scope: "taxonomy", tags: ["convention"], updated: OLD_DAY }),
+    },
+    {
+      rel: "memories/taxonomy/conv-dead.md",
+      content: memoryFile({ id: "conv-dead", title: "retired convention", scope: "taxonomy", tags: ["convention"], obsolete: true }),
+    },
+  ]);
+  try {
+    const conventions = listConventions(vault);
+    assert.deepEqual(
+      conventions.map((c) => c.id),
+      ["conv-person", "conv-old"],
+      "taxonomy scope only, obsolete excluded, newest first",
+    );
+    assert.equal(typeof conventions[0].summary, "string");
+  } finally {
+    await close();
+  }
+});
+
+// ── detectTaxonomyDrift ──────────────────────────────────────────────
+
+test("drift: recurring tag cluster without convention fires, capped examples", async () => {
+  const { vault, close } = await makeVault([
+    { rel: "p1.md", content: memoryFile({ id: "p1", title: "caio", scope: "proj", tags: ["person"] }) },
+    { rel: "p2.md", content: memoryFile({ id: "p2", title: "donghun", scope: "proj", tags: ["person"] }) },
+    { rel: "p3.md", content: memoryFile({ id: "p3", title: "zzallirog", scope: "proj", tags: ["person"] }) },
+    { rel: "x.md", content: memoryFile({ id: "x1", title: "single", scope: "proj", tags: ["solo-tag"] }) },
+  ]);
+  try {
+    const clusters = detectTaxonomyDrift(vault);
+    assert.equal(clusters.length, 1, "only the person cluster reaches the threshold");
+    assert.equal(clusters[0].key, "person");
+    assert.equal(clusters[0].count, 3);
+    assert.ok(clusters[0].examples.length <= 3);
+  } finally {
+    await close();
+  }
+});
+
+test("drift: a covering convention silences the cluster", async () => {
+  const { vault, close } = await makeVault([
+    { rel: "p1.md", content: memoryFile({ id: "p1", title: "caio", scope: "proj", tags: ["person"] }) },
+    { rel: "p2.md", content: memoryFile({ id: "p2", title: "donghun", scope: "proj", tags: ["person"] }) },
+    { rel: "p3.md", content: memoryFile({ id: "p3", title: "zzallirog", scope: "proj", tags: ["person"] }) },
+    {
+      rel: "memories/taxonomy/conv-person.md",
+      content: memoryFile({ id: "conv-person", title: "person convention", scope: "taxonomy", tags: ["convention", "person"] }),
+    },
+  ]);
+  try {
+    assert.deepEqual(detectTaxonomyDrift(vault), [], "covered cluster must stay silent");
+  } finally {
+    await close();
+  }
+});
+
+test("drift: stale memories and structural keys never cluster", async () => {
+  const { vault, close } = await makeVault([
+    // Alt: außerhalb des Fensters — zählt nicht.
+    { rel: "o1.md", content: memoryFile({ id: "o1", title: "old1", scope: "proj", tags: ["person"], updated: OLD_DAY }) },
+    { rel: "o2.md", content: memoryFile({ id: "o2", title: "old2", scope: "proj", tags: ["person"], updated: OLD_DAY }) },
+    { rel: "o3.md", content: memoryFile({ id: "o3", title: "old3", scope: "proj", tags: ["person"], updated: OLD_DAY }) },
+    // Frisch, aber nur strukturelle Schlüssel (scope-Name als Tag, Memory-Typ).
+    { rel: "s1.md", content: memoryFile({ id: "s1", title: "s1", scope: "proj", tags: ["proj", "lesson"], topicPath: ["proj"] }) },
+    { rel: "s2.md", content: memoryFile({ id: "s2", title: "s2", scope: "proj", tags: ["proj", "lesson"], topicPath: ["proj"] }) },
+    { rel: "s3.md", content: memoryFile({ id: "s3", title: "s3", scope: "proj", tags: ["proj", "lesson"], topicPath: ["proj"] }) },
+  ]);
+  try {
+    assert.deepEqual(detectTaxonomyDrift(vault), [], "stale + structural keys must not fire");
+  } finally {
+    await close();
+  }
+});
+
+// ── folder-Routing + Re-Filing ───────────────────────────────────────
+
+async function makeDeps(): Promise<{ deps: ToolDeps; dir: string; close: () => Promise<void> }> {
+  const { vault, dir, close } = await makeVault([]);
+  const search = new SearchIndex(vault);
+  search.start();
+  const telemetry = new Telemetry();
+  const deps: ToolDeps = { vault, search, telemetry, vaultPath: dir };
+  return {
+    deps,
+    dir,
+    close: async () => {
+      search.stop();
+      await close();
+    },
+  };
+}
+
+const PERSON_INPUT = {
+  title: "caio ribeiro",
+  type: "project-fact",
+  summary: "person memo",
+  body: "Handle, role, interaction log.",
+  topic_path: ["people", "caio"],
+  tags: ["person"],
+  scope: "bastra-recall",
+  recall_when: ["caio shows up"],
+};
+
+test("save_memory: folder routes the file, taxonomy scope has a reserved home", async () => {
+  const { deps, dir, close } = await makeDeps();
+  try {
+    const a = await saveMemoryHandler(deps, { ...PERSON_INPUT, folder: "memories/people" });
+    assert.equal(a.file_path, join(dir, "memories/people/caio-ribeiro.md"));
+
+    const b = await saveMemoryHandler(deps, {
+      ...PERSON_INPUT,
+      title: "person convention",
+      type: "workflow",
+      scope: "taxonomy",
+      tags: ["convention", "person"],
+    });
+    assert.equal(b.file_path, join(dir, "memories/taxonomy/person-convention.md"));
+  } finally {
+    await close();
+  }
+});
+
+test("save_memory: overwrite with a changed folder MOVES (old file trashed)", async () => {
+  const { deps, dir, close } = await makeDeps();
+  try {
+    const first = await saveMemoryHandler(deps, PERSON_INPUT);
+    assert.ok(first.file_path.includes("memories/projects/bastra-recall"));
+
+    // Ohne overwrite: Umzug wird abgelehnt.
+    await assert.rejects(
+      saveMemoryHandler(deps, { ...PERSON_INPUT, folder: "memories/people" }),
+      /already exists/,
+    );
+
+    const moved = await saveMemoryHandler(deps, {
+      ...PERSON_INPUT,
+      folder: "memories/people",
+      overwrite: true,
+    });
+    assert.equal(moved.file_path, join(dir, "memories/people/caio-ribeiro.md"));
+    // Alte Datei ist weg (im Trash), neue existiert, Index zeigt auf neu.
+    await assert.rejects(access(first.file_path), "old file must be gone");
+    await access(join(dir, ".bastra/trash/caio-ribeiro.md"));
+    assert.equal(deps.vault.get("caio-ribeiro")?.filePath, moved.file_path);
+  } finally {
+    await close();
+  }
+});
+
+test("save_memory: traversal folder is rejected", async () => {
+  const { deps, close } = await makeDeps();
+  try {
+    await assert.rejects(
+      saveMemoryHandler(deps, { ...PERSON_INPUT, folder: "../outside" }),
+      /folder/,
+    );
+    await assert.rejects(
+      saveMemoryHandler(deps, { ...PERSON_INPUT, folder: "/absolute" }),
+      /folder/,
+    );
+  } finally {
+    await close();
+  }
+});

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -69,6 +69,7 @@ import {
   moveDocument,
 } from "./documents-write-handler.js";
 import { getUpdateState } from "./update-check.js";
+import { listConventions, detectTaxonomyDrift } from "./taxonomy.js";
 import { getApiToken } from "./settings.js";
 import type { EmbeddingStatus } from "./embedding-status.js";
 
@@ -273,6 +274,18 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
 
     if (method === "POST" && url === "/hook/recall") {
       handleHookRecall(req, res, t0, vault, search, telemetry);
+      return;
+    }
+
+    // Selbstlernende Taxonomie (#64): Konventions-Liste für die Session-Hook-
+    // Injection (#66) und Drift-Analyse für den Stop-Hook (#67). Beides
+    // loopback-only (Host-Gate oben), read-only, kein Auth — wie /hook/recall.
+    if (method === "GET" && url === "/hook/taxonomy") {
+      sendJson(res, 200, { conventions: listConventions(vault) });
+      return;
+    }
+    if (method === "GET" && url === "/hook/drift") {
+      sendJson(res, 200, { clusters: detectTaxonomyDrift(vault) });
       return;
     }
 

--- a/packages/daemon/src/session-hook.ts
+++ b/packages/daemon/src/session-hook.ts
@@ -72,6 +72,17 @@ interface HealthResponse {
   update_available: UpdateAvailable | null;
 }
 
+interface ConventionLean {
+  id: string;
+  title: string;
+  summary: string;
+  updated: string;
+}
+
+interface TaxonomyResponse {
+  conventions: ConventionLean[];
+}
+
 async function main(): Promise<void> {
   const startedAt = Date.now();
 
@@ -142,6 +153,16 @@ async function main(): Promise<void> {
   merged.sort((a, b) => b.score - a.score);
   const top = merged.slice(0, TOTAL_HINTS_CAP);
 
+  // Taxonomie-Konventionen (#66): bindende, selbst-gelernte Struktur-Regeln
+  // des Vaults. Dedizierter Listen-Endpoint statt Recall-Suche — Konventionen
+  // konkurrieren nicht über Scores und dürfen nicht am Floor sterben.
+  let conventions: ConventionLean[] = [];
+  if (responses.some((r) => r.resp !== null)) {
+    const remainingMs = Math.max(60, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
+    conventions = await fetchTaxonomy(url, Math.min(150, remainingMs));
+  }
+  const taxonomyBlock = formatTaxonomyBlock(conventions);
+
   // Best-effort update probe — only when we already have a daemon reachable.
   // Strict budget: 200 ms; if nothing back, we just skip the block.
   //
@@ -188,16 +209,17 @@ async function main(): Promise<void> {
     }
   }
 
-  if (top.length === 0 && updateBlock === "") {
+  const extras = taxonomyBlock + updateBlock;
+  if (top.length === 0 && extras === "") {
     if (status === "ok") status = "no-hits";
     emitEmpty();
   } else if (top.length === 0) {
-    // Only an update banner, no recall hits.
+    // Only conventions and/or an update banner, no recall hits.
     process.stdout.write(
       JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "SessionStart",
-          additionalContext: updateBlock.trimStart(),
+          additionalContext: extras.trimStart(),
         },
       }),
     );
@@ -206,7 +228,7 @@ async function main(): Promise<void> {
       JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "SessionStart",
-          additionalContext: formatBlock(top, project, payload.source ?? null) + updateBlock,
+          additionalContext: formatBlock(top, project, payload.source ?? null) + extras,
         },
       }),
     );
@@ -219,6 +241,7 @@ async function main(): Promise<void> {
     daemon_url: url,
     daemon_reachable: responses.some((r) => r.resp !== null),
     hint_count: top.length,
+    convention_count: conventions.length,
     top_score: top[0]?.score ?? null,
     latency_ms_total: Date.now() - startedAt,
     status,
@@ -340,6 +363,68 @@ function postRecall(
   });
 }
 
+/**
+ * Konventions-Block (#66). Kompakt: Titel + Summary pro Konvention, dazu die
+ * Anweisung, sie beim Speichern zu BEFOLGEN (Details via load_memory). Cap 6 —
+ * mehr Konventionen heißt das Vault braucht eher eine Meta-Aufräumrunde als
+ * mehr Kontext.
+ */
+function formatTaxonomyBlock(conventions: ConventionLean[]): string {
+  if (conventions.length === 0) return "";
+  const lines = conventions
+    .slice(0, 6)
+    .map((c) => `- [${c.id}] ${c.title}: ${c.summary}`);
+  return (
+    `\n<vault-taxonomy>\n` +
+    `Self-learned vault conventions — BINDING when saving memories in these clusters. ` +
+    `Follow the convention's folder/topic_path/tags exactly (load_memory(id) for the full rule) ` +
+    `instead of inventing variant tags that fragment recall:\n` +
+    lines.join("\n") +
+    `\n</vault-taxonomy>`
+  );
+}
+
+function fetchTaxonomy(baseUrl: string, timeoutMs: number): Promise<ConventionLean[]> {
+  return new Promise((resolve_) => {
+    let url: URL;
+    try {
+      url = new URL("/hook/taxonomy", baseUrl);
+    } catch {
+      resolve_([]);
+      return;
+    }
+    const req = request(
+      {
+        method: "GET",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString("utf8")) as TaxonomyResponse;
+            if ((res.statusCode ?? 500) === 200 && Array.isArray(data.conventions)) {
+              resolve_(data.conventions);
+              return;
+            }
+          } catch { /* fallthrough */ }
+          resolve_([]);
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      resolve_([]);
+    });
+    req.on("error", () => resolve_([]));
+    req.end();
+  });
+}
+
 function probeHealth(baseUrl: string, timeoutMs: number): Promise<HealthResponse | null> {
   return new Promise((resolve_) => {
     let url: URL;
@@ -435,6 +520,7 @@ interface SessionHookTelemetry {
   daemon_url: string;
   daemon_reachable: boolean;
   hint_count: number;
+  convention_count: number;
   top_score: number | null;
   latency_ms_total: number;
   status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";

--- a/packages/daemon/src/stop-hook.ts
+++ b/packages/daemon/src/stop-hook.ts
@@ -26,6 +26,7 @@
  *   - Telemetry best-effort.
  */
 import { appendFile, mkdir, open } from "node:fs/promises";
+import { request } from "node:http";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
@@ -83,14 +84,22 @@ async function main(): Promise<void> {
   const last30 = turns.slice(-30);
   const suggestions = evaluateHeuristics(last30, { cwd: payload.cwd });
 
-  if (suggestions.length === 0) {
+  // Drift-Detektor (#67): unabhängig vom Transcript — der Daemon prüft, ob
+  // jüngste Memories ein wiederkehrendes Cluster ohne Taxonomie-Konvention
+  // bilden. Best-effort mit hartem Budget; Daemon weg → still.
+  const drift = await fetchDrift(250);
+
+  if (suggestions.length === 0 && drift.length === 0) {
     emitEmpty();
   } else {
     // Stop-Hook hat kein hookSpecificOutput im Claude-Code-Schema.
     // Nur top-level Felder erlaubt: continue, suppressOutput, stopReason,
     // decision, reason, systemMessage, terminalSequence, permissionDecision.
     // → systemMessage trägt den <save-eval>-Block (sichtbar für den Agent).
-    const blocks = suggestions.map(formatSuggestion).join("\n");
+    const blocks = [
+      ...suggestions.map(formatSuggestion),
+      ...(drift.length > 0 ? [formatDriftBlock(drift)] : []),
+    ].join("\n");
     process.stdout.write(
       JSON.stringify({
         systemMessage: blocks,
@@ -102,8 +111,86 @@ async function main(): Promise<void> {
   await writeTelemetry({
     heuristic: suggestions.map((s) => s.heuristic).join(",") || null,
     suggested_count: suggestions.length,
+    drift_clusters: drift.length,
     turn_count: turns.length,
     latency_ms_total: totalMs,
+  });
+}
+
+// ─── Taxonomie-Drift (#67) ───────────────────────────────────────
+
+interface DriftCluster {
+  key: string;
+  kind: "tag" | "topic";
+  count: number;
+  examples: string[];
+}
+
+/**
+ * Drift-Hinweis für den Agent. Suggestion-only — der Agent entscheidet im
+ * nächsten Turn, ob er eine Konvention etabliert; geschrieben wird hier nie.
+ */
+function formatDriftBlock(clusters: DriftCluster[]): string {
+  const lines = clusters.map(
+    (c) =>
+      `- ${c.count} recent memories share the ${c.kind} '${c.key}' with no ` +
+      `taxonomy convention covering it (e.g. ${c.examples.join(", ")}).`,
+  );
+  return (
+    `<taxonomy-drift>\n` +
+    `The vault is forming ad-hoc clusters without a home:\n` +
+    lines.join("\n") +
+    `\nIf a cluster is here to stay, establish a convention next turn: ` +
+    `save_memory with scope='taxonomy', tag 'convention', body = the rule ` +
+    `(folder, topic_path shape, tags, body shape, one example) — then re-file ` +
+    `the members (overwrite=true + the convention's folder). ` +
+    `Suggestion only: weigh it, ask the user if unsure, never bulk-move silently.\n` +
+    `</taxonomy-drift>`
+  );
+}
+
+function fetchDrift(timeoutMs: number): Promise<DriftCluster[]> {
+  return new Promise((resolve_) => {
+    const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
+    const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? "6723";
+    let url: URL;
+    try {
+      url = new URL("/hook/drift", httpURL ?? `http://127.0.0.1:${httpPort}`);
+    } catch {
+      resolve_([]);
+      return;
+    }
+    const req = request(
+      {
+        method: "GET",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+              clusters?: DriftCluster[];
+            };
+            if ((res.statusCode ?? 500) === 200 && Array.isArray(data.clusters)) {
+              resolve_(data.clusters);
+              return;
+            }
+          } catch { /* fallthrough */ }
+          resolve_([]);
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      resolve_([]);
+    });
+    req.on("error", () => resolve_([]));
+    req.end();
   });
 }
 
@@ -447,6 +534,7 @@ function readStdin(): Promise<string> {
 interface StopHookTelemetry {
   heuristic: string | null;
   suggested_count: number;
+  drift_clusters: number;
   turn_count: number;
   latency_ms_total: number;
 }

--- a/packages/daemon/src/taxonomy.ts
+++ b/packages/daemon/src/taxonomy.ts
@@ -1,0 +1,141 @@
+/**
+ * Selbstlernende Taxonomie (#64) — Daemon-Seite.
+ *
+ * Zwei Bausteine:
+ *   - listConventions(): die Konventions-Memories aus dem reservierten Scope
+ *     "taxonomy" (#65), kompakt für die Session-Hook-Injection (#66). Bewusst
+ *     ein Listen-Endpoint statt Suche — Konventionen sind bindende Regeln und
+ *     dürfen nicht am Recall-Score-Floor sterben.
+ *   - detectTaxonomyDrift(): erkennt, wenn jüngste Memories wiederholt
+ *     dasselbe Ad-hoc-Cluster bilden (gemeinsamer Tag / topic_path-Bereich),
+ *     ohne dass eine Konvention es abdeckt (#67). Suggestion-only — der
+ *     Stop-Hook formatiert daraus einen Hinweis; geschrieben wird nie
+ *     automatisch.
+ */
+import type { Vault } from "@bastra-recall/core";
+import { envInt } from "./env.js";
+
+export interface ConventionLean {
+  id: string;
+  title: string;
+  summary: string;
+  updated: string;
+}
+
+export const TAXONOMY_SCOPE = "taxonomy";
+
+export function listConventions(vault: Vault, cap = 12): ConventionLean[] {
+  return vault
+    .list()
+    .filter((m) => m.fm.scope === TAXONOMY_SCOPE && !m.fm.obsolete)
+    .sort((a, b) => String(b.fm.updated).localeCompare(String(a.fm.updated)))
+    .slice(0, cap)
+    .map((m) => ({
+      id: m.fm.id,
+      title: m.fm.title,
+      summary: m.fm.summary,
+      updated: String(m.fm.updated),
+    }));
+}
+
+export interface DriftCluster {
+  /** Normalisierter Cluster-Schlüssel, z.B. "person" oder "deployment". */
+  key: string;
+  kind: "tag" | "topic";
+  /** Distinkte Memories im Fenster, die den Schlüssel teilen. */
+  count: number;
+  /** Bis zu 3 Beispiel-Memory-Ids. */
+  examples: string[];
+}
+
+/** Memory-Typen + strukturelle Werte, die als Cluster-Schlüssel nur Rauschen
+ *  wären (jedes lesson-Memory trägt den Tag-Kandidaten "lesson" implizit). */
+const NOISE_KEYS = new Set([
+  "lesson",
+  "preference",
+  "project-fact",
+  "meta-working",
+  "decision",
+  "workflow",
+  "reference",
+  "user-preference",
+  "bookmark",
+  "doc",
+  "convention",
+]);
+
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/**
+ * Wiederkehrende Cluster ohne Konvention finden.
+ *
+ * Heuristik (bewusst konservativ — lieber still als nervig):
+ *   - Fenster: Memories mit `updated` in den letzten BASTRA_DRIFT_WINDOW_DAYS
+ *     (Default 14).
+ *   - Schlüssel-Kandidaten pro Memory: jeder Tag plus jedes
+ *     topic_path-Segment AB Index 1 (Segment 0 ist fast immer der Projekt-/
+ *     Scope-Name — der hat mit memories/projects/<scope>/ schon eine Heimat).
+ *   - Cluster ab BASTRA_DRIFT_MIN_CLUSTER (Default 3) distinkten Memories.
+ *   - Abgedeckt = eine Konvention (scope=taxonomy) erwähnt den Schlüssel in
+ *     tags, topic_path oder Titel — dann ist das Cluster gelernt und still.
+ *   - Scope-Namen selbst und Memory-Typen sind nie Schlüssel (Rauschen).
+ *   - Maximal 2 Vorschläge, größtes Cluster zuerst.
+ */
+export function detectTaxonomyDrift(vault: Vault, now: number = Date.now()): DriftCluster[] {
+  const windowDays = envInt("BASTRA_DRIFT_WINDOW_DAYS", 14);
+  const minCluster = envInt("BASTRA_DRIFT_MIN_CLUSTER", 3);
+  const cutoff = now - windowDays * 86_400_000;
+
+  const all = vault.list();
+
+  // Coverage-Korpus: was bestehende Konventionen bereits benennen.
+  const covered = new Set<string>();
+  for (const c of all) {
+    if (c.fm.scope !== TAXONOMY_SCOPE || c.fm.obsolete) continue;
+    for (const t of c.fm.tags) covered.add(norm(t));
+    for (const seg of c.fm.topic_path) covered.add(norm(seg));
+    for (const w of c.fm.title.toLowerCase().split(/[^a-zäöüß0-9_-]+/u)) {
+      if (w.length >= 3) covered.add(w);
+    }
+  }
+
+  // Scope-Namen sind strukturell, keine Drift-Kandidaten.
+  const scopeNames = new Set(all.map((m) => norm(m.fm.scope)));
+
+  const clusters = new Map<string, { kind: "tag" | "topic"; ids: Set<string> }>();
+  for (const m of all) {
+    if (m.fm.scope === TAXONOMY_SCOPE || m.fm.obsolete) continue;
+    const updatedMs = Date.parse(String(m.fm.updated));
+    if (!Number.isFinite(updatedMs) || updatedMs < cutoff) continue;
+
+    const candidates = new Map<string, "tag" | "topic">();
+    for (const t of m.fm.tags) candidates.set(norm(t), "tag");
+    for (const seg of m.fm.topic_path.slice(1)) {
+      const k = norm(seg);
+      if (!candidates.has(k)) candidates.set(k, "topic");
+    }
+    for (const [key, kind] of candidates) {
+      if (key.length < 3) continue;
+      if (NOISE_KEYS.has(key) || scopeNames.has(key) || covered.has(key)) continue;
+      let entry = clusters.get(key);
+      if (!entry) {
+        entry = { kind, ids: new Set() };
+        clusters.set(key, entry);
+      }
+      entry.ids.add(m.fm.id);
+    }
+  }
+
+  return [...clusters.entries()]
+    .filter(([, v]) => v.ids.size >= minCluster)
+    .sort((a, b) => b[1].ids.size - a[1].ids.size)
+    .slice(0, 2)
+    .map(([key, v]) => ({
+      key,
+      kind: v.kind,
+      count: v.ids.size,
+      examples: [...v.ids].slice(0, 3),
+    }));
+}

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -12,6 +12,8 @@
 import { z } from "zod";
 import {
   saveMemory,
+  slugify,
+  moveToTrash,
   truncateSummaryTo,
   SaveMemoryInput,
   stripAutoRelatedSection,
@@ -513,7 +515,30 @@ export async function saveMemoryHandler(
 
   const saveQuality = scoreSaveQuality(deps, parsed.data);
 
+  // Re-Filing (#64): Wenn die id schon indexiert ist, aber der neue Save sie
+  // woanders ablegt (geänderte folder/scope-Konvention), würde saveMemory nur
+  // den NEUEN Pfad auf Kollision prüfen — die alte Datei bliebe als Duplikat
+  // mit derselben id liegen. Deshalb: ohne overwrite ablehnen, mit overwrite
+  // die alte Datei in den Trash verschieben (recoverbar, kein Hard-Delete).
+  const finalId = parsed.data.id ?? slugify(parsed.data.title);
+  const previous = deps.vault.get(finalId);
+  if (previous && !parsed.data.overwrite) {
+    throw new Error(
+      `memory already exists: ${finalId} (at ${previous.filePath}). ` +
+        `Pass overwrite=true to replace it — a changed folder/scope moves the file.`,
+    );
+  }
+
   const result = await saveMemory(deps.vaultPath, parsed.data);
+  if (previous && previous.filePath !== result.file_path) {
+    try {
+      await moveToTrash(deps.vaultPath, previous.filePath, finalId);
+      deps.vault.forgetFile(previous.filePath);
+    } catch (err) {
+      // Alte Datei schon weg (extern gelöscht/verschoben) → nichts aufzuräumen.
+      console.error(`[bastra-recall] re-file: could not trash old path: ${(err as Error).message}`);
+    }
+  }
   // Don't trust the watcher on cloud-storage mounts — force-index now
   // so a follow-up recall() in the same session sees the new memory.
   await deps.vault.reindexFile(result.file_path);
@@ -695,6 +720,23 @@ export const MEMORY_TOOL_DEFS: ToolDef[] = [
       "  'about to write a Tailwind grid' beats 'CSS questions'. Without " +
       "  good recall_when, the memory is dead weight.\n" +
       "\n" +
+      "TAXONOMY CONVENTIONS (self-learning vault structure):\n" +
+      "- The vault can teach itself new categories. A convention is a " +
+      "  memory in the reserved scope 'taxonomy' that names a cluster " +
+      "  and fixes its axes: folder, topic_path shape, tags, body shape.\n" +
+      "- BEFORE saving into a recurring cluster (people, places, tools, " +
+      "  …): recall('taxonomy convention <cluster>') — if a convention " +
+      "  exists, FOLLOW it exactly (its folder/topic_path/tags), do not " +
+      "  invent variant tags that fragment recall.\n" +
+      "- When you notice the same ad-hoc cluster for the third time " +
+      "  without a convention, establish one: save a memory with " +
+      "  scope='taxonomy', tag 'convention', body = the rule (axes + " +
+      "  folder + body shape + one example), then apply it. Use the " +
+      "  `folder` arg so members get a real home (e.g. 'memories/people').\n" +
+      "- Re-filing: overwrite=true with a new folder MOVES the memory " +
+      "  (old file goes to the vault trash) — use this to migrate " +
+      "  existing memories under a new convention.\n" +
+      "\n" +
       "AFTER SAVING: surface a single-line ack to the user, prefixed " +
       "with `→`: `→ saved: <title> (id: <id>)`. Nothing more.",
     inputSchema: {
@@ -753,7 +795,18 @@ export const MEMORY_TOOL_DEFS: ToolDef[] = [
           type: "string",
           description:
             "Project/area this memory belongs to, e.g. 'bastra-recall', " +
-            "'carnexus', 'user-preference', 'all-projects'.",
+            "'carnexus', 'user-preference', 'all-projects'. The scope " +
+            "'taxonomy' is reserved for convention memories (self-learned " +
+            "vault structure rules).",
+        },
+        folder: {
+          type: "string",
+          description:
+            "Optional target folder relative to the vault root (e.g. " +
+            "'memories/people'). Overrides the default scope/type routing — " +
+            "use it when a taxonomy convention assigns this cluster a home. " +
+            "With overwrite=true a changed folder MOVES the memory (old " +
+            "file is trashed, recoverable).",
         },
         recall_when: {
           type: "array",

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -134,6 +134,43 @@ When you complete the **next** version of a feature you already have a topology 
 
 ---
 
+## Self-learning taxonomy — let the vault grow its own structure
+
+The vault can teach itself new categories on the free axes (`folder`,
+`topic_path`, `tags`) — the closed `type` enum stays untouched. A **convention**
+is a memory in the reserved scope `taxonomy` (tag `convention`) that fixes how a
+recurring cluster is stored: its folder, topic_path shape, tags, and body shape.
+Active conventions arrive at session start in a `<vault-taxonomy>` block.
+
+### Apply (always)
+
+Before saving into a recurring cluster (people, places, tools, …): check the
+injected conventions — or `recall("taxonomy convention <cluster>")`. If one
+covers the cluster, **follow it exactly** (its `folder`/`topic_path`/`tags`).
+Never invent variant tags for a covered cluster; that fragments recall.
+
+### Establish (when a cluster recurs without a home)
+
+When you notice the same ad-hoc cluster for the third time — or the stop hook
+surfaces a `<taxonomy-drift>` suggestion — establish a convention:
+
+1. `save_memory` with `scope: "taxonomy"`, `type: "workflow"`, tags
+   `["convention", "<cluster-key>"]`, body = the rule (folder, topic_path
+   shape, tags, body shape, one worked example).
+2. Apply it immediately to the memory you were about to save (use the
+   `folder` arg so members get a real home, e.g. `memories/people`).
+3. Re-file existing members: `save_memory` with `overwrite: true` + the
+   convention's `folder` **moves** a memory (old file goes to the vault
+   trash, recoverable). Split collection memos into one-memory-per-entity
+   while you're at it, and link them with `[[wikilinks]]` instead of
+   restating their story.
+
+Conventions are living rules: refresh with `overwrite=true`, never fork a
+`-v2`. For bulk re-filing (>5 memories at once), tell the user what you're
+about to move first.
+
+---
+
 ## Tone with the user
 
 - If you load a memory and apply it, you don't need to mention it unless asked. Just behave correctly. Silence is the best compliment to a working memory.


### PR DESCRIPTION
Implements the **Community — Self-learning memory taxonomy** milestone (#64): closes #65, closes #66, closes #67. The #68 pilot (person convention + per-person split) runs vault-side once this lands.

## The loop

**notice → record → apply**, built from the vault's own memory, entirely on the free axes (`scope`/`topic_path`/`tags`/`folder`). The closed `type` enum is untouched; everything is per-vault.

## What's in here

- **Enabler — `folder` arg on `save_memory`** (core): optional target folder relative to the vault root (path-safe, containment-checked, reusing the #99 guards). Conventions can establish real structure like `memories/people/`. Reserved scope `taxonomy` → `memories/taxonomy/` (#65).
- **Enabler — re-filing** (daemon): `overwrite=true` with a changed target path **moves** the memory — old file goes to `.bastra/trash/` (recoverable), index updated immediately via the new `Vault.forgetFile()`. Without `overwrite` the collision is rejected with a clear message.
- **#65 — contract**: [docs/taxonomy.md](docs/taxonomy.md) defines the convention-memory format (cluster, rule, worked `person` example); SKILL.md gains apply/establish guidance; the `save_memory` tool description teaches the contract to agents.
- **#66 — hook injection**: the session hook fetches `GET /hook/taxonomy` (dedicated list endpoint — conventions are binding rules and must not die at the recall score floor) and injects a `<vault-taxonomy>` block. Budgeted, fail-silent.
- **#67 — drift detector**: `detectTaxonomyDrift()` flags clusters of ≥ `BASTRA_DRIFT_MIN_CLUSTER` (3) recent memories sharing a tag / sub-project topic segment with no covering convention; scope names and memory types never count. The stop hook surfaces at most two clusters as a `<taxonomy-drift>` suggestion — suggestion only, never auto-written.
- **Docs**: README EN+DE (taxonomy section; also adds the `BASTRA_ALLOWED_HOSTS` DNS-rebinding bullet that #99 forgot), hooks.md (new endpoints + env vars).

## Verify

```bash
npm run build && npm run check:types && npm test
```

209/209 tests green — 7 new in `packages/daemon/__tests__/taxonomy.test.ts`: conventions listing, drift fire/covered/stale cases, folder routing, move-on-overwrite (old file in trash, index follows), traversal rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)