### PR TITLE
harden(embeddings): apply the loopback/opt-in egress guard to the Ollama embedding path (#125)

### DIFF
--- a/packages/core/__tests__/ollama-egress.test.ts
+++ b/packages/core/__tests__/ollama-egress.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for src/ollama-egress.ts — the shared loopback/opt-in guard (#124/#125),
+ * plus its enforcement on the embedding provider (the #125 gap).
+ *
+ * Run: npx tsx --test packages/core/__tests__/ollama-egress.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { assertLocalOrOptIn } from "../src/ollama-egress.js";
+import { OllamaEmbeddingProvider } from "../src/embeddings.js";
+
+function withoutOptIn(fn: () => void): void {
+  const prev = process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+  delete process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+    else process.env.BASTRA_ALLOW_REMOTE_OLLAMA = prev;
+  }
+}
+
+function withOptIn(fn: () => void): void {
+  const prev = process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+  process.env.BASTRA_ALLOW_REMOTE_OLLAMA = "1";
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.BASTRA_ALLOW_REMOTE_OLLAMA;
+    else process.env.BASTRA_ALLOW_REMOTE_OLLAMA = prev;
+  }
+}
+
+// ─── the guard itself (mirrors the reranker's #124 tests) ──────────
+
+test("assertLocalOrOptIn allows loopback endpoints", () => {
+  for (const u of ["http://localhost:11434", "http://127.0.0.1:11434", "http://[::1]:11434"]) {
+    assert.doesNotThrow(() => assertLocalOrOptIn(u), `${u} should be allowed`);
+  }
+});
+
+test("assertLocalOrOptIn refuses a non-loopback endpoint unless opted in", () => {
+  withoutOptIn(() => {
+    assert.throws(() => assertLocalOrOptIn("http://10.0.0.5:11434"), /non-loopback/);
+  });
+  withOptIn(() => {
+    assert.doesNotThrow(() => assertLocalOrOptIn("http://10.0.0.5:11434"));
+  });
+});
+
+test("assertLocalOrOptIn lets a malformed URL through (fetch reports it, behaviour unchanged)", () => {
+  assert.doesNotThrow(() => assertLocalOrOptIn("not a url"));
+});
+
+// ─── the #125 gap: the embedding provider must enforce it too ──────
+
+test("OllamaEmbeddingProvider: loopback baseURL (and the default) construct fine", () => {
+  withoutOptIn(() => {
+    assert.doesNotThrow(() => new OllamaEmbeddingProvider({}));
+    assert.doesNotThrow(() => new OllamaEmbeddingProvider({ baseURL: "http://127.0.0.1:11434" }));
+  });
+});
+
+test("OllamaEmbeddingProvider: a remote baseURL is refused unless opted in (#125)", () => {
+  withoutOptIn(() => {
+    assert.throws(() => new OllamaEmbeddingProvider({ baseURL: "http://10.0.0.5:11434" }), /non-loopback/);
+  });
+  withOptIn(() => {
+    assert.doesNotThrow(() => new OllamaEmbeddingProvider({ baseURL: "http://10.0.0.5:11434" }));
+  });
+});

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -20,6 +20,7 @@ import * as path from "node:path";
 import type { Memory } from "./schema.js";
 import type { Vault, VaultEvent } from "./vault.js";
 import { EmbedCache, hashEmbedContent } from "./embed-cache.js";
+import { assertLocalOrOptIn } from "./ollama-egress.js";
 
 // ─── Tunables (env-overridable für load-tests / large-vault-bursts) ──
 
@@ -142,6 +143,11 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
     keepAlive?: string | number;
   }) {
     this.baseURL = opts.baseURL ?? "http://localhost:11434";
+    // Embedding text (query + memory) is POSTed to this endpoint. Enforce the
+    // same "no egress" contract the reranker does (#124/#125): loopback by
+    // default, remote only with BASTRA_ALLOW_REMOTE_OLLAMA=1. Fail fast at
+    // construction rather than silently shipping text off-box on first embed.
+    assertLocalOrOptIn(this.baseURL);
     this.model = opts.model ?? "embeddinggemma";
     // EmbeddingGemma default 768, andere Modelle abweichend — via opts
     // override-bar. Bei Mismatch wird der Index automatisch invalidiert

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,8 @@ export {
   auditedRestore,
 } from "./audit-save.js";
 
+export { assertLocalOrOptIn } from "./ollama-egress.js";
+
 export {
   EmbeddingIndex,
   OpenAIEmbeddingProvider,

--- a/packages/core/src/ollama-egress.ts
+++ b/packages/core/src/ollama-egress.ts
@@ -1,0 +1,32 @@
+/**
+ * Egress contract for the local Ollama endpoint.
+ *
+ * Both the reranker (chat, candidate text) and the embedding provider (query +
+ * memory text) talk to Ollama at `BASTRA_OLLAMA_URL`. The documented contract is
+ * "no API key, no cloud, no egress" — the text stays on the machine. But the URL
+ * is a free-form env var, so a mistyped or injected value would silently ship
+ * memory text off-box.
+ *
+ * This is the single shared assertion that enforces the contract: stay on
+ * loopback by default, reach a remote endpoint only when the operator opts in
+ * explicitly (BASTRA_ALLOW_REMOTE_OLLAMA=1). Malformed URLs fall through so the
+ * existing fetch path reports them exactly as before (behaviour unchanged).
+ *
+ * Lives in core (the lower layer) so the daemon reranker and the core embedding
+ * provider share one guard instead of each re-implementing it.
+ */
+export function assertLocalOrOptIn(rawUrl: string): void {
+  let host: string;
+  try {
+    host = new URL(rawUrl).hostname.toLowerCase();
+  } catch {
+    return; // not a parseable URL — let fetch fail normally, behaviour unchanged
+  }
+  const isLoopback =
+    host === "localhost" || host === "::1" || host === "[::1]" || /^127\./.test(host);
+  if (isLoopback || process.env.BASTRA_ALLOW_REMOTE_OLLAMA === "1") return;
+  throw new Error(
+    `bastra-recall: refusing non-loopback Ollama endpoint "${host}" — this would ` +
+      `send memory text off-box. Set BASTRA_ALLOW_REMOTE_OLLAMA=1 to use a remote endpoint on purpose.`,
+  );
+}

--- a/packages/daemon/src/learned-recall/reranker.ts
+++ b/packages/daemon/src/learned-recall/reranker.ts
@@ -9,6 +9,12 @@
  * unit-testable without a running model.
  */
 
+import { assertLocalOrOptIn } from "@bastra-recall/core";
+
+// Re-exported so existing importers (and tests) keep resolving it from here,
+// while the embedding path shares the same assertion. See #124/#125.
+export { assertLocalOrOptIn };
+
 export interface RerankCandidate {
   id: string;
   /** Short text the model judges against the query (title + summary). */
@@ -26,30 +32,6 @@ export interface RerankResult {
 export type ChatFn = (prompt: string) => Promise<string>;
 
 export const DEFAULT_RERANK_MODEL = "qwen3-vl:4b";
-
-/**
- * The reranker sends candidate memory text to the chat endpoint, so a non-loopback
- * `baseURL` means that text leaves the machine. The header contract is "no egress" —
- * this enforces it: stay on loopback by default, reach a remote endpoint only when the
- * operator opts in explicitly (BASTRA_ALLOW_REMOTE_OLLAMA=1). Guards against a mistyped
- * or injected BASTRA_OLLAMA_URL silently shipping memory off-box. Malformed URLs fall
- * through so the existing fetch path reports them as before. Exported for tests.
- */
-export function assertLocalOrOptIn(rawUrl: string): void {
-  let host: string;
-  try {
-    host = new URL(rawUrl).hostname.toLowerCase();
-  } catch {
-    return; // not a parseable URL — let fetch fail normally, behaviour unchanged
-  }
-  const isLoopback =
-    host === "localhost" || host === "::1" || host === "[::1]" || /^127\./.test(host);
-  if (isLoopback || process.env.BASTRA_ALLOW_REMOTE_OLLAMA === "1") return;
-  throw new Error(
-    `bastra-recall: refusing non-loopback Ollama endpoint "${host}" — the reranker would ` +
-      `send memory text off-box. Set BASTRA_ALLOW_REMOTE_OLLAMA=1 to use a remote endpoint on purpose.`,
-  );
-}
 
 /** A live Ollama chat client (POST /api/chat, non-streaming). */
 export function ollamaChat(opts: { baseURL?: string; model?: string; timeoutMs?: number } = {}): ChatFn {


### PR DESCRIPTION
Follows #124 (reranker loopback guard, merged) and closes the sibling gap filed as #125.

## The gap
#124 hardened the reranker's chat endpoint, but the same `BASTRA_OLLAMA_URL` feeds `OllamaEmbeddingProvider.embed()` with no guard — and that path carries *more* text than the reranker: every hybrid recall embeds the **query**, and indexing/backfill embeds **all memory text**. A mistyped or injected remote URL silently shipped that text off-box. The "no API key, no cloud, no egress" contract held at the small surface, not the large one.

## The fix — one shared assertion
Rather than re-implement the guard at each of the three embedding construction sites (`index.ts`, `bridge.ts`, `scripts/backfill-related.ts`), this makes the egress contract a single assertion:

- `assertLocalOrOptIn` moves into `@bastra-recall/core` (`packages/core/src/ollama-egress.ts`) — the lower layer both consumers reach. Logic unchanged.
- `reranker.ts` imports it from core and **re-exports** it: its public surface and the #124 tests are untouched; `ollamaChat` still guards exactly as before.
- `OllamaEmbeddingProvider` asserts on `baseURL` **at construction** — fail fast rather than leaking on the first embed. All three construction sites (and any future caller) inherit it.

Default (loopback) behaviour is byte-identical; a remote endpoint needs `BASTRA_ALLOW_REMOTE_OLLAMA=1`, the same opt-in as the reranker. Fail-closed; same self-inflicted-config / injected-env class as #124, larger surface.

## Placement — your call
I put the canonical guard in `core` so both paths share one copy (matching #125's "instead of each site re-implementing it"). That touches your just-merged `reranker.ts` — a one-line import + re-export. If you'd rather keep the guard's home in `daemon` and accept a small duplicate in `core`, that's a trivial reshape of this PR; say the word and I'll re-home it.

## Tests
+5 core tests (`packages/core/__tests__/ollama-egress.test.ts`): the guard (loopback allowed / non-loopback refused / opt-in / malformed-passthrough) + provider construction (remote refused unless opted in — the #125 root). `core` 65/65, `daemon` 238/238, both typecheck clean.

Closes #125.