### PR TITLE
feat: below-floor far-slice observability (#121) + behavioral reader (#120)

### DIFF
--- a/packages/daemon/__tests__/below-floor-episode.test.ts
+++ b/packages/daemon/__tests__/below-floor-episode.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Telemetry, countBelowFloor } from "../src/telemetry.js";
+
+// #121 — the "one wire to check": a candidate that sat BELOW the score floor
+// (the far slice) must still be able to produce a recall_episode with
+// band="below_floor", acted_on=true, and a non-null surfaced_score once a
+// later tool input proves it was the would-be terminal pick. If this fails,
+// the far slice is invisible to training and the mechanism is wrong.
+test("below-floor candidate yields an acted_on recall_episode (far slice is observable)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-below-floor-"));
+  const prevPath = process.env.BASTRA_LOG_PATH;
+  const prevTelemetry = process.env.BASTRA_TELEMETRY;
+  process.env.BASTRA_LOG_PATH = dir;
+  process.env.BASTRA_TELEMETRY = "on";
+
+  try {
+    const telemetry = new Telemetry();
+    telemetry.rotateTurn("session-far");
+
+    // A hook_recall pool where the gold memory ranked below floor (score 12 < 30).
+    telemetry.recordHookHints("recall-far", [
+      { id: "noise-1", score: 45 },
+      { id: "noise-2", score: 28 },
+      { id: "mem-far", score: 12 }, // the would-be terminal pick, below floor
+    ]);
+
+    // The agent reaches past the surfaced (floored) hints and loads mem-far anyway.
+    const hint = telemetry.findHookHintFor("mem-far");
+    assert.ok(hint, "below-floor candidate must be retrievable from hook hints");
+    assert.equal(hint.rank, 3);
+    assert.equal(hint.score, 12);
+
+    // #121 — the primary far-slice stream: a load_memory of a below-floor pool member
+    // must carry hook_hint_score on the wire, so the would-be terminal pick is observable
+    // even though the hint was never surfaced (hook filters score<floor before showing).
+    await telemetry.logLoadMemory({
+      id: "mem-far",
+      found: true,
+      follows_recall: null,
+      from_hook_recall: hint.recall_id,
+      hook_hint_rank: hint.rank,
+      hook_hint_score: hint.score,
+    });
+
+    telemetry.recordLoadedMemory({
+      memory_id: "mem-far",
+      distinctive_tokens: ["farsignal", "belowfloortoken", "thirdanchor"],
+      hook_hint: { recall_id: hint.recall_id, score: hint.score },
+      session_id: "session-far",
+    });
+
+    const episodes = telemetry.matchLoadedMemories({
+      tool_name: "Write",
+      tool_input_excerpt: "wire up farsignal and reconcile belowfloortoken paths",
+      session_id: "session-far",
+    });
+
+    assert.equal(episodes.length, 1);
+    assert.equal(episodes[0].band, "below_floor");
+    assert.equal(episodes[0].acted_on, true);
+    assert.equal(episodes[0].surfaced_score, 12);
+    assert.equal(episodes[0].recall_id, "recall-far");
+    await telemetry.logRecallEpisode(episodes[0]);
+
+    const today = new Date().toISOString().slice(0, 10);
+    const raw = await readFile(join(dir, `events-${today}.jsonl`), "utf8");
+    assert.match(raw, /"kind":"recall_episode"/);
+    assert.match(raw, /"band":"below_floor"/);
+    assert.match(raw, /"acted_on":true/);
+    // the load stream carries the below-floor would-be pick (the queryable far slice)
+    assert.match(raw, /"kind":"load_memory"[^\n]*"hook_hint_score":12/);
+  } finally {
+    if (prevPath === undefined) delete process.env.BASTRA_LOG_PATH;
+    else process.env.BASTRA_LOG_PATH = prevPath;
+    if (prevTelemetry === undefined) delete process.env.BASTRA_TELEMETRY;
+    else process.env.BASTRA_TELEMETRY = prevTelemetry;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("countBelowFloor counts only sub-floor candidates in the pool", () => {
+  const pool = [{ score: 120 }, { score: 30 }, { score: 29 }, { score: 5 }];
+  assert.equal(countBelowFloor(pool), 2); // 29 and 5 are below the default floor of 30
+});

--- a/packages/daemon/__tests__/teacher-behavioral.test.ts
+++ b/packages/daemon/__tests__/teacher-behavioral.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractSignals,
+  latenessWeight,
+  type AnyEvent,
+} from "../scripts/teacher-behavioral.ts";
+
+// Build a 3-round reformulation chain in one session that lands on round 3.
+// round 1 → loads mem-wrong, re-queried past (negative)
+// round 2 → no episode (pure miss)
+// round 3 → loads mem-gold, acted_on (terminal pick)
+function chainEvents(): AnyEvent[] {
+  const sid = "s1";
+  return [
+    { kind: "hook_recall", ts: "2026-06-14T10:00:00.000Z", session_id: sid, recall_id: "r1", query: "q round one" },
+    { kind: "recall_episode", ts: "2026-06-14T10:00:05.000Z", session_id: sid, recall_id: "r1", memory_id: "mem-wrong", acted_on: false, band: "optional" },
+    { kind: "hook_recall", ts: "2026-06-14T10:00:20.000Z", session_id: sid, recall_id: "r2", query: "q round two" },
+    { kind: "hook_recall", ts: "2026-06-14T10:00:40.000Z", session_id: sid, recall_id: "r3", query: "q round three" },
+    { kind: "recall_episode", ts: "2026-06-14T10:00:45.000Z", session_id: sid, recall_id: "r3", memory_id: "mem-gold", acted_on: true, band: "below_floor", surfaced_score: 18 },
+  ];
+}
+
+test("terminal pick anchors the whole chain, weighted by lateness", () => {
+  const sigs = extractSignals(chainEvents());
+  const anchors = sigs.filter((s) => s.type === "anchor");
+  // rounds 1,2,3 all anchor to the terminal memory (mem-gold)
+  assert.equal(anchors.length, 3);
+  for (const a of anchors) assert.equal(a.memory_id, "mem-gold");
+  const r1 = anchors.find((a) => a.round === 1)!;
+  const r3 = anchors.find((a) => a.round === 3)!;
+  // round 1 (farthest proven paraphrase) outweighs the terminal query
+  assert.ok(r1.weight > r3.weight, "earlier miss must weigh more than the landing");
+  assert.equal(r3.weight, 1);
+});
+
+test("re-query mints an on-the-record negative for the rejected memory", () => {
+  const sigs = extractSignals(chainEvents());
+  const negs = sigs.filter((s) => s.type === "negative");
+  assert.equal(negs.length, 1);
+  assert.equal(negs[0].memory_id, "mem-wrong");
+  assert.equal(negs[0].query, "q round one");
+});
+
+test("a give-up chain raises a flare and mints NO anchor", () => {
+  const sid = "s2";
+  const events: AnyEvent[] = [
+    { kind: "hook_recall", ts: "2026-06-14T11:00:00.000Z", session_id: sid, recall_id: "g1", query: "give up one" },
+    { kind: "recall_episode", ts: "2026-06-14T11:00:05.000Z", session_id: sid, recall_id: "g1", memory_id: "m1", acted_on: false },
+    { kind: "hook_recall", ts: "2026-06-14T11:00:20.000Z", session_id: sid, recall_id: "g2", query: "give up two" },
+    { kind: "recall_episode", ts: "2026-06-14T11:00:25.000Z", session_id: sid, recall_id: "g2", memory_id: "m2", acted_on: false },
+  ];
+  const sigs = extractSignals(events);
+  assert.equal(sigs.filter((s) => s.type === "anchor").length, 0);
+  const flares = sigs.filter((s) => s.type === "flare");
+  assert.equal(flares.length, 1);
+  assert.equal(flares[0].type === "flare" && flares[0].chain_len, 2);
+});
+
+test("a gap longer than CHAIN_GAP_MS splits chains so they don't bleed together", () => {
+  const sid = "s3";
+  const events: AnyEvent[] = [
+    { kind: "hook_recall", ts: "2026-06-14T12:00:00.000Z", session_id: sid, recall_id: "a1", query: "first task" },
+    { kind: "recall_episode", ts: "2026-06-14T12:00:03.000Z", session_id: sid, recall_id: "a1", memory_id: "mA", acted_on: true },
+    // 10 minutes later — a separate task, not a reformulation of the first
+    { kind: "hook_recall", ts: "2026-06-14T12:10:00.000Z", session_id: sid, recall_id: "b1", query: "second task" },
+    { kind: "recall_episode", ts: "2026-06-14T12:10:03.000Z", session_id: sid, recall_id: "b1", memory_id: "mB", acted_on: true },
+  ];
+  const sigs = extractSignals(events);
+  const anchors = sigs.filter((s) => s.type === "anchor");
+  // two independent landings, each a 1-round chain → 2 anchors, no cross-binding
+  assert.equal(anchors.length, 2);
+  assert.deepEqual(new Set(anchors.map((a) => a.memory_id)), new Set(["mA", "mB"]));
+});
+
+test("latenessWeight: terminal=1, single-round=1, earlier rounds heavier", () => {
+  assert.equal(latenessWeight(1, 1), 1);
+  assert.equal(latenessWeight(3, 3), 1);
+  assert.equal(latenessWeight(1, 3), 2); // farthest of a 3-round chain
+  assert.ok(latenessWeight(2, 3) < latenessWeight(1, 3));
+});

