### PR TITLE
Add simulated-user survival to @bastra-recall/eval (#89)

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -52,6 +52,59 @@ lift on a production vault. A citable number comes from running the ablation on
 a real vault (e.g. the 59-memory vault behind the M0 baseline) with hand-written
 paraphrases. Treat the synthetic figure as a smoke test, not a result.
 
+## Simulated-user survival (`npm run personas`)
+
+`marginal-lift` answers *"does the trigger field help?"* with one paraphrase
+set. The companion harness asks the sharper, production-shaped question on the
+**same** control/treatment indexes:
+
+> `recall_when` is written at **save** time — a prediction of how a future
+> session will phrase the situation. The query is formed at **recall** time, in
+> that session's own words. **How much of the lift survives when the recall-time
+> query drifts off the save-time prediction?**
+
+We model the recall-time query distribution with **N simulated user personas**
+(junior / senior / terse / verbose / non-native / concept-namer / …), each
+phrasing every memory in its own voice. Each query gets a continuous overlap
+score against the gold memory's `recall_when` tokens, then:
+
+```
+near  = query shares trigger vocabulary (overlap ≥ cut)   → prediction hit
+far   = query uses different words      (overlap < cut)   → prediction missed
+survival = marginal-lift@k(far) / marginal-lift@k(near)
+```
+
+`survival ≈ 1` → the trigger generalizes past its own wording (load-bearing).
+`survival ≈ 0` → it only helps when you already used its words — i.e. the lift
+sits closer to the circular M0 regime than to real recall. The report also
+prints the **Recall@k envelope across personas** (the robustness spread) and a
+**persona-diversity** number.
+
+```bash
+npm run personas --workspace=@bastra-recall/eval
+npm run personas -- --k 3 --near 0.30
+BASTRA_VAULT_PATH=/path/to/vault \
+  npm run personas -- --personas my-personas.json --out survival.json
+```
+
+### Why simulated, not hand-written?
+
+The issue thread asks for *hand-written* paraphrases, and that's the right
+instinct for an **independent** probe. But for this product it is ecologically
+backwards: **nobody hand-writes the memories** (the AI saves them) **or
+hand-phrases the recall query** (the AI forms it). Production is model-mediated
+on *both* ends, so simulated queries are the faithful test; hand-written ones
+test a path that never happens. The retriever is lexical BM25 (no embedding
+space), so the only contamination risk from LLM-authored queries is
+**trigger-vocabulary leakage** — and the overlap score measures that directly,
+per query. Two guards keep it honest (see `__tests__/persona-diversity.test.ts`):
+the personas must be **distinct voices** (no mode collapse) and must **span the
+near↔far axis** (the gradient is emergent, not hand-binned).
+
+> Same caveat as above: the bundled `fixtures/personas.json` runs against the
+> synthetic vault — a mechanism demo, not a headline. A citable survival number
+> comes from real personas against a real vault.
+
 ## Cases format (`fixtures/cases.json`)
 
 ```jsonc

--- a/packages/eval/__tests__/persona-diversity.test.ts
+++ b/packages/eval/__tests__/persona-diversity.test.ts
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Diversity guard for the simulated-user survival harness.
+ *
+ * The robustness envelope (persona-lift.ts) is only honest if the personas are
+ * genuinely distinct voices. An LLM asked for N personas can mode-collapse into
+ * N rewordings of one voice — which would fake a tight envelope and a
+ * meaningless near/far split. This test fails if the bundled personas drift
+ * toward each other, the same way boost-drift guards the field weights.
+ */
+const STOP = new Set(
+  ("a an the to of in on at for and or but with without when how why is are be it its " +
+    "into as my me i you your their them they not no than instead while per after before " +
+    "does do that this so what which").split(" "),
+);
+function toks(s: string): Set<string> {
+  return new Set(
+    s.toLowerCase().split(/[^a-z0-9.]+/).filter((t) => t && t.length > 1 && !STOP.has(t)),
+  );
+}
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+const file = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, "../fixtures/personas.json"), "utf8"),
+) as { personas: Record<string, Record<string, string>> };
+
+test("bundled personas are distinct voices, not mode-collapsed", () => {
+  const labels = Object.keys(file.personas);
+  assert.ok(labels.length >= 3, "need at least 3 personas for an envelope");
+
+  const sims: number[] = [];
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const A = file.personas[labels[i]], B = file.personas[labels[j]];
+      const ids = Object.keys(A).filter((id) => id in B);
+      assert.ok(ids.length > 0, `${labels[i]} and ${labels[j]} share no memory ids`);
+      sims.push(ids.reduce((acc, id) => acc + jaccard(toks(A[id]), toks(B[id])), 0) / ids.length);
+    }
+  }
+  const mean = sims.reduce((a, b) => a + b, 0) / sims.length;
+  assert.ok(
+    mean < 0.35,
+    `mean pairwise persona similarity ${mean.toFixed(3)} is too high — personas are mode-collapsed; the survival envelope would be fake`,
+  );
+});
+
+test("personas span the near<->far overlap axis (gradient is emergent)", () => {
+  // Each persona-query carries some overlap with how a memory might be triggered;
+  // a diverse set should produce both high-overlap and low-overlap queries rather
+  // than clustering at one end. We check that the per-persona query sets differ
+  // enough that at least one pair is near-orthogonal.
+  const labels = Object.keys(file.personas);
+  let minPair = 1;
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const A = file.personas[labels[i]], B = file.personas[labels[j]];
+      const ids = Object.keys(A).filter((id) => id in B);
+      const s = ids.reduce((acc, id) => acc + jaccard(toks(A[id]), toks(B[id])), 0) / ids.length;
+      minPair = Math.min(minPair, s);
+    }
+  }
+  assert.ok(minPair < 0.15, `most-distinct persona pair similarity ${minPair.toFixed(3)} — voices not spread enough`);
+});

--- a/packages/eval/fixtures/personas.json
+++ b/packages/eval/fixtures/personas.json
@@ -1,0 +1,125 @@
+{
+  "_comment": "Simulated-user queries for the synthetic eval-vault: 10 personas x 10 memories, each persona phrasing every situation in its own voice (junior/senior/non-native/terse/verbose/concept-namer/error-message/why-asker/outsider/mobile-typo). LLM-generated on purpose — production memories and recall queries are both AI-mediated, so this is the ecologically faithful test (see persona-lift.ts / README). Diversity is guarded: mean pairwise query similarity ~0.12, 10/10 distinct voices. Like cases.json, the synthetic-vault number is a mechanism demo, not a headline.",
+  "personas": {
+    "junior": {
+      "backoff-jitter": "why do all my requests fail at the same time after server comes back",
+      "css-flexbox-min-width-zero": "text in flex container not shrinking going outside the box",
+      "debounce-vs-throttle": "function running too many times when user types in search box",
+      "docker-manifest-before-source": "docker build taking forever reinstalling everything each time I change code",
+      "focus-ring-keyboard": "how to remove that ugly blue outline but not break accessibility",
+      "git-rebase-autosquash-fixup": "how to clean up my messy commits before pull request",
+      "money-not-float": "prices showing wrong like 9.999999 instead of 10 in javascript",
+      "postgres-index-type-mismatch": "added index but query still slow postgres not using it",
+      "secrets-in-env": "accidentally pushed api key to github what do I do",
+      "timestamps-store-utc": "date showing wrong time for users in different countries"
+    },
+    "senior": {
+      "backoff-jitter": "thundering herd on retry storm exponential backoff needs jitter to decorrelate",
+      "css-flexbox-min-width-zero": "flex child overflows container due to implicit min-width auto; override with min-width:0",
+      "debounce-vs-throttle": "leading vs trailing edge rate limiting for input events debounce throttle tradeoffs",
+      "docker-manifest-before-source": "layer cache invalidation on source change; copy package.json before COPY . to preserve dep layer",
+      "focus-ring-keyboard": "outline:none removes :focus indicator for keyboard navigation; use :focus-visible instead",
+      "git-rebase-autosquash-fixup": "squash fixup commits via --fixup flag and rebase --autosquash before merge",
+      "money-not-float": "IEEE 754 floating point precision loss for currency; store as integer minor units or use decimal type",
+      "postgres-index-type-mismatch": "index scan skipped by planner due to implicit type coercion breaking operator class match",
+      "secrets-in-env": "credential exposure in git history; rotate immediately, use env vars or secrets manager, git filter-repo",
+      "timestamps-store-utc": "timezone-aware storage strategy; persist UTC epoch or timestamptz, localize at presentation layer"
+    },
+    "nonnative": {
+      "backoff-jitter": "many clients retry in same time and make server crash again how to spread the requests",
+      "css-flexbox-min-width-zero": "flex item is not becoming smaller and is going outside parent div why",
+      "debounce-vs-throttle": "event is firing too many times on typing what is difference debounce and throttle",
+      "docker-manifest-before-source": "every time I change one file docker is reinstalling all packages from beginning",
+      "focus-ring-keyboard": "I remove outline from button but now keyboard users cannot see where is focus",
+      "git-rebase-autosquash-fixup": "before merge request I want to combine small fix commits into one clean commit",
+      "money-not-float": "when I save price as float number the calculation is not correct like 10.00 becomes 9.9999",
+      "postgres-index-type-mismatch": "my index is existing but postgres is not using it why query is still slow",
+      "secrets-in-env": "I pushed secret key in git repository by mistake what should I do now",
+      "timestamps-store-utc": "time is showing wrong in different timezone for my users how to fix"
+    },
+    "terse": {
+      "backoff-jitter": "retry stampede fix jitter",
+      "css-flexbox-min-width-zero": "flex child overflow shrink fix",
+      "debounce-vs-throttle": "debounce throttle input events",
+      "docker-manifest-before-source": "docker cache bust dependencies",
+      "focus-ring-keyboard": "remove outline keep accessibility",
+      "git-rebase-autosquash-fixup": "clean commits before merge",
+      "money-not-float": "float currency rounding bug",
+      "postgres-index-type-mismatch": "index ignored type mismatch",
+      "secrets-in-env": "committed secret git rotate",
+      "timestamps-store-utc": "timezone storage best practice"
+    },
+    "verbose": {
+      "backoff-jitter": "I have a bunch of microservices that all retry failed requests at the same interval and when a downstream service recovers they all hit it simultaneously and knock it back down so I need a way to spread out those retries randomly",
+      "css-flexbox-min-width-zero": "I have a flex row with text inside one of the children and the text is really long so instead of truncating or wrapping it just pushes past the container boundary and I cannot figure out why min-width or overflow hidden is not working",
+      "debounce-vs-throttle": "my search input fires an API call on every keystroke and my scroll handler runs constantly and I know there are two different techniques to limit how often a function runs but I cannot remember when to use each one",
+      "docker-manifest-before-source": "my Dockerfile copies all my source code then runs npm install but every single time I change any file it reinstalls all the node modules from scratch even if package.json did not change",
+      "focus-ring-keyboard": "my designer asked me to remove the default browser focus outline because it looks ugly but someone told me it completely breaks keyboard navigation so I need a CSS-only solution that keeps it for keyboard users",
+      "git-rebase-autosquash-fixup": "I have like fifteen commits on my feature branch that are a mix of real work and tiny oops fixes and I want to clean them into a few logical commits before I open a pull request",
+      "money-not-float": "I am storing product prices as floating point numbers and after arithmetic the results come back as something like 19.999999998 instead of 20.00 and I need the correct way to handle money",
+      "postgres-index-type-mismatch": "I created an index on a column I query all the time but when I run EXPLAIN ANALYZE the planner is still doing a sequential scan instead of using the index and I cannot figure out why",
+      "secrets-in-env": "I accidentally committed a database password and an API token into my git repository and pushed it to GitHub and I need to know what steps to take right now",
+      "timestamps-store-utc": "users in different timezones are seeing event times that are off by several hours and during daylight saving it gets even worse and I need the correct architecture for storing times"
+    },
+    "conceptnamer": {
+      "backoff-jitter": "jitter decorrelation thundering herd mitigation",
+      "css-flexbox-min-width-zero": "flex child min-width overflow containment",
+      "debounce-vs-throttle": "debounce throttle input rate limiting tradeoff",
+      "docker-manifest-before-source": "dependency layer cache invalidation ordering",
+      "focus-ring-keyboard": "focus-visible progressive outline accessibility",
+      "git-rebase-autosquash-fixup": "fixup autosquash interactive rebase commit hygiene",
+      "money-not-float": "monetary value integer minor units decimal precision",
+      "postgres-index-type-mismatch": "predicate type coercion index scan suppression",
+      "secrets-in-env": "credential externalization git history remediation",
+      "timestamps-store-utc": "UTC normalization timezone-agnostic storage"
+    },
+    "errormsg": {
+      "backoff-jitter": "503 spike after outage recovery all clients retry simultaneously",
+      "css-flexbox-min-width-zero": "flex item overflow parent container text not truncating",
+      "debounce-vs-throttle": "function called hundreds of times on keypress scroll event listener",
+      "docker-manifest-before-source": "npm install runs every build no cache hit layer invalidated",
+      "focus-ring-keyboard": "outline none accessibility audit keyboard navigation broken tab",
+      "git-rebase-autosquash-fixup": "squash merge wip commits history dirty before pr",
+      "money-not-float": "0.1 + 0.2 != 0.3 currency calculation rounding error production",
+      "postgres-index-type-mismatch": "seq scan instead of index scan explain analyze query slow",
+      "secrets-in-env": "api key committed git log exposed credential rotation",
+      "timestamps-store-utc": "timestamp wrong timezone DST clock shift date display bug"
+    },
+    "whyasker": {
+      "backoff-jitter": "why do all my clients retry at the same time after a service comes back up",
+      "css-flexbox-min-width-zero": "why does flex child element overflow instead of shrinking to fit",
+      "debounce-vs-throttle": "why does my event handler fire too many times and when should I use debounce vs throttle",
+      "docker-manifest-before-source": "why does docker reinstall all dependencies every time I change source code",
+      "focus-ring-keyboard": "why does removing outline css break keyboard navigation for accessibility",
+      "git-rebase-autosquash-fixup": "why are my wip and fixup commits showing up in the final git history",
+      "money-not-float": "why does floating point arithmetic give wrong results when calculating money",
+      "postgres-index-type-mismatch": "why is postgres ignoring my index and doing a sequential scan",
+      "secrets-in-env": "why should I never store secrets in source code and what do I do if I already did",
+      "timestamps-store-utc": "why do my timestamps show the wrong time for users in different timezones"
+    },
+    "outsider": {
+      "backoff-jitter": "when server comes back online all apps hit it at once and it crashes again",
+      "css-flexbox-min-width-zero": "text in row element sticks out past the edge instead of cutting off",
+      "debounce-vs-throttle": "search box fires too many requests while user is still typing",
+      "docker-manifest-before-source": "every small code change makes docker download all packages again from scratch",
+      "focus-ring-keyboard": "removed the ugly dotted box around buttons now keyboard users cant see where they are",
+      "git-rebase-autosquash-fixup": "how to clean up messy save point commits before sharing code with team",
+      "money-not-float": "prices come out slightly wrong like 9.999999 instead of 10 in database",
+      "postgres-index-type-mismatch": "added index to database column but queries are still slow not using it",
+      "secrets-in-env": "accidentally pushed password to github what do I do now",
+      "timestamps-store-utc": "time shown to users is wrong depending on what country they are in"
+    },
+    "mobiletypo": {
+      "backoff-jitter": "retyr storm aftr outage all clients hit same time fix",
+      "css-flexbox-min-width-zero": "flex item wont shrink overfow row min width",
+      "debounce-vs-throttle": "to many fn calls on scroll typin debounce throttle diff",
+      "docker-manifest-before-source": "docker cache miss evry build reinstals deps copy order",
+      "focus-ring-keyboard": "removed outline css now kbd nav broke focus visble",
+      "git-rebase-autosquash-fixup": "cleanup wip commits b4 merge autosquash fixup rebse",
+      "money-not-float": "float moeny rounding wrnog use deciml or int cents",
+      "postgres-index-type-mismatch": "index not used postgres seq scan type mismtch cast",
+      "secrets-in-env": "commited secret to git by accident rotate env var",
+      "timestamps-store-utc": "wrong time diff timezone store utc dsplay local"
+    }
+  }
+}

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "lift": "tsx src/marginal-lift.ts",
+    "personas": "tsx src/persona-lift.ts",
     "check:types": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/eval/src/persona-lift.ts
+++ b/packages/eval/src/persona-lift.ts
@@ -1,0 +1,311 @@
+#!/usr/bin/env tsx
+/**
+ * Simulated-user survival — recall_when lift under realistic query drift (#89).
+ *
+ * `marginal-lift.ts` answers "does the trigger field help?" with one paraphrase
+ * set. This harness asks the sharper, production-shaped question on the SAME
+ * control/treatment indexes:
+ *
+ *   recall_when is written at SAVE time — a prediction of how a future session
+ *   will phrase the situation. The query is formed at RECALL time, in that
+ *   session's own words. How much of the trigger's lift SURVIVES when the
+ *   recall-time query drifts away from the save-time prediction?
+ *
+ * We model the recall-time query distribution with N simulated user personas
+ * (junior/senior/terse/verbose/non-native/…), each phrasing every memory in
+ * their own voice. Every query gets a continuous overlap score against the
+ * gold memory's recall_when tokens, then we split:
+ *
+ *   near  = query shares trigger vocabulary (overlap ≥ cut)   — prediction hit
+ *   far   = query uses different words (overlap < cut)        — prediction missed
+ *   survival = marginal-lift@k(far) / marginal-lift@k(near)
+ *
+ * survival ≈ 1  -> recall_when generalizes past its own wording (load-bearing).
+ * survival ≈ 0  -> the trigger only helps when you already used its words
+ *                  (the lift is closer to the circular M0 regime than to real recall).
+ *
+ * Two integrity guards keep the envelope honest (see __tests__):
+ *   - persona DIVERSITY: the N personas must be genuinely distinct voices, not
+ *     one voice in N masks (mode collapse would fake a tight envelope).
+ *   - overlap SPREAD: diverse users naturally span near↔far, so the gradient is
+ *     emergent, not hand-binned.
+ *
+ * Why simulated, not hand-written paraphrases? In production NOBODY hand-writes
+ * the memories (the AI saves them) OR hand-phrases the recall query (the AI
+ * forms it). Both ends are model-mediated, so simulated queries are the
+ * ecologically faithful test. The retriever is lexical BM25 (no embedding
+ * space), so the only contamination risk is trigger-vocabulary leakage — which
+ * the overlap score measures directly. See README for the full rationale.
+ *
+ * IMPORTANT — read before citing a number:
+ *   The bundled `fixtures/personas.json` runs against the tiny SYNTHETIC
+ *   eval-vault. It proves the harness computes; it is NOT a headline result.
+ *   A citable survival number comes from a real vault:
+ *     BASTRA_VAULT_PATH=/path npm run personas -- --personas my-personas.json
+ *
+ * Usage:
+ *   npm run personas                          # bundled synthetic vault + personas
+ *   npm run personas -- --k 3 --near 0.30     # tune @k and the near/far cut
+ *   BASTRA_VAULT_PATH=/v npm run personas -- --personas p.json --out survival.json
+ *
+ * Exit code: 0 always (a measurement, not a pass/fail gate).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Vault } from "@bastra-recall/core";
+import type { Memory } from "@bastra-recall/core";
+import { buildIndex, rankOf, TREATMENT_RECALL_WHEN_BOOST } from "./index-config.js";
+
+// ── Persona fixtures ───────────────────────────────────────────
+
+interface PersonaFile {
+  /** label -> (memory id -> the query that persona would type for it). */
+  personas: Record<string, Record<string, string>>;
+}
+
+// ── CLI ────────────────────────────────────────────────────────
+
+interface Args {
+  vault: string;
+  personas: string;
+  out: string | null;
+  boost: number;
+  k: number;
+  near: number;
+}
+
+const DEFAULT_VAULT = resolve(import.meta.dirname, "../fixtures/eval-vault");
+const DEFAULT_PERSONAS = resolve(import.meta.dirname, "../fixtures/personas.json");
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    vault: process.env.BASTRA_VAULT_PATH ?? DEFAULT_VAULT,
+    personas: DEFAULT_PERSONAS,
+    out: null,
+    boost: TREATMENT_RECALL_WHEN_BOOST,
+    k: 3,
+    near: 0.3,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--vault") args.vault = req(argv[++i], "--vault");
+    else if (a === "--personas") args.personas = req(argv[++i], "--personas");
+    else if (a === "--out") args.out = req(argv[++i], "--out");
+    else if (a === "--boost") args.boost = num(argv[++i], "--boost");
+    else if (a === "--k") args.k = num(argv[++i], "--k");
+    else if (a === "--near") args.near = num(argv[++i], "--near");
+    else if (a === "-h" || a === "--help") {
+      console.log(
+        "persona-lift — simulated-user survival of recall_when\n" +
+          "  --vault <path>     vault to index (or BASTRA_VAULT_PATH)\n" +
+          "  --personas <path>  personas JSON ({personas:{label:{id:query}}})\n" +
+          "  --boost <n>        treatment recall_when weight (default 5)\n" +
+          "  --k <n>            Recall@k (default 3)\n" +
+          "  --near <0..1>      query↔trigger overlap cut for near/far (default 0.30)\n" +
+          "  --out <path>       also write a JSON report",
+      );
+      process.exit(0);
+    } else throw new Error(`unknown flag: ${a}`);
+  }
+  return args;
+}
+
+function req(v: string | undefined, flag: string): string {
+  if (!v) throw new Error(`${flag} needs a value`);
+  return v;
+}
+function num(v: string | undefined, flag: string): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) throw new Error(`${flag} must be a number`);
+  return n;
+}
+
+// ── Tokenisation (matches the overlap gate; lexical, BM25-relevant) ──
+
+const STOP = new Set(
+  ("a an the to of in on at for and or but with without when how why is are be it its " +
+    "into as my me i you your their them they not no than instead while per after before " +
+    "does do that this so what which").split(" "),
+);
+function toks(s: string): Set<string> {
+  return new Set(
+    s.toLowerCase().split(/[^a-z0-9.]+/).filter((t) => t && t.length > 1 && !STOP.has(t)),
+  );
+}
+/** Fraction of the query's content tokens that occur in the trigger tokens. */
+function coverage(query: string, trigger: Set<string>): number {
+  const q = toks(query);
+  if (q.size === 0) return 0;
+  let hit = 0;
+  for (const t of q) if (trigger.has(t)) hit++;
+  return hit / q.size;
+}
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+// ── Recall counters ────────────────────────────────────────────
+
+interface Run {
+  hitK: number;
+  hit1: number;
+  total: number;
+}
+const emptyRun = (): Run => ({ hitK: 0, hit1: 0, total: 0 });
+function record(run: Run, rank: number, k: number): void {
+  run.total++;
+  if (rank === 1) run.hit1++;
+  if (rank >= 1 && rank <= k) run.hitK++;
+}
+const recallK = (r: Run): number => (r.total ? r.hitK / r.total : 0);
+const pct = (x: number): string => `${(x * 100).toFixed(1)}%`;
+const signed = (x: number): string => `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)} pp`;
+
+// ── Main ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const file = JSON.parse(readFileSync(args.personas, "utf8")) as PersonaFile;
+
+  const vault = new Vault(args.vault);
+  const { loaded, skipped } = await vault.init();
+  for (const s of skipped) console.error(`  skipped ${s.path}: ${s.err}`);
+  const memories: Memory[] = vault.list().filter((m) => !m.fm.obsolete);
+  const known = new Set(memories.map((m) => m.fm.id));
+  const triggerToks = new Map<string, Set<string>>();
+  for (const m of memories) {
+    const t = new Set<string>();
+    for (const phrase of m.fm.recall_when) for (const tok of toks(phrase)) t.add(tok);
+    triggerToks.set(m.fm.id, t);
+  }
+
+  const control = buildIndex(memories, { kind: "control" });
+  const treatment = buildIndex(memories, { kind: "treatment", boost: args.boost });
+
+  const overallC = emptyRun(), overallT = emptyRun();
+  const nearC = emptyRun(), nearT = emptyRun();
+  const farC = emptyRun(), farT = emptyRun();
+  const perPersonaT = new Map<string, Run>();
+  const unknownIds = new Set<string>();
+  let totalQueries = 0;
+
+  for (const [label, byMemory] of Object.entries(file.personas)) {
+    const pRun = emptyRun();
+    for (const [id, query] of Object.entries(byMemory)) {
+      if (!known.has(id)) {
+        unknownIds.add(id);
+        continue;
+      }
+      totalQueries++;
+      const cRank = rankOf(control.search(query), id);
+      const tRank = rankOf(treatment.search(query), id);
+      const cov = coverage(query, triggerToks.get(id) ?? new Set());
+      const isNear = cov >= args.near;
+      record(overallC, cRank, args.k);
+      record(overallT, tRank, args.k);
+      record(isNear ? nearC : farC, cRank, args.k);
+      record(isNear ? nearT : farT, tRank, args.k);
+      record(pRun, tRank, args.k);
+    }
+    perPersonaT.set(label, pRun);
+  }
+
+  const liftAll = recallK(overallT) - recallK(overallC);
+  const liftNear = recallK(nearT) - recallK(nearC);
+  const liftFar = recallK(farT) - recallK(farC);
+  const survival = liftNear > 0 ? liftFar / liftNear : NaN;
+
+  // persona-diversity sanity (mean pairwise query Jaccard across shared ids)
+  const labels = Object.keys(file.personas);
+  const pairSims: number[] = [];
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const A = file.personas[labels[i]], B = file.personas[labels[j]];
+      const ids = Object.keys(A).filter((id) => id in B);
+      if (!ids.length) continue;
+      const s = ids.reduce((acc, id) => acc + jaccard(toks(A[id]), toks(B[id])), 0) / ids.length;
+      pairSims.push(s);
+    }
+  }
+  const meanSim = pairSims.length ? pairSims.reduce((a, b) => a + b, 0) / pairSims.length : 0;
+
+  // ── report ──
+  const L: string[] = [];
+  L.push("# recall_when — Simulated-User Survival\n");
+  L.push(
+    `Vault: **${loaded}** memorys  ·  personas: **${labels.length}**  ·  ` +
+      `queries: **${totalQueries}**  ·  boost: **×${args.boost}**  ·  k = **${args.k}**  ·  ` +
+      `near/far cut: **${args.near}**\n`,
+  );
+
+  L.push("## Lift by recall-time vocabulary drift\n");
+  L.push("| query↔trigger | n | control R@" + args.k + " | treatment R@" + args.k + " | marginal lift |");
+  L.push("|---|---|---|---|---|");
+  L.push(`| **all** | ${overallT.total} | ${pct(recallK(overallC))} | ${pct(recallK(overallT))} | **${signed(liftAll)}** |`);
+  L.push(`| near (≥${args.near}) | ${nearT.total} | ${pct(recallK(nearC))} | ${pct(recallK(nearT))} | ${signed(liftNear)} |`);
+  L.push(`| far (<${args.near}) | ${farT.total} | ${pct(recallK(farC))} | ${pct(recallK(farT))} | ${signed(liftFar)} |`);
+  L.push("");
+  L.push(
+    `**survival = lift(far) / lift(near) = ${Number.isFinite(survival) ? survival.toFixed(2) : "n/a"}** — ` +
+      `the fraction of recall_when's benefit that holds when the recall-time query ` +
+      `drifts off the save-time trigger wording.\n`,
+  );
+
+  L.push("## Robustness envelope across user personas\n");
+  L.push(`Recall@${args.k} (treatment) per simulated user — the spread is the envelope:\n`);
+  L.push("| persona | queries | Recall@" + args.k + " |");
+  L.push("|---|---|---|");
+  const persRecalls: number[] = [];
+  for (const [label, r] of perPersonaT) {
+    persRecalls.push(recallK(r));
+    L.push(`| ${label} | ${r.total} | ${pct(recallK(r))} |`);
+  }
+  if (persRecalls.length) {
+    L.push("");
+    L.push(
+      `Envelope: **${pct(Math.min(...persRecalls))} – ${pct(Math.max(...persRecalls))}** ` +
+        `across ${persRecalls.length} user styles.\n`,
+    );
+  }
+
+  L.push("## Persona-diversity check\n");
+  L.push(
+    `Mean pairwise query similarity (token Jaccard): **${meanSim.toFixed(3)}** ` +
+      `(${meanSim < 0.35 ? "diverse — envelope is honest" : "HIGH — personas may be mode-collapsed; envelope suspect"}).\n`,
+  );
+
+  if (unknownIds.size) {
+    L.push(`> ⚠️ ${unknownIds.size} id(s) not in vault (skipped): ${[...unknownIds].join(", ")}\n`);
+  }
+
+  const report = L.join("\n");
+  console.log(report);
+
+  if (args.out) {
+    const json = {
+      vault: args.vault,
+      vaultSize: loaded,
+      boost: args.boost,
+      k: args.k,
+      nearCut: args.near,
+      queries: totalQueries,
+      liftAll,
+      liftNear,
+      liftFar,
+      survival,
+      personaRecall: Object.fromEntries([...perPersonaT].map(([l, r]) => [l, recallK(r)])),
+      meanPairwiseSimilarity: meanSim,
+      unknownIds: [...unknownIds],
+    };
+    writeFileSync(args.out, JSON.stringify(json, null, 2));
+    console.error(`\n[persona-lift] JSON written to ${args.out}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Companion to the `marginal-lift` ablation (#93 / #89). Same one-knob
control/treatment indexes — this adds the question I think the v0.7 number
really wants to answer.

### The question

`recall_when` is written at **save** time — a prediction of how a future
session will phrase the situation. The query is formed at **recall** time, in
that session's own words. So: **how much of the trigger's lift survives when the
recall-time query drifts off the save-time prediction?**

I model the recall-time query distribution with **N simulated user personas**
(junior / senior / terse / verbose / non-native / concept-namer / error-message
/ why-asker / outsider / mobile-typo), each phrasing every memory in its own
voice. Each query gets a continuous overlap score against the gold memory's
`recall_when` tokens, then:

```
near  = query shares trigger vocabulary (overlap ≥ cut)   → prediction hit
far   = query uses different words      (overlap < cut)   → prediction missed
survival = marginal-lift@k(far) / marginal-lift@k(near)
```

`survival ≈ 1` → the trigger generalizes past its own wording (load-bearing).
`survival ≈ 0` → it only helps when you already used its words — i.e. the lift
sits closer to the circular M0 regime than to real recall. The report also
prints a **Recall@k envelope across personas** (robustness spread) and a
**persona-diversity** number.

### Why simulated, not hand-written

The issue thread asks for *hand-written* paraphrases — the right instinct for an
**independent** probe, and I nearly went that way. But for this product it's
ecologically backwards: **nobody hand-writes the memories** (the AI saves them)
**or hand-phrases the recall query** (the AI forms it). Production is
model-mediated on *both* ends, so simulated queries are the faithful test;
hand-written ones exercise a path that doesn't happen. The retriever is lexical
BM25 (no embedding space), so the only contamination risk from LLM-authored
queries is **trigger-vocabulary leakage** — which the overlap score measures
directly, per query, rather than assuming it away.

Two guards keep the envelope honest (CI tests):
- **persona-diversity** — the personas must be distinct voices, not one voice in
  N masks (mode collapse would fake a tight envelope). Bundled set: mean
  pairwise similarity **0.123**, 10/10 distinct.
- **axis spread** — diverse users naturally span near↔far, so the gradient is
  emergent, not hand-binned.

If you'd rather have a hand-written set for the citable run, the harness takes
any personas file — say the word and I'll do that instead. Your standard, your
call.

### What's here

| file | |
|---|---|
| `src/persona-lift.ts` | survival runner — `npm run personas` |
| `fixtures/personas.json` | 10 personas × 10 memories (synthetic vault) |
| `__tests__/persona-diversity.test.ts` | mode-collapse + axis-spread guards |
| `README.md` | method + the simulated-vs-hand-written rationale |

Reuses `buildIndex`/`rankOf` from `index-config.ts` unchanged — the one-knob
ablation and the existing drift-guard are untouched.

### Verified locally

- `npm run build --workspace=@bastra-recall/core` ✓
- `npm run personas` ✓ (synthetic: lift@3 +8.0pp, survival 0.85, diversity 0.123)
- `node --import tsx --test packages/eval/__tests__/*.test.ts` → 3/3 ✓
- `tsc --noEmit` clean ✓

### Not a headline

Like `cases.json`, `fixtures/personas.json` runs against the synthetic vault — a
mechanism demo, not a result (on it the envelope is degenerate at 100%). The
citable survival number comes from real personas against the real 59-memory
vault behind M0. Happy to drive that next.
