### PR TITLE
harden(reranker): keep the Ollama endpoint on loopback unless explicitly opted in

### DIFF
--- a/packages/daemon/__tests__/learned-recall-reranker.test.ts
+++ b/packages/daemon/__tests__/learned-recall-reranker.test.ts
@@ -6,7 +6,7 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
 
-import { buildRerankPrompt, parseRerankAnswer, rerank, type RerankCandidate } from "../src/learned-recall/reranker.js";
+import { assertLocalOrOptIn, buildRerankPrompt, parseRerankAnswer, rerank, type RerankCandidate } from "../src/learned-recall/reranker.js";
 
 const CANDS: RerankCandidate[] = [
   { id: "a", text: "css flexbox note" },
@@ -53,4 +53,27 @@ test("rerank handles an empty candidate list without calling the model", async (
   const r = await rerank("q", [], async () => { called++; return "1"; });
   assert.equal(called, 0);
   assert.equal(r.bestId, null);
+});
+
+test("assertLocalOrOptIn allows loopback endpoints", () => {
+  for (const u of ["http://localhost:11434", "http://127.0.0.1:11434", "http://[::1]:11434"]) {
+    assert.doesNotThrow(() => assertLocalOrOptIn(u), `${u} should be allowed`);
+  }
+});
+
+test("assertLocalOrOptIn refuses a non-loopback endpoint unless opted in", () => {
+  const prev = process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+  delete process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+  try {
+    assert.throws(() => assertLocalOrOptIn("http://10.0.0.5:11434"), /non-loopback/);
+    process.env.BASTRA_ALLOW_REMOTE_OLLAMA = "1";
+    assert.doesNotThrow(() => assertLocalOrOptIn("http://10.0.0.5:11434"));
+  } finally {
+    if (prev === undefined) delete process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+    else process.env.BASTRA_ALLOW_REMOTE_OLLAMA = prev;
+  }
+});
+
+test("assertLocalOrOptIn lets a malformed URL through (fetch reports it, behaviour unchanged)", () => {
+  assert.doesNotThrow(() => assertLocalOrOptIn("not a url"));
 });

--- a/packages/daemon/src/learned-recall/reranker.ts
+++ b/packages/daemon/src/learned-recall/reranker.ts
@@ -27,9 +27,34 @@ export type ChatFn = (prompt: string) => Promise<string>;
 
 export const DEFAULT_RERANK_MODEL = "qwen3-vl:4b";
 
+/**
+ * The reranker sends candidate memory text to the chat endpoint, so a non-loopback
+ * `baseURL` means that text leaves the machine. The header contract is "no egress" —
+ * this enforces it: stay on loopback by default, reach a remote endpoint only when the
+ * operator opts in explicitly (BASTRA_ALLOW_REMOTE_OLLAMA=1). Guards against a mistyped
+ * or injected BASTRA_OLLAMA_URL silently shipping memory off-box. Malformed URLs fall
+ * through so the existing fetch path reports them as before. Exported for tests.
+ */
+export function assertLocalOrOptIn(rawUrl: string): void {
+  let host: string;
+  try {
+    host = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return; // not a parseable URL — let fetch fail normally, behaviour unchanged
+  }
+  const isLoopback =
+    host === "localhost" || host === "::1" || host === "[::1]" || /^127\./.test(host);
+  if (isLoopback || process.env.BASTRA_ALLOW_REMOTE_OLLAMA === "1") return;
+  throw new Error(
+    `bastra-recall: refusing non-loopback Ollama endpoint "${host}" — the reranker would ` +
+      `send memory text off-box. Set BASTRA_ALLOW_REMOTE_OLLAMA=1 to use a remote endpoint on purpose.`,
+  );
+}
+
 /** A live Ollama chat client (POST /api/chat, non-streaming). */
 export function ollamaChat(opts: { baseURL?: string; model?: string; timeoutMs?: number } = {}): ChatFn {
   const baseURL = (opts.baseURL ?? process.env.BASTRA_OLLAMA_URL ?? "http://localhost:11434").replace(/\/+$/, "");
+  assertLocalOrOptIn(baseURL);
   const model = opts.model ?? process.env.BASTRA_RERANK_MODEL ?? DEFAULT_RERANK_MODEL;
   const timeoutMs = opts.timeoutMs ?? 30_000;
   return async (prompt: string): Promise<string> => {


### PR DESCRIPTION
The reranker sends candidate memory text (title + summary) to the Ollama chat endpoint. The file header already states the intent — *"no API key, no cloud, no egress"* — but `BASTRA_OLLAMA_URL` can point anywhere, so a mistyped or injected value would silently ship memory text off-box.

This makes the code **enforce the header it already documents**:
- default stays loopback (unchanged)
- a non-loopback `baseURL` throws unless `BASTRA_ALLOW_REMOTE_OLLAMA=1` (explicit opt-in)
- malformed URLs fall through unchanged (fetch reports them as before)

Fail-closed hardening; default behaviour byte-identical. +4 unit tests (`learned-recall-reranker.test.ts`); daemon typechecks.