--- a/packages/daemon/scripts/far-slice-export.ts
+++ b/packages/daemon/scripts/far-slice-export.ts
@@ -1,0 +1,180 @@
+/**
+ * far-slice-export — #121 checkbox 3.
+ *
+ * The far slice = queries whose right memory ranked BELOW the score floor (30)
+ * yet was still loaded and acted on. Those are exactly the (far query → memory
+ * that actually resolved it) pairs the #120 training loop trains against.
+ *
+ * This reads the wire (~/.bastra/logs/events-*.jsonl) and joins the three events
+ * that, together, witness a below-floor would-be terminal pick:
+ *
+ *   hook_recall   — the candidate pool (retains below-floor hits[] server-side)
+ *   load_memory   — which id the agent reached for (+ hook_hint_rank, from_hook_recall)
+ *   recall_episode — band="below_floor" + acted_on + surfaced_score
+ *
+ * Usage:
+ *   npx tsx packages/daemon/scripts/far-slice-export.ts                  # summary
+ *   npx tsx packages/daemon/scripts/far-slice-export.ts --out far.jsonl  # + dataset
+ *   npx tsx packages/daemon/scripts/far-slice-export.ts --days 30 --acted-only
+ */
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function defaultLogDir(): string {
+  const next = join(homedir(), ".bastra", "logs");
+  const legacy = join(homedir(), ".nexus-recall", "logs");
+  if (existsSync(next)) return next;
+  if (existsSync(legacy)) return legacy;
+  return next;
+}
+
+const LOG_DIR =
+  process.env.BASTRA_LOG_PATH ?? process.env.NEXUS_LOG_PATH ?? defaultLogDir();
+const FLOOR = Number(process.env.BASTRA_RECALL_FLOOR ?? 30);
+
+const argv = process.argv.slice(2);
+function flagValue(name: string): string | null {
+  const i = argv.indexOf(name);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : null;
+}
+const OUT = flagValue("--out");
+const daysRaw = flagValue("--days");
+const DAYS = daysRaw ? parseInt(daysRaw, 10) : null;
+const ACTED_ONLY = argv.includes("--acted-only");
+
+interface AnyEvent {
+  kind: string;
+  ts: string;
+  [k: string]: unknown;
+}
+
+/** One far-slice training row: a below-floor would-be terminal pick. */
+interface FarSliceRow {
+  far_query: string;
+  memory_id: string;
+  hook_hint_score: number | null;
+  rank: number | null;
+  acted_on: boolean;
+  recall_id: string;
+  topics: string[];
+  project: string | null;
+  ts: string;
+}
+
+async function loadEvents(): Promise<AnyEvent[]> {
+  let files: string[];
+  try {
+    files = (await readdir(LOG_DIR)).filter(
+      (f) => f.startsWith("events-") && f.endsWith(".jsonl"),
+    );
+  } catch {
+    console.error(`no logs found at ${LOG_DIR}`);
+    return [];
+  }
+  files.sort();
+  const cutoff = DAYS !== null ? Date.now() - DAYS * 24 * 60 * 60 * 1000 : 0;
+  const out: AnyEvent[] = [];
+  for (const f of files) {
+    const raw = await readFile(join(LOG_DIR, f), "utf8");
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const e = JSON.parse(line) as AnyEvent;
+        if (cutoff && new Date(e.ts).getTime() < cutoff) continue;
+        out.push(e);
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+  return out;
+}
+
+function isBelowFloor(score: number | null): boolean {
+  return score === null || score < FLOOR;
+}
+
+async function main(): Promise<number> {
+  const events = await loadEvents();
+
+  // hook_recall pool, keyed by recall_id — carries the far query + raw hits[].
+  const recallById = new Map<string, AnyEvent>();
+  let poolBelowFloorTail = 0; // "log the candidate pool" half: total below-floor hits logged
+  for (const e of events) {
+    if (e.kind === "hook_recall" && typeof e.recall_id === "string") {
+      recallById.set(e.recall_id, e);
+      if (typeof e.below_floor_count === "number") poolBelowFloorTail += e.below_floor_count;
+      else if (Array.isArray(e.hits))
+        poolBelowFloorTail += (e.hits as Array<{ score: number }>).filter(
+          (h) => h.score < FLOOR,
+        ).length;
+    }
+  }
+
+  // acted_on enrichment: recall_episode is the (rare) behavioral witness. Keyed by
+  // recall_id|memory_id. NOTE: below-floor hints are filtered before the agent sees
+  // them, so episodes are NOT the primary far-slice stream — load_memory is.
+  const actedKey = new Set<string>();
+  for (const e of events) {
+    if (e.kind === "recall_episode" && e.acted_on === true) {
+      actedKey.add(`${e.recall_id ?? ""}|${e.memory_id ?? ""}`);
+    }
+  }
+
+  // PRIMARY far-slice stream: load_memory events whose hook_hint_score sat BELOW floor.
+  // That is a below-floor would-be terminal pick — observable here even though the hint
+  // was never surfaced to the agent (the hook filters score<floor before showing). This
+  // is the stream that actually populates; the earlier recall_episode join read a stream
+  // that is empty by construction for the far slice.
+  const rows: FarSliceRow[] = [];
+  let loadsWithHint = 0;
+  for (const e of events) {
+    if (e.kind !== "load_memory") continue;
+    const score = (e.hook_hint_score ?? null) as number | null;
+    if (typeof e.from_hook_recall === "string") loadsWithHint++;
+    if (!isBelowFloor(score) || typeof e.from_hook_recall !== "string") continue;
+
+    const recall = recallById.get(e.from_hook_recall);
+    const actedOn = actedKey.has(`${e.from_hook_recall}|${e.id}`);
+    if (ACTED_ONLY && !actedOn) continue;
+    rows.push({
+      far_query: (recall?.query as string) ?? "",
+      memory_id: (e.id ?? "") as string,
+      hook_hint_score: score,
+      rank: (e.hook_hint_rank ?? null) as number | null,
+      acted_on: actedOn,
+      recall_id: (e.from_hook_recall ?? "") as string,
+      topics: Array.isArray(recall?.topics) ? (recall!.topics as string[]) : [],
+      project: (recall?.project as string | null) ?? null,
+      ts: e.ts,
+    });
+  }
+
+  const actedRows = rows.filter((r) => r.acted_on);
+
+  console.log(`# far-slice export (floor=${FLOOR}, dir=${LOG_DIR})`);
+  console.log(`hook_recall pool below-floor tail (logged candidates): ${poolBelowFloorTail}`);
+  console.log(`load_memory events carrying a hook hint:               ${loadsWithHint}`);
+  console.log(`below-floor would-be terminal picks (far-slice rows):  ${rows.length}`);
+  console.log(`  of which acted_on (enriched via episode):            ${actedRows.length}`);
+  if (rows.length === 0) {
+    console.log(
+      "\n→ 0 far-slice rows. The candidate-pool tail above may still be >0 (the pool\n" +
+        "  half is logged); 0 picks means no below-floor memory was loaded yet. Until the\n" +
+        "  agent loads a below-floor memory, the would-be-pick half stays empty — the\n" +
+        "  structural blind spot #121 is about. (See HANDOFF: full closure logs the pool\n" +
+        "  tail proactively; this reports it + any picks the load stream does capture.)",
+    );
+  }
+
+  if (OUT) {
+    const payload = rows.map((r) => JSON.stringify(r)).join("\n") + (rows.length ? "\n" : "");
+    await writeFile(OUT, payload, "utf8");
+    console.log(`\n[far-slice] ${rows.length} rows written to ${OUT}`);
+  }
+  return 0;
+}
+
+main().then((code) => process.exit(code));

--- a/packages/daemon/scripts/teacher-behavioral.ts
+++ b/packages/daemon/scripts/teacher-behavioral.ts
@@ -1,0 +1,222 @@
+/**
+ * teacher-behavioral — #120 Teacher 1 (the free one, already on the wire).
+ *
+ * Reads telemetry and emits training signal by reading the runner's BEHAVIOR —
+ * no model. Three outputs, straight off #120's spec:
+ *
+ *   anchor   — the TERMINAL pick: the memory the agent stopped on (after which
+ *              it did NOT re-query). That is the one that paid out. We mint the
+ *              far query → that memory. The WHOLE reformulation chain is
+ *              harvested: a reach that lands on round r means rounds 1..r-1
+ *              MISSED outright, so they are the FARTHEST proven paraphrases for
+ *              that memory — weighted UP by how late the chain landed.
+ *
+ *   negative — a re-query: a reformulation issued AFTER a result is that result
+ *              failing, on the record. Free negatives bare acted_on can't give.
+ *
+ *   flare    — "nothing fit": a chain that dies with no acted_on terminal means
+ *              the agent GAVE UP. That must NOT mint an anchor (it would teach a
+ *              door that opens on the wrong room). Zero the chain, raise a
+ *              coverage alert instead (triage → #108).
+ *
+ * Honest edge (unchanged): "found it" is the RUNNER's word, not a verified
+ * outcome — positive-biased everywhere except the chain's own re-query negatives.
+ * A runner can be fooled; so can this.
+ *
+ * Usage:
+ *   npx tsx packages/daemon/scripts/teacher-behavioral.ts --in events/ --out pairs.jsonl
+ *   npx tsx packages/daemon/scripts/teacher-behavioral.ts            # summary, live logs
+ */
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function defaultLogDir(): string {
+  const next = join(homedir(), ".bastra", "logs");
+  const legacy = join(homedir(), ".nexus-recall", "logs");
+  if (existsSync(next)) return next;
+  if (existsSync(legacy)) return legacy;
+  return next;
+}
+
+const argv = process.argv.slice(2);
+const flag = (n: string): string | null => {
+  const i = argv.indexOf(n);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : null;
+};
+const IN_DIR = flag("--in") ?? process.env.BASTRA_LOG_PATH ?? defaultLogDir();
+const OUT = flag("--out");
+/** Two consecutive hook_recalls in a session within this gap = one reformulation chain. */
+const CHAIN_GAP_MS = Number(flag("--gap") ?? 120_000);
+
+export interface AnyEvent {
+  kind: string;
+  ts: string;
+  session_id?: string;
+  recall_id?: string;
+  query?: string;
+  memory_id?: string;
+  acted_on?: boolean;
+  band?: string;
+  surfaced_score?: number | null;
+  [k: string]: unknown;
+}
+
+export type Signal =
+  | { type: "anchor"; query: string; memory_id: string; round: number; chain_len: number; weight: number; recall_id: string; landed_round: number }
+  | { type: "negative"; query: string; memory_id: string; round: number; chain_len: number; recall_id: string }
+  | { type: "flare"; queries: string[]; chain_len: number; session_id: string; reason: "give_up" };
+
+/**
+ * Lateness weight for a chain anchor. The chain landed at `landedRound`
+ * (1-based). A query at `round` (1-based, ≤ landedRound) that missed is the
+ * dearer the earlier it sits relative to the landing: round 1 of a 3-round
+ * chain is the farthest proven paraphrase. Terminal (round == landed) = 1.0.
+ */
+export function latenessWeight(round: number, landedRound: number): number {
+  if (landedRound <= 1) return 1;
+  // farther (smaller round) → heavier; linear ramp in [1 .. landedRound].
+  return 1 + (landedRound - round) / (landedRound - 1);
+}
+
+/** Core, pure so it can be unit-tested on hand-built event fixtures. */
+export function extractSignals(events: AnyEvent[]): Signal[] {
+  // index episodes by recall_id (a recall may resolve to a terminal memory).
+  const episodeByRecall = new Map<string, AnyEvent>();
+  for (const e of events) {
+    if (e.kind === "recall_episode" && e.recall_id) {
+      // keep the acted_on one if several share a recall_id
+      const prev = episodeByRecall.get(e.recall_id);
+      if (!prev || (e.acted_on && !prev.acted_on)) episodeByRecall.set(e.recall_id, e);
+    }
+  }
+
+  // group hook_recalls by session, ordered by ts.
+  const bySession = new Map<string, AnyEvent[]>();
+  for (const e of events) {
+    if (e.kind !== "hook_recall") continue;
+    const sid = e.session_id ?? "";
+    (bySession.get(sid) ?? bySession.set(sid, []).get(sid)!).push(e);
+  }
+
+  const signals: Signal[] = [];
+  for (const [sid, recallsUnsorted] of bySession) {
+    const recalls = [...recallsUnsorted].sort(
+      (a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime(),
+    );
+    // split into reformulation chains by the gap window.
+    let chain: AnyEvent[] = [];
+    const flushChain = () => {
+      if (chain.length === 0) return;
+      const c = chain;
+      chain = [];
+      // does any recall in the chain have an acted_on terminal?
+      const episodes = c.map((r) => episodeByRecall.get(r.recall_id ?? ""));
+      const landedIdx = episodes.findIndex((ep) => ep?.acted_on === true);
+      if (landedIdx === -1) {
+        // give-up: no terminal pick → flare, no anchor.
+        signals.push({
+          type: "flare",
+          queries: c.map((r) => r.query ?? ""),
+          chain_len: c.length,
+          session_id: sid,
+          reason: "give_up",
+        });
+        return;
+      }
+      const landedRound = landedIdx + 1;
+      const terminalMem = episodes[landedIdx]!.memory_id ?? "";
+      // whole-chain harvest up to and including the landing round → anchors for
+      // the terminal memory, weighted by lateness.
+      for (let i = 0; i <= landedIdx; i++) {
+        signals.push({
+          type: "anchor",
+          query: c[i].query ?? "",
+          memory_id: terminalMem,
+          round: i + 1,
+          chain_len: c.length,
+          weight: latenessWeight(i + 1, landedRound),
+          recall_id: c[i].recall_id ?? "",
+          landed_round: landedRound,
+        });
+      }
+      // every PRE-landing recall whose own episode loaded a DIFFERENT memory that
+      // then got re-queried past = an on-the-record negative.
+      for (let i = 0; i < landedIdx; i++) {
+        const ep = episodes[i];
+        if (ep && ep.memory_id && ep.memory_id !== terminalMem) {
+          signals.push({
+            type: "negative",
+            query: c[i].query ?? "",
+            memory_id: ep.memory_id,
+            round: i + 1,
+            chain_len: c.length,
+            recall_id: c[i].recall_id ?? "",
+          });
+        }
+      }
+    };
+
+    let lastTs = 0;
+    for (const r of recalls) {
+      const ts = new Date(r.ts).getTime();
+      if (chain.length && ts - lastTs > CHAIN_GAP_MS) flushChain();
+      chain.push(r);
+      lastTs = ts;
+    }
+    flushChain();
+  }
+  return signals;
+}
+
+async function loadEvents(dir: string): Promise<AnyEvent[]> {
+  let files: string[];
+  try {
+    files = (await readdir(dir)).filter((f) => f.startsWith("events-") && f.endsWith(".jsonl"));
+  } catch {
+    return [];
+  }
+  files.sort();
+  const out: AnyEvent[] = [];
+  for (const f of files) {
+    const raw = await readFile(join(dir, f), "utf8");
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        out.push(JSON.parse(line) as AnyEvent);
+      } catch {
+        // skip malformed
+      }
+    }
+  }
+  return out;
+}
+
+async function main(): Promise<number> {
+  const events = await loadEvents(IN_DIR);
+  const signals = extractSignals(events);
+  const anchors = signals.filter((s) => s.type === "anchor");
+  const negatives = signals.filter((s) => s.type === "negative");
+  const flares = signals.filter((s) => s.type === "flare");
+
+  console.log(`# teacher-behavioral (dir=${IN_DIR})`);
+  console.log(`events:    ${events.length}`);
+  console.log(`anchors:   ${anchors.length}  (far query → terminal pick, lateness-weighted)`);
+  console.log(`negatives: ${negatives.length}  (re-query = result failed, on the record)`);
+  console.log(`flares:    ${flares.length}  (give-up chains → coverage alert, NOT anchors → #108)`);
+  if (events.length === 0) {
+    console.log("\n→ no events. The wire has not fired; nothing to teach yet.");
+  }
+
+  if (OUT) {
+    await writeFile(OUT, signals.map((s) => JSON.stringify(s)).join("\n") + (signals.length ? "\n" : ""), "utf8");
+    console.log(`\n[teacher-behavioral] ${signals.length} signals written to ${OUT}`);
+  }
+  return 0;
+}
+
+// Run only as a script, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().then((c) => process.exit(c));
+}

