### PR TITLE
fix(related-enrich): stop cross-process write ping-pong on related_via

### DIFF
--- a/packages/core/__tests__/related-enrich.test.ts
+++ b/packages/core/__tests__/related-enrich.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { Vault } from "../src/vault.js";
+import type { EmbeddingIndex } from "../src/embeddings.js";
+import { RelatedEnricher } from "../src/related-enrich.js";
+
+function memoryMd(id: string): string {
+  return `---
+id: ${id}
+title: ${id}
+type: lesson
+summary: s
+topic_path: [t]
+tags: [t]
+scope: t
+recall_when: ["w"]
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+body ${id}
+`;
+}
+
+/** Stub-Index: liefert für jede id dieselben, von außen mutierbaren Hits. */
+function stubEmbeddings(hits: { id: string; score: number }[]) {
+  const stub = {
+    current: hits,
+    findSimilarById(_id: string, _k: number) {
+      return this.current;
+    },
+    onEmbed(_l: (id: string) => void) {
+      return () => {};
+    },
+  };
+  return { stub, index: stub as unknown as EmbeddingIndex };
+}
+
+async function vaultWith(ids: string[]): Promise<{ dir: string; vault: Vault }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "bastra-related-"));
+  for (const id of ids) {
+    await writeFile(path.join(dir, `${id}.md`), memoryMd(id));
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  return { dir, vault };
+}
+
+test("enrich schreibt Section + frontmatter, atomar ohne tmp-Leiche", async () => {
+  const { dir, vault } = await vaultWith(["a", "b"]);
+  try {
+    const { index } = stubEmbeddings([{ id: "b", score: 0.85 }]);
+    const enricher = new RelatedEnricher(vault, index);
+
+    const written = await enricher.enrich("a");
+    assert.ok(written);
+    assert.equal(written.length, 1);
+
+    const raw = await readFile(path.join(dir, "a.md"), "utf8");
+    assert.match(raw, /- \[\[b\]\] \(cosine 0\.85\)/);
+    assert.match(raw, /related_via:/);
+
+    const leftovers = (await readdir(dir)).filter((f) => f.endsWith(".tmp"));
+    assert.deepEqual(leftovers, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Cosine-Drift ≤ ε ist no-op — kein Write-Ping-Pong zwischen Prozessen", async () => {
+  const { dir, vault } = await vaultWith(["a", "b"]);
+  try {
+    const { stub, index } = stubEmbeddings([{ id: "b", score: 0.804 }]);
+    const enricher = new RelatedEnricher(vault, index);
+    await enricher.enrich("a");
+    const before = await readFile(path.join(dir, "a.md"), "utf8");
+    assert.match(before, /\(cosine 0\.80\)/);
+
+    // Zweiter Prozess sieht 0.806 → toFixed(2) kippt auf "0.81". Exakter
+    // Vergleich würde rewriten; tolerant ist es äquivalent.
+    stub.current = [{ id: "b", score: 0.806 }];
+    const result = await enricher.enrich("a");
+    assert.equal(result, null);
+    assert.equal(await readFile(path.join(dir, "a.md"), "utf8"), before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Cosine-Drift > ε schreibt neu (echte Score-Änderung)", async () => {
+  const { dir, vault } = await vaultWith(["a", "b"]);
+  try {
+    const { stub, index } = stubEmbeddings([{ id: "b", score: 0.8 }]);
+    const enricher = new RelatedEnricher(vault, index);
+    await enricher.enrich("a");
+
+    stub.current = [{ id: "b", score: 0.9 }];
+    const result = await enricher.enrich("a");
+    assert.ok(result);
+    const raw = await readFile(path.join(dir, "a.md"), "utf8");
+    assert.match(raw, /\(cosine 0\.90\)/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeGate=false unterdrückt den Write (Single-Writer)", async () => {
+  const { dir, vault } = await vaultWith(["a", "b"]);
+  try {
+    const { index } = stubEmbeddings([{ id: "b", score: 0.85 }]);
+    const enricher = new RelatedEnricher(vault, index, {
+      writeGate: () => false,
+    });
+    const before = await readFile(path.join(dir, "a.md"), "utf8");
+
+    const result = await enricher.enrich("a");
+    assert.equal(result, null);
+    assert.equal(await readFile(path.join(dir, "a.md"), "utf8"), before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Hysterese: bestehender Link überlebt bis threshold−ε, neuer braucht threshold", async () => {
+  const { dir, vault } = await vaultWith(["a", "b", "c"]);
+  try {
+    const { stub, index } = stubEmbeddings([{ id: "b", score: 0.71 }]);
+    const enricher = new RelatedEnricher(vault, index); // threshold 0.7
+    await enricher.enrich("a");
+    assert.match(await readFile(path.join(dir, "a.md"), "utf8"), /\[\[b\]\]/);
+
+    // b rutscht knapp unter die Schwelle (0.695 ≥ 0.7−0.02 → bleibt),
+    // c steht gleich hoch, war aber nie verlinkt → kommt nicht rein.
+    stub.current = [
+      { id: "b", score: 0.695 },
+      { id: "c", score: 0.695 },
+    ];
+    await enricher.enrich("a");
+    const raw = await readFile(path.join(dir, "a.md"), "utf8");
+    assert.match(raw, /\[\[b\]\]/);
+    assert.doesNotMatch(raw, /\[\[c\]\]/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/src/related-enrich.ts
+++ b/packages/core/src/related-enrich.ts
@@ -19,10 +19,16 @@
  * Loop-Prevention:
  *   Der reindex triggert ein neues Embed (Body hat sich geändert). Das zweite
  *   Embed liefert dasselbe Similarity-Set → sameIdSet UND sameBody → no-op.
- *   Kein File-Write, kein Loop. (Score-Rundung ist deterministisch über
- *   .toFixed(3), also vergleichbar.)
+ *   Kein File-Write, kein Loop.
+ *
+ *   WICHTIG: Der Vergleich ist drift-tolerant (SCORE_EPSILON), nicht exakt.
+ *   Zwei Prozesse auf demselben Vault (Daemon + Mac-App-Bridge) haben eigene
+ *   EmbeddingIndizes mit minimal abweichenden Vektoren (~±0.002 Cosine). Ein
+ *   exakter String-Vergleich ließ beide an Rundungsgrenzen (0.8049 vs 0.8051
+ *   → "0.80" vs "0.81") dasselbe File im Sekundentakt gegenseitig
+ *   überschreiben — Dauer-Re-Embed, Ollama-Modell entlud nie.
  */
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, rename, unlink } from "node:fs/promises";
 import matter from "gray-matter";
 import type { Vault } from "./vault.js";
 import type { EmbeddingIndex } from "./embeddings.js";
@@ -36,7 +42,17 @@ export interface RelatedEnricherOptions {
    *  0.7 — lieber wenige präzise Links als viele Halb-Treffer (Multi-Hop
    *  würde sonst rauschen). */
   threshold?: number;
+  /** Optionaler Single-Writer-Gate: wird unmittelbar vor einem File-Write
+   *  gefragt; liefert er false, wird der Write übersprungen (ein anderer
+   *  Prozess — typisch der Daemon — besitzt die related_via-Pflege). Ohne
+   *  Gate schreibt der Enricher immer. */
+  writeGate?: () => boolean | Promise<boolean>;
 }
+
+/** Toleranz für Cosine-Drift zwischen Prozessen mit eigenem EmbeddingIndex
+ *  (Daemon vs. Mac-App-Bridge). Drift liegt real bei ~±0.002 — 0.02 ist weit
+ *  darüber und weit unter jeder inhaltlich relevanten Score-Änderung. */
+const SCORE_EPSILON = 0.02;
 
 interface RelatedViaEntry {
   id: string;
@@ -49,6 +65,8 @@ export class RelatedEnricher {
   private readonly topN: number;
   private readonly threshold: number;
 
+  private readonly writeGate?: () => boolean | Promise<boolean>;
+
   constructor(
     private readonly vault: Vault,
     private readonly embeddings: EmbeddingIndex,
@@ -56,6 +74,7 @@ export class RelatedEnricher {
   ) {
     this.topN = opts.topN ?? 5;
     this.threshold = opts.threshold ?? 0.7;
+    this.writeGate = opts.writeGate;
   }
 
   start(): void {
@@ -81,8 +100,13 @@ export class RelatedEnricher {
     const similar = this.embeddings.findSimilarById(id, this.topN * 2);
     if (!similar) return null; // Vector noch nicht da
 
+    const existing = (memory.fm as { related_via?: RelatedViaEntry[] }).related_via ?? [];
+    // Hysterese: bestehende Links überleben bis threshold−ε. Sonst flappt ein
+    // Nachbar, der zwischen zwei Prozessen um die Schwelle pendelt (0.699 vs
+    // 0.701), als add/remove-Ping-Pong.
+    const keepIds = new Set(existing.map((e) => e.id));
     const filtered = similar
-      .filter((h) => h.score >= this.threshold)
+      .filter((h) => h.score >= this.threshold - (keepIds.has(h.id) ? SCORE_EPSILON : 0))
       .slice(0, this.topN)
       .map<RelatedViaEntry>((h) => ({
         id: h.id,
@@ -90,13 +114,14 @@ export class RelatedEnricher {
         score: Number(h.score.toFixed(3)),
       }));
 
-    const existing = (memory.fm as { related_via?: RelatedViaEntry[] }).related_via ?? [];
     const sameVia = sameIdSet(existing, filtered);
 
     const expectedBody = rebuildBodyWithAutoSection(memory.body, filtered);
-    const sameBody = memory.body === expectedBody;
+    const sameBody = autoRelatedEquivalent(memory.body, expectedBody);
 
     if (sameVia && sameBody) return null;
+
+    if (this.writeGate && !(await this.writeGate())) return null;
 
     await rewriteFile(memory.filePath, filtered, expectedBody);
     await this.vault.reindexFile(memory.filePath);
@@ -108,6 +133,43 @@ function sameIdSet(a: RelatedViaEntry[], b: RelatedViaEntry[]): boolean {
   if (a.length !== b.length) return false;
   const aIds = new Set(a.map((e) => e.id));
   for (const e of b) if (!aIds.has(e.id)) return false;
+  return true;
+}
+
+const AUTO_LINE = /^- \[\[([^\]]+)\]\] \(cosine (\d+(?:\.\d+)?)\)$/;
+
+/** Liest die Einträge der Auto-Related-Section als id→cosine-Map.
+ *  Ohne Section: leere Map (== „keine Einträge"). */
+function parseAutoSectionEntries(body: string): Map<string, number> {
+  const entries = new Map<string, number>();
+  const startIdx = body.indexOf(AUTO_RELATED_START);
+  const endIdx = body.indexOf(AUTO_RELATED_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return entries;
+  const section = body.slice(startIdx + AUTO_RELATED_START.length, endIdx);
+  for (const line of section.split("\n")) {
+    const m = AUTO_LINE.exec(line.trim());
+    if (m) entries.set(m[1], Number(m[2]));
+  }
+  return entries;
+}
+
+/** Drift-toleranter Body-Vergleich: gleich, wenn der Body außerhalb der
+ *  Auto-Section identisch ist und die Section dieselben ids mit Cosines
+ *  innerhalb von SCORE_EPSILON trägt. Reihenfolge der Einträge ist egal —
+ *  zwei Prozesse dürfen bei nahezu gleichen Scores unterschiedlich sortieren,
+ *  ohne sich gegenseitig zu überschreiben. */
+function autoRelatedEquivalent(current: string, expected: string): boolean {
+  if (current === expected) return true;
+  if (stripAutoRelatedSection(current) !== stripAutoRelatedSection(expected)) {
+    return false;
+  }
+  const a = parseAutoSectionEntries(current);
+  const b = parseAutoSectionEntries(expected);
+  if (a.size !== b.size) return false;
+  for (const [id, score] of b) {
+    const cur = a.get(id);
+    if (cur === undefined || Math.abs(cur - score) > SCORE_EPSILON) return false;
+  }
   return true;
 }
 
@@ -151,5 +213,16 @@ async function rewriteFile(
     newBody.startsWith("\n") ? newBody : `\n${newBody}`,
     fm,
   );
-  await writeFile(filePath, next, "utf8");
+  // Atomar via temp+rename: ein direkter writeFile lässt das File kurzzeitig
+  // leer (live beobachtet) — Datenverlust-Fenster für Watcher, Cloud-Sync und
+  // parallele Reader. Temp liegt im selben Verzeichnis (gleiches Volume,
+  // rename bleibt atomar) und endet nicht auf .md (Vault-Walker ignoriert es).
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await writeFile(tmp, next, "utf8");
+  try {
+    await rename(tmp, filePath);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
 }

--- a/packages/daemon/src/bridge.ts
+++ b/packages/daemon/src/bridge.ts
@@ -67,15 +67,56 @@ async function attachEmbeddings(search: SearchIndex, vault: Vault): Promise<void
   );
   // Auto-Related-Enricher: pflegt frontmatter.related_via nach jedem Embed-
   // Batch. Im Bridge-Pfad (Mac-App) gleicher Default-Status wie im MCP-Pfad.
+  // Single-Writer: writeGate lässt die Bridge nur schreiben, wenn KEIN Daemon
+  // läuft (App-only-Setup). Läuft einer, gehört related_via ihm — zwei
+  // Enricher mit eigenen Indizes runden Cosines minimal anders und
+  // überschreiben sonst dasselbe File im Sekundentakt (Write-Ping-Pong,
+  // hielt das Ollama-Modell permanent geladen).
   if (envBool("BASTRA_AUTO_RELATED", true)) {
     const enricher = new RelatedEnricher(vault, idx, {
       topN: envInt("BASTRA_RELATED_TOP_N", 5),
       threshold: envFloat("BASTRA_RELATED_THRESHOLD", 0.7),
+      writeGate: daemonAbsent,
     });
     enricher.start();
     process.stderr.write(
-      `[bastra-recall.bridge] auto-related: enabled (top ${envInt("BASTRA_RELATED_TOP_N", 5)} ≥ ${envFloat("BASTRA_RELATED_THRESHOLD", 0.7)})\n`,
+      `[bastra-recall.bridge] auto-related: enabled (top ${envInt("BASTRA_RELATED_TOP_N", 5)} ≥ ${envFloat("BASTRA_RELATED_THRESHOLD", 0.7)}, defers to daemon)\n`,
     );
+  }
+}
+
+// ─── Single-Writer-Probe ─────────────────────────────────────────
+// Cached health-Probe auf den Daemon (Port BASTRA_HTTP_PORT, Default 6723 —
+// gleiche Auflösung wie die Hooks). TTL 30s: der Gate wird pro Enrich-Write
+// gefragt; ohne Cache würde jeder Embed-Batch eine HTTP-Probe kosten.
+const DAEMON_PROBE_TTL_MS = 30_000;
+let daemonProbeAt = 0;
+let daemonAlive = false;
+
+async function daemonAbsent(): Promise<boolean> {
+  const now = Date.now();
+  if (now - daemonProbeAt > DAEMON_PROBE_TTL_MS) {
+    daemonProbeAt = now;
+    daemonAlive = await probeDaemonHealth();
+  }
+  return !daemonAlive;
+}
+
+async function probeDaemonHealth(): Promise<boolean> {
+  const port = envInt("BASTRA_HTTP_PORT", 6723, "NEXUS_HTTP_PORT");
+  const ctrl = new AbortController();
+  const tid = setTimeout(() => ctrl.abort(), 1000);
+  try {
+    const resp = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: ctrl.signal,
+    });
+    if (!resp.ok) return false;
+    const body = (await resp.json()) as { ok?: boolean };
+    return body.ok === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(tid);
   }
 }
 


### PR DESCRIPTION
## Problem

The daemon and the Mac-app bridge each run their own `RelatedEnricher` with a separate `EmbeddingIndex`. The two indices round cosine scores slightly differently (~±0.002). The old exact string compare made both processes see the *other's* file as "changed" and rewrite it — every second, forever. That permanent re-embed loop kept the Ollama model pinned in memory and never let it unload.

## Fix

- **Drift-tolerant compare** (`SCORE_EPSILON = 0.02`): `autoRelatedEquivalent()` treats an auto-related section as unchanged when the same ids carry cosines within ε, regardless of order. Plus threshold **hysteresis** so a neighbour pinging the 0.7 boundary (0.699 ↔ 0.701) doesn't flap add/remove.
- **Single-writer gate** (`writeGate`): the bridge only writes `related_via` when **no daemon is alive** (cached `/health` probe, 30s TTL). When a daemon runs, it owns the field.
- **Atomic write** via temp + `rename` — no empty-file window for watchers, cloud sync, or parallel readers.

## Tests

New `packages/core/__tests__/related-enrich.test.ts`: atomic write (no `.tmp` leftover), drift ≤ ε is a no-op, drift > ε rewrites, `writeGate=false` suppresses the write, hysteresis keeps an existing link / blocks a new one.

Verified locally: `npm run build` ✓ · `npm run check:types` ✓ · `npm test` → 214/214 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