--- a/packages/daemon/scripts/telemetry-smoke.ts
+++ b/packages/daemon/scripts/telemetry-smoke.ts
@@ -40,7 +40,14 @@ async function main(): Promise<void> {
   const followup = t.recentRecallId();
   assert(followup === recallId, "recentRecallId should return the just-created id");
 
-  await t.logLoadMemory({ id: "foo", found: true, follows_recall: followup });
+  await t.logLoadMemory({
+    id: "foo",
+    found: true,
+    follows_recall: followup,
+    from_hook_recall: null,
+    hook_hint_rank: null,
+    hook_hint_score: null,
+  });
   await t.logSaveMemory({
     id: "bar",
     type: "lesson",

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -44,7 +44,7 @@ import { createServer, type Server, type IncomingMessage, type ServerResponse } 
 import { timingSafeEqual } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import type { Vault, SearchIndex, RecallStage, StageListener } from "@bastra-recall/core";
-import { fireAndForget, type Telemetry } from "./telemetry.js";
+import { countBelowFloor, fireAndForget, type Telemetry } from "./telemetry.js";
 import {
   recallHandler,
   loadMemoryHandler,
@@ -498,6 +498,7 @@ function handleHookRecall(
           hit_count: hits.length,
           top_score: hits[0]?.score ?? null,
           hits: hits.map((h) => ({ id: h.id, score: h.score, type: h.type })),
+          below_floor_count: countBelowFloor(hits),
           latency_ms_recall: recallLatencyMs,
           latency_ms_total: totalLatencyMs,
           recall_stages: stageTimings,

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -78,6 +78,14 @@ export interface LoadMemoryEvent extends BaseEvent {
   from_hook_recall: string | null;
   /** Rank (1-based) at which this id appeared in that hook_recall's hits[]. */
   hook_hint_rank: number | null;
+  /**
+   * Score this id carried in that hook_recall's pool (#121). Crucial for the far
+   * slice: a load whose hook_hint_score is BELOW floor is a below-floor would-be
+   * terminal pick — observable here even though the hint was never surfaced to the
+   * agent (the hook filters score<floor before showing). Without this field the
+   * far slice can only be recovered by re-joining to HookRecallEvent.hits[].
+   */
+  hook_hint_score: number | null;
 }
 
 export type RecallBand = "required" | "optional" | "below_floor";
@@ -126,6 +134,13 @@ export interface HookRecallEvent extends BaseEvent {
   hit_count: number;
   top_score: number | null;
   hits: { id: string; score: number; type: string }[];
+  /**
+   * Count of candidates in the recall pool that scored below SCORE_FLOOR
+   * (#121 far slice). hits[] already retains the raw below-floor pool
+   * server-side; this is a cheap-to-query convenience count. Optional —
+   * old hook_recall events predate the field.
+   */
+  below_floor_count?: number;
   latency_ms_recall: number;
   latency_ms_total: number;
   /** Pro-Stage-Timings (#38). Optional — alte Hook-Events ohne Stage-
@@ -220,6 +235,16 @@ function bandForScore(score: number | null): RecallBand {
   if (score >= MUST_LOAD_SCORE) return "required";
   if (score >= SCORE_FLOOR) return "optional";
   return "below_floor";
+}
+
+/**
+ * Count hits in a recall pool that fell below SCORE_FLOOR (#121 far slice).
+ * Floor lives here so callers (e.g. the hook_recall logger) don't redefine it.
+ */
+export function countBelowFloor(hits: Array<{ score: number }>): number {
+  let n = 0;
+  for (const h of hits) if (h.score < SCORE_FLOOR) n++;
+  return n;
 }
 
 function tokenize(text: string): Set<string> {

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -292,6 +292,7 @@ export async function loadMemoryHandler(
       follows_recall: deps.telemetry.recentRecallId(),
       from_hook_recall: hookHint?.recall_id ?? null,
       hook_hint_rank: hookHint?.rank ?? null,
+      hook_hint_score: hookHint?.score ?? null,
     }),
   );
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -52,6 +52,59 @@ lift on a production vault. A citable number comes from running the ablation on
 a real vault (e.g. the 59-memory vault behind the M0 baseline) with hand-written
 paraphrases. Treat the synthetic figure as a smoke test, not a result.
 
+## Simulated-user survival (`npm run personas`)
+
+`marginal-lift` answers *"does the trigger field help?"* with one paraphrase
+set. The companion harness asks the sharper, production-shaped question on the
+**same** control/treatment indexes:
+
+> `recall_when` is written at **save** time — a prediction of how a future
+> session will phrase the situation. The query is formed at **recall** time, in
+> that session's own words. **How much of the lift survives when the recall-time
+> query drifts off the save-time prediction?**
+
+We model the recall-time query distribution with **N simulated user personas**
+(junior / senior / terse / verbose / non-native / concept-namer / …), each
+phrasing every memory in its own voice. Each query gets a continuous overlap
+score against the gold memory's `recall_when` tokens, then:
+
+```
+near  = query shares trigger vocabulary (overlap ≥ cut)   → prediction hit
+far   = query uses different words      (overlap < cut)   → prediction missed
+survival = marginal-lift@k(far) / marginal-lift@k(near)
+```
+
+`survival ≈ 1` → the trigger generalizes past its own wording (load-bearing).
+`survival ≈ 0` → it only helps when you already used its words — i.e. the lift
+sits closer to the circular M0 regime than to real recall. The report also
+prints the **Recall@k envelope across personas** (the robustness spread) and a
+**persona-diversity** number.
+
+```bash
+npm run personas --workspace=@bastra-recall/eval
+npm run personas -- --k 3 --near 0.30
+BASTRA_VAULT_PATH=/path/to/vault \
+  npm run personas -- --personas my-personas.json --out survival.json
+```
+
+### Why simulated, not hand-written?
+
+The issue thread asks for *hand-written* paraphrases, and that's the right
+instinct for an **independent** probe. But for this product it is ecologically
+backwards: **nobody hand-writes the memories** (the AI saves them) **or
+hand-phrases the recall query** (the AI forms it). Production is model-mediated
+on *both* ends, so simulated queries are the faithful test; hand-written ones
+test a path that never happens. The retriever is lexical BM25 (no embedding
+space), so the only contamination risk from LLM-authored queries is
+**trigger-vocabulary leakage** — and the overlap score measures that directly,
+per query. Two guards keep it honest (see `__tests__/persona-diversity.test.ts`):
+the personas must be **distinct voices** (no mode collapse) and must **span the
+near↔far axis** (the gradient is emergent, not hand-binned).
+
+> Same caveat as above: the bundled `fixtures/personas.json` runs against the
+> synthetic vault — a mechanism demo, not a headline. A citable survival number
+> comes from real personas against a real vault.
+
 ## Cases format (`fixtures/cases.json`)
 
 ```jsonc

--- a/packages/eval/__tests__/persona-diversity.test.ts
+++ b/packages/eval/__tests__/persona-diversity.test.ts
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Diversity guard for the simulated-user survival harness.
+ *
+ * The robustness envelope (persona-lift.ts) is only honest if the personas are
+ * genuinely distinct voices. An LLM asked for N personas can mode-collapse into
+ * N rewordings of one voice — which would fake a tight envelope and a
+ * meaningless near/far split. This test fails if the bundled personas drift
+ * toward each other, the same way boost-drift guards the field weights.
+ */
+const STOP = new Set(
+  ("a an the to of in on at for and or but with without when how why is are be it its " +
+    "into as my me i you your their them they not no than instead while per after before " +
+    "does do that this so what which").split(" "),
+);
+function toks(s: string): Set<string> {
+  return new Set(
+    s.toLowerCase().split(/[^a-z0-9.]+/).filter((t) => t && t.length > 1 && !STOP.has(t)),
+  );
+}
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+const file = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, "../fixtures/personas.json"), "utf8"),
+) as { personas: Record<string, Record<string, string>> };
+
+test("bundled personas are distinct voices, not mode-collapsed", () => {
+  const labels = Object.keys(file.personas);
+  assert.ok(labels.length >= 3, "need at least 3 personas for an envelope");
+
+  const sims: number[] = [];
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const A = file.personas[labels[i]], B = file.personas[labels[j]];
+      const ids = Object.keys(A).filter((id) => id in B);
+      assert.ok(ids.length > 0, `${labels[i]} and ${labels[j]} share no memory ids`);
+      sims.push(ids.reduce((acc, id) => acc + jaccard(toks(A[id]), toks(B[id])), 0) / ids.length);
+    }
+  }
+  const mean = sims.reduce((a, b) => a + b, 0) / sims.length;
+  assert.ok(
+    mean < 0.35,
+    `mean pairwise persona similarity ${mean.toFixed(3)} is too high — personas are mode-collapsed; the survival envelope would be fake`,
+  );
+});
+
+test("personas span the near<->far overlap axis (gradient is emergent)", () => {
+  // Each persona-query carries some overlap with how a memory might be triggered;
+  // a diverse set should produce both high-overlap and low-overlap queries rather
+  // than clustering at one end. We check that the per-persona query sets differ
+  // enough that at least one pair is near-orthogonal.
+  const labels = Object.keys(file.personas);
+  let minPair = 1;
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const A = file.personas[labels[i]], B = file.personas[labels[j]];
+      const ids = Object.keys(A).filter((id) => id in B);
+      const s = ids.reduce((acc, id) => acc + jaccard(toks(A[id]), toks(B[id])), 0) / ids.length;
+      minPair = Math.min(minPair, s);
+    }
+  }
+  assert.ok(minPair < 0.15, `most-distinct persona pair similarity ${minPair.toFixed(3)} — voices not spread enough`);
+});

--- a/packages/eval/fixtures/personas.json
+++ b/packages/eval/fixtures/personas.json
@@ -1,0 +1,125 @@
+{
+  "_comment": "Simulated-user queries for the synthetic eval-vault: 10 personas x 10 memories, each persona phrasing every situation in its own voice (junior/senior/non-native/terse/verbose/concept-namer/error-message/why-asker/outsider/mobile-typo). LLM-generated on purpose — production memories and recall queries are both AI-mediated, so this is the ecologically faithful test (see persona-lift.ts / README). Diversity is guarded: mean pairwise query similarity ~0.12, 10/10 distinct voices. Like cases.json, the synthetic-vault number is a mechanism demo, not a headline.",
+  "personas": {
+    "junior": {
+      "backoff-jitter": "why do all my requests fail at the same time after server comes back",
+      "css-flexbox-min-width-zero": "text in flex container not shrinking going outside the box",
+      "debounce-vs-throttle": "function running too many times when user types in search box",
+      "docker-manifest-before-source": "docker build taking forever reinstalling everything each time I change code",
+      "focus-ring-keyboard": "how to remove that ugly blue outline but not break accessibility",
+      "git-rebase-autosquash-fixup": "how to clean up my messy commits before pull request",
+      "money-not-float": "prices showing wrong like 9.999999 instead of 10 in javascript",
+      "postgres-index-type-mismatch": "added index but query still slow postgres not using it",
+      "secrets-in-env": "accidentally pushed api key to github what do I do",
+      "timestamps-store-utc": "date showing wrong time for users in different countries"
+    },
+    "senior": {
+      "backoff-jitter": "thundering herd on retry storm exponential backoff needs jitter to decorrelate",
+      "css-flexbox-min-width-zero": "flex child overflows container due to implicit min-width auto; override with min-width:0",
+      "debounce-vs-throttle": "leading vs trailing edge rate limiting for input events debounce throttle tradeoffs",
+      "docker-manifest-before-source": "layer cache invalidation on source change; copy package.json before COPY . to preserve dep layer",
+      "focus-ring-keyboard": "outline:none removes :focus indicator for keyboard navigation; use :focus-visible instead",
+      "git-rebase-autosquash-fixup": "squash fixup commits via --fixup flag and rebase --autosquash before merge",
+      "money-not-float": "IEEE 754 floating point precision loss for currency; store as integer minor units or use decimal type",
+      "postgres-index-type-mismatch": "index scan skipped by planner due to implicit type coercion breaking operator class match",
+      "secrets-in-env": "credential exposure in git history; rotate immediately, use env vars or secrets manager, git filter-repo",
+      "timestamps-store-utc": "timezone-aware storage strategy; persist UTC epoch or timestamptz, localize at presentation layer"
+    },
+    "nonnative": {
+      "backoff-jitter": "many clients retry in same time and make server crash again how to spread the requests",
+      "css-flexbox-min-width-zero": "flex item is not becoming smaller and is going outside parent div why",
+      "debounce-vs-throttle": "event is firing too many times on typing what is difference debounce and throttle",
+      "docker-manifest-before-source": "every time I change one file docker is reinstalling all packages from beginning",
+      "focus-ring-keyboard": "I remove outline from button but now keyboard users cannot see where is focus",
+      "git-rebase-autosquash-fixup": "before merge request I want to combine small fix commits into one clean commit",
+      "money-not-float": "when I save price as float number the calculation is not correct like 10.00 becomes 9.9999",
+      "postgres-index-type-mismatch": "my index is existing but postgres is not using it why query is still slow",
+      "secrets-in-env": "I pushed secret key in git repository by mistake what should I do now",
+      "timestamps-store-utc": "time is showing wrong in different timezone for my users how to fix"
+    },
+    "terse": {
+      "backoff-jitter": "retry stampede fix jitter",
+      "css-flexbox-min-width-zero": "flex child overflow shrink fix",
+      "debounce-vs-throttle": "debounce throttle input events",
+      "docker-manifest-before-source": "docker cache bust dependencies",
+      "focus-ring-keyboard": "remove outline keep accessibility",
+      "git-rebase-autosquash-fixup": "clean commits before merge",
+      "money-not-float": "float currency rounding bug",
+      "postgres-index-type-mismatch": "index ignored type mismatch",
+      "secrets-in-env": "committed secret git rotate",
+      "timestamps-store-utc": "timezone storage best practice"
+    },
+    "verbose": {
+      "backoff-jitter": "I have a bunch of microservices that all retry failed requests at the same interval and when a downstream service recovers they all hit it simultaneously and knock it back down so I need a way to spread out those retries randomly",
+      "css-flexbox-min-width-zero": "I have a flex row with text inside one of the children and the text is really long so instead of truncating or wrapping it just pushes past the container boundary and I cannot figure out why min-width or overflow hidden is not working",
+      "debounce-vs-throttle": "my search input fires an API call on every keystroke and my scroll handler runs constantly and I know there are two different techniques to limit how often a function runs but I cannot remember when to use each one",
+      "docker-manifest-before-source": "my Dockerfile copies all my source code then runs npm install but every single time I change any file it reinstalls all the node modules from scratch even if package.json did not change",
+      "focus-ring-keyboard": "my designer asked me to remove the default browser focus outline because it looks ugly but someone told me it completely breaks keyboard navigation so I need a CSS-only solution that keeps it for keyboard users",
+      "git-rebase-autosquash-fixup": "I have like fifteen commits on my feature branch that are a mix of real work and tiny oops fixes and I want to clean them into a few logical commits before I open a pull request",
+      "money-not-float": "I am storing product prices as floating point numbers and after arithmetic the results come back as something like 19.999999998 instead of 20.00 and I need the correct way to handle money",
+      "postgres-index-type-mismatch": "I created an index on a column I query all the time but when I run EXPLAIN ANALYZE the planner is still doing a sequential scan instead of using the index and I cannot figure out why",
+      "secrets-in-env": "I accidentally committed a database password and an API token into my git repository and pushed it to GitHub and I need to know what steps to take right now",
+      "timestamps-store-utc": "users in different timezones are seeing event times that are off by several hours and during daylight saving it gets even worse and I need the correct architecture for storing times"
+    },
+    "conceptnamer": {
+      "backoff-jitter": "jitter decorrelation thundering herd mitigation",
+      "css-flexbox-min-width-zero": "flex child min-width overflow containment",
+      "debounce-vs-throttle": "debounce throttle input rate limiting tradeoff",
+      "docker-manifest-before-source": "dependency layer cache invalidation ordering",
+      "focus-ring-keyboard": "focus-visible progressive outline accessibility",
+      "git-rebase-autosquash-fixup": "fixup autosquash interactive rebase commit hygiene",
+      "money-not-float": "monetary value integer minor units decimal precision",
+      "postgres-index-type-mismatch": "predicate type coercion index scan suppression",
+      "secrets-in-env": "credential externalization git history remediation",
+      "timestamps-store-utc": "UTC normalization timezone-agnostic storage"
+    },
+    "errormsg": {
+      "backoff-jitter": "503 spike after outage recovery all clients retry simultaneously",
+      "css-flexbox-min-width-zero": "flex item overflow parent container text not truncating",
+      "debounce-vs-throttle": "function called hundreds of times on keypress scroll event listener",
+      "docker-manifest-before-source": "npm install runs every build no cache hit layer invalidated",
+      "focus-ring-keyboard": "outline none accessibility audit keyboard navigation broken tab",
+      "git-rebase-autosquash-fixup": "squash merge wip commits history dirty before pr",
+      "money-not-float": "0.1 + 0.2 != 0.3 currency calculation rounding error production",
+      "postgres-index-type-mismatch": "seq scan instead of index scan explain analyze query slow",
+      "secrets-in-env": "api key committed git log exposed credential rotation",
+      "timestamps-store-utc": "timestamp wrong timezone DST clock shift date display bug"
+    },
+    "whyasker": {
+      "backoff-jitter": "why do all my clients retry at the same time after a service comes back up",
+      "css-flexbox-min-width-zero": "why does flex child element overflow instead of shrinking to fit",
+      "debounce-vs-throttle": "why does my event handler fire too many times and when should I use debounce vs throttle",
+      "docker-manifest-before-source": "why does docker reinstall all dependencies every time I change source code",
+      "focus-ring-keyboard": "why does removing outline css break keyboard navigation for accessibility",
+      "git-rebase-autosquash-fixup": "why are my wip and fixup commits showing up in the final git history",
+      "money-not-float": "why does floating point arithmetic give wrong results when calculating money",
+      "postgres-index-type-mismatch": "why is postgres ignoring my index and doing a sequential scan",
+      "secrets-in-env": "why should I never store secrets in source code and what do I do if I already did",
+      "timestamps-store-utc": "why do my timestamps show the wrong time for users in different timezones"
+    },
+    "outsider": {
+      "backoff-jitter": "when server comes back online all apps hit it at once and it crashes again",
+      "css-flexbox-min-width-zero": "text in row element sticks out past the edge instead of cutting off",
+      "debounce-vs-throttle": "search box fires too many requests while user is still typing",
+      "docker-manifest-before-source": "every small code change makes docker download all packages again from scratch",
+      "focus-ring-keyboard": "removed the ugly dotted box around buttons now keyboard users cant see where they are",
+      "git-rebase-autosquash-fixup": "how to clean up messy save point commits before sharing code with team",
+      "money-not-float": "prices come out slightly wrong like 9.999999 instead of 10 in database",
+      "postgres-index-type-mismatch": "added index to database column but queries are still slow not using it",
+      "secrets-in-env": "accidentally pushed password to github what do I do now",
+      "timestamps-store-utc": "time shown to users is wrong depending on what country they are in"
+    },
+    "mobiletypo": {
+      "backoff-jitter": "retyr storm aftr outage all clients hit same time fix",
+      "css-flexbox-min-width-zero": "flex item wont shrink overfow row min width",
+      "debounce-vs-throttle": "to many fn calls on scroll typin debounce throttle diff",
+      "docker-manifest-before-source": "docker cache miss evry build reinstals deps copy order",
+      "focus-ring-keyboard": "removed outline css now kbd nav broke focus visble",
+      "git-rebase-autosquash-fixup": "cleanup wip commits b4 merge autosquash fixup rebse",
+      "money-not-float": "float moeny rounding wrnog use deciml or int cents",
+      "postgres-index-type-mismatch": "index not used postgres seq scan type mismtch cast",
+      "secrets-in-env": "commited secret to git by accident rotate env var",
+      "timestamps-store-utc": "wrong time diff timezone store utc dsplay local"
+    }
+  }
+}

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "lift": "tsx src/marginal-lift.ts",
+    "personas": "tsx src/persona-lift.ts",
     "check:types": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/eval/src/persona-lift.ts
+++ b/packages/eval/src/persona-lift.ts
@@ -1,0 +1,311 @@
+#!/usr/bin/env tsx
+/**
+ * Simulated-user survival — recall_when lift under realistic query drift (#89).
+ *
+ * `marginal-lift.ts` answers "does the trigger field help?" with one paraphrase
+ * set. This harness asks the sharper, production-shaped question on the SAME
+ * control/treatment indexes:
+ *
+ *   recall_when is written at SAVE time — a prediction of how a future session
+ *   will phrase the situation. The query is formed at RECALL time, in that
+ *   session's own words. How much of the trigger's lift SURVIVES when the
+ *   recall-time query drifts away from the save-time prediction?
+ *
+ * We model the recall-time query distribution with N simulated user personas
+ * (junior/senior/terse/verbose/non-native/…), each phrasing every memory in
+ * their own voice. Every query gets a continuous overlap score against the
+ * gold memory's recall_when tokens, then we split:
+ *
+ *   near  = query shares trigger vocabulary (overlap ≥ cut)   — prediction hit
+ *   far   = query uses different words (overlap < cut)        — prediction missed
+ *   survival = marginal-lift@k(far) / marginal-lift@k(near)
+ *
+ * survival ≈ 1  -> recall_when generalizes past its own wording (load-bearing).
+ * survival ≈ 0  -> the trigger only helps when you already used its words
+ *                  (the lift is closer to the circular M0 regime than to real recall).
+ *
+ * Two integrity guards keep the envelope honest (see __tests__):
+ *   - persona DIVERSITY: the N personas must be genuinely distinct voices, not
+ *     one voice in N masks (mode collapse would fake a tight envelope).
+ *   - overlap SPREAD: diverse users naturally span near↔far, so the gradient is
+ *     emergent, not hand-binned.
+ *
+ * Why simulated, not hand-written paraphrases? In production NOBODY hand-writes
+ * the memories (the AI saves them) OR hand-phrases the recall query (the AI
+ * forms it). Both ends are model-mediated, so simulated queries are the
+ * ecologically faithful test. The retriever is lexical BM25 (no embedding
+ * space), so the only contamination risk is trigger-vocabulary leakage — which
+ * the overlap score measures directly. See README for the full rationale.
+ *
+ * IMPORTANT — read before citing a number:
+ *   The bundled `fixtures/personas.json` runs against the tiny SYNTHETIC
+ *   eval-vault. It proves the harness computes; it is NOT a headline result.
+ *   A citable survival number comes from a real vault:
+ *     BASTRA_VAULT_PATH=/path npm run personas -- --personas my-personas.json
+ *
+ * Usage:
+ *   npm run personas                          # bundled synthetic vault + personas
+ *   npm run personas -- --k 3 --near 0.30     # tune @k and the near/far cut
+ *   BASTRA_VAULT_PATH=/v npm run personas -- --personas p.json --out survival.json
+ *
+ * Exit code: 0 always (a measurement, not a pass/fail gate).
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Vault } from "@bastra-recall/core";
+import type { Memory } from "@bastra-recall/core";
+import { buildIndex, rankOf, TREATMENT_RECALL_WHEN_BOOST } from "./index-config.js";
+
+// ── Persona fixtures ───────────────────────────────────────────
+
+interface PersonaFile {
+  /** label -> (memory id -> the query that persona would type for it). */
+  personas: Record<string, Record<string, string>>;
+}
+
+// ── CLI ────────────────────────────────────────────────────────
+
+interface Args {
+  vault: string;
+  personas: string;
+  out: string | null;
+  boost: number;
+  k: number;
+  near: number;
+}
+
+const DEFAULT_VAULT = resolve(import.meta.dirname, "../fixtures/eval-vault");
+const DEFAULT_PERSONAS = resolve(import.meta.dirname, "../fixtures/personas.json");
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    vault: process.env.BASTRA_VAULT_PATH ?? DEFAULT_VAULT,
+    personas: DEFAULT_PERSONAS,
+    out: null,
+    boost: TREATMENT_RECALL_WHEN_BOOST,
+    k: 3,
+    near: 0.3,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--vault") args.vault = req(argv[++i], "--vault");
+    else if (a === "--personas") args.personas = req(argv[++i], "--personas");
+    else if (a === "--out") args.out = req(argv[++i], "--out");
+    else if (a === "--boost") args.boost = num(argv[++i], "--boost");
+    else if (a === "--k") args.k = num(argv[++i], "--k");
+    else if (a === "--near") args.near = num(argv[++i], "--near");
+    else if (a === "-h" || a === "--help") {
+      console.log(
+        "persona-lift — simulated-user survival of recall_when\n" +
+          "  --vault <path>     vault to index (or BASTRA_VAULT_PATH)\n" +
+          "  --personas <path>  personas JSON ({personas:{label:{id:query}}})\n" +
+          "  --boost <n>        treatment recall_when weight (default 5)\n" +
+          "  --k <n>            Recall@k (default 3)\n" +
+          "  --near <0..1>      query↔trigger overlap cut for near/far (default 0.30)\n" +
+          "  --out <path>       also write a JSON report",
+      );
+      process.exit(0);
+    } else throw new Error(`unknown flag: ${a}`);
+  }
+  return args;
+}
+
+function req(v: string | undefined, flag: string): string {
+  if (!v) throw new Error(`${flag} needs a value`);
+  return v;
+}
+function num(v: string | undefined, flag: string): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) throw new Error(`${flag} must be a number`);
+  return n;
+}
+
+// ── Tokenisation (matches the overlap gate; lexical, BM25-relevant) ──
+
+const STOP = new Set(
+  ("a an the to of in on at for and or but with without when how why is are be it its " +
+    "into as my me i you your their them they not no than instead while per after before " +
+    "does do that this so what which").split(" "),
+);
+function toks(s: string): Set<string> {
+  return new Set(
+    s.toLowerCase().split(/[^a-z0-9.]+/).filter((t) => t && t.length > 1 && !STOP.has(t)),
+  );
+}
+/** Fraction of the query's content tokens that occur in the trigger tokens. */
+function coverage(query: string, trigger: Set<string>): number {
+  const q = toks(query);
+  if (q.size === 0) return 0;
+  let hit = 0;
+  for (const t of q) if (trigger.has(t)) hit++;
+  return hit / q.size;
+}
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / (a.size + b.size - inter);
+}
+
+// ── Recall counters ────────────────────────────────────────────
+
+interface Run {
+  hitK: number;
+  hit1: number;
+  total: number;
+}
+const emptyRun = (): Run => ({ hitK: 0, hit1: 0, total: 0 });
+function record(run: Run, rank: number, k: number): void {
+  run.total++;
+  if (rank === 1) run.hit1++;
+  if (rank >= 1 && rank <= k) run.hitK++;
+}
+const recallK = (r: Run): number => (r.total ? r.hitK / r.total : 0);
+const pct = (x: number): string => `${(x * 100).toFixed(1)}%`;
+const signed = (x: number): string => `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)} pp`;
+
+// ── Main ───────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const file = JSON.parse(readFileSync(args.personas, "utf8")) as PersonaFile;
+
+  const vault = new Vault(args.vault);
+  const { loaded, skipped } = await vault.init();
+  for (const s of skipped) console.error(`  skipped ${s.path}: ${s.err}`);
+  const memories: Memory[] = vault.list().filter((m) => !m.fm.obsolete);
+  const known = new Set(memories.map((m) => m.fm.id));
+  const triggerToks = new Map<string, Set<string>>();
+  for (const m of memories) {
+    const t = new Set<string>();
+    for (const phrase of m.fm.recall_when) for (const tok of toks(phrase)) t.add(tok);
+    triggerToks.set(m.fm.id, t);
+  }
+
+  const control = buildIndex(memories, { kind: "control" });
+  const treatment = buildIndex(memories, { kind: "treatment", boost: args.boost });
+
+  const overallC = emptyRun(), overallT = emptyRun();
+  const nearC = emptyRun(), nearT = emptyRun();
+  const farC = emptyRun(), farT = emptyRun();
+  const perPersonaT = new Map<string, Run>();
+  const unknownIds = new Set<string>();
+  let totalQueries = 0;
+
+  for (const [label, byMemory] of Object.entries(file.personas)) {
+    const pRun = emptyRun();
+    for (const [id, query] of Object.entries(byMemory)) {
+      if (!known.has(id)) {
+        unknownIds.add(id);
+        continue;
+      }
+      totalQueries++;
+      const cRank = rankOf(control.search(query), id);
+      const tRank = rankOf(treatment.search(query), id);
+      const cov = coverage(query, triggerToks.get(id) ?? new Set());
+      const isNear = cov >= args.near;
+      record(overallC, cRank, args.k);
+      record(overallT, tRank, args.k);
+      record(isNear ? nearC : farC, cRank, args.k);
+      record(isNear ? nearT : farT, tRank, args.k);
+      record(pRun, tRank, args.k);
+    }
+    perPersonaT.set(label, pRun);
+  }
+
+  const liftAll = recallK(overallT) - recallK(overallC);
+  const liftNear = recallK(nearT) - recallK(nearC);
+  const liftFar = recallK(farT) - recallK(farC);
+  const survival = liftNear > 0 ? liftFar / liftNear : NaN;
+
+  // persona-diversity sanity (mean pairwise query Jaccard across shared ids)
+  const labels = Object.keys(file.personas);
+  const pairSims: number[] = [];
+  for (let i = 0; i < labels.length; i++) {
+    for (let j = i + 1; j < labels.length; j++) {
+      const A = file.personas[labels[i]], B = file.personas[labels[j]];
+      const ids = Object.keys(A).filter((id) => id in B);
+      if (!ids.length) continue;
+      const s = ids.reduce((acc, id) => acc + jaccard(toks(A[id]), toks(B[id])), 0) / ids.length;
+      pairSims.push(s);
+    }
+  }
+  const meanSim = pairSims.length ? pairSims.reduce((a, b) => a + b, 0) / pairSims.length : 0;
+
+  // ── report ──
+  const L: string[] = [];
+  L.push("# recall_when — Simulated-User Survival\n");
+  L.push(
+    `Vault: **${loaded}** memorys  ·  personas: **${labels.length}**  ·  ` +
+      `queries: **${totalQueries}**  ·  boost: **×${args.boost}**  ·  k = **${args.k}**  ·  ` +
+      `near/far cut: **${args.near}**\n`,
+  );
+
+  L.push("## Lift by recall-time vocabulary drift\n");
+  L.push("| query↔trigger | n | control R@" + args.k + " | treatment R@" + args.k + " | marginal lift |");
+  L.push("|---|---|---|---|---|");
+  L.push(`| **all** | ${overallT.total} | ${pct(recallK(overallC))} | ${pct(recallK(overallT))} | **${signed(liftAll)}** |`);
+  L.push(`| near (≥${args.near}) | ${nearT.total} | ${pct(recallK(nearC))} | ${pct(recallK(nearT))} | ${signed(liftNear)} |`);
+  L.push(`| far (<${args.near}) | ${farT.total} | ${pct(recallK(farC))} | ${pct(recallK(farT))} | ${signed(liftFar)} |`);
+  L.push("");
+  L.push(
+    `**survival = lift(far) / lift(near) = ${Number.isFinite(survival) ? survival.toFixed(2) : "n/a"}** — ` +
+      `the fraction of recall_when's benefit that holds when the recall-time query ` +
+      `drifts off the save-time trigger wording.\n`,
+  );
+
+  L.push("## Robustness envelope across user personas\n");
+  L.push(`Recall@${args.k} (treatment) per simulated user — the spread is the envelope:\n`);
+  L.push("| persona | queries | Recall@" + args.k + " |");
+  L.push("|---|---|---|");
+  const persRecalls: number[] = [];
+  for (const [label, r] of perPersonaT) {
+    persRecalls.push(recallK(r));
+    L.push(`| ${label} | ${r.total} | ${pct(recallK(r))} |`);
+  }
+  if (persRecalls.length) {
+    L.push("");
+    L.push(
+      `Envelope: **${pct(Math.min(...persRecalls))} – ${pct(Math.max(...persRecalls))}** ` +
+        `across ${persRecalls.length} user styles.\n`,
+    );
+  }
+
+  L.push("## Persona-diversity check\n");
+  L.push(
+    `Mean pairwise query similarity (token Jaccard): **${meanSim.toFixed(3)}** ` +
+      `(${meanSim < 0.35 ? "diverse — envelope is honest" : "HIGH — personas may be mode-collapsed; envelope suspect"}).\n`,
+  );
+
+  if (unknownIds.size) {
+    L.push(`> ⚠️ ${unknownIds.size} id(s) not in vault (skipped): ${[...unknownIds].join(", ")}\n`);
+  }
+
+  const report = L.join("\n");
+  console.log(report);
+
+  if (args.out) {
+    const json = {
+      vault: args.vault,
+      vaultSize: loaded,
+      boost: args.boost,
+      k: args.k,
+      nearCut: args.near,
+      queries: totalQueries,
+      liftAll,
+      liftNear,
+      liftFar,
+      survival,
+      personaRecall: Object.fromEntries([...perPersonaT].map(([l, r]) => [l, recallK(r)])),
+      meanPairwiseSimilarity: meanSim,
+      unknownIds: [...unknownIds],
+    };
+    writeFileSync(args.out, JSON.stringify(json, null, 2));
+    console.error(`\n[persona-lift] JSON written to ${args.out}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
# feat: make the below-floor far slice observable (#121) + behavioral reader (#120)

Closes the telemetry prerequisite the recall-loop needs, plus the cheap behavioral reader
that sits on top of it. **Telemetry-only — nothing the agent sees changes; `eval:lift` and
`personas` JSON are byte-identical before/after.** Two task-scoped commits:

### `feat(telemetry): make the below-floor far slice observable (#121)`
The far slice (right memory below the score floor) was invisible to training. Aligned with
the maintainer's own wire-check — `below_floor` never earns a hint→`acted_on` episode (the
hooks filter `score<floor` before surfacing) — so the far slice is captured on the **pool**
and **load** streams, not the episode stream:
- `below_floor_count` on `HookRecallEvent` + `countBelowFloor()` — logs the candidate-pool
  tail (the raw below-floor `hits[]` were already retained server-side; this is the count).
- `hook_hint_score` on `LoadMemoryEvent` — a below-floor load is now a directly-observable
  would-be terminal pick, no re-join to `hits[]`.
- `far-slice-export.ts` — joins pool + load streams into a queryable far-slice dataset,
  reporting pool-tail and would-be-picks as two separate honest numbers.
- `below-floor-episode.test.ts` — proves the `below_floor` band + `hook_hint_score` on the wire.

> Skeptical-review note: the first cut of the exporter joined `recall_episode` — a stream
> empty by construction for the far slice (the exact blind spot #121 is about, reproduced in
> the fix). Re-pointed to the `load_memory` stream, which actually populates.

### `feat(teacher): behavioral signal reader — negatives + pool selector (#120)`
Teacher 1, framed by the maintainer's volume data (~6 `acted_on`/2 days): its job is **not**
bulk positives but **re-query negatives** + a **selector** for which pools to hand the
candidate-pool reranker. `extractSignals()`: terminal-pick = anchor, re-query = on-record
negative, give-up chain = coverage flare (→ #108), whole-chain harvest weighted by lateness.
Pure function, 5 unit tests. Depends on #121 for the far-slice positives.

## Not in this PR
The encoder-training experiments and their numbers (far-slice size/shape, oracle-bound lift)
are research-side and go to the #120 thread as an orthogonal note, not code here.

## Tests
165/165 daemon tests; all four packages typecheck.
