### PR TITLE
eval: opt-in out-of-pool predictor + stratified transfer-gate (#129/#130)

### DIFF
--- a/packages/eval/oop-gate/.gitignore
+++ b/packages/eval/oop-gate/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/packages/eval/oop-gate/08_predictor.py
+++ b/packages/eval/oop-gate/08_predictor.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+08_predictor.py — out-of-pool predictor (P2-P4 of PLAN-oop-predictor.md).
+
+Cheap, query-side predictor: from FIRST-STAGE score-shape + query IDF, predict whether a
+far query's gold is IN the candidate pool (recall@pool membership) — BEFORE any reranker.
+out-of-pool = the slice no reranker/teacher can reach (the #129 stratification target).
+
+Pure numpy on purpose (Bellard): a logistic regression over ~9 features + ROC-AUC is ~40
+lines; no sklearn/torch dependency, runs on stock macOS python3 + numpy. The GPU/corpus step
+that produces the score dump is 08a_dump.py (run where e5-small + the MS MARCO subcorpus live).
+
+INPUT (from 08a_dump.py): scores_dump.json
+  [{qid, voice, top_scores:[float x K], gold_rank:int(1-based,-1 if not in top-K),
+    q_mean_idf:float, q_max_idf:float}, ...]
+LABEL: in_pool = 1 if 1 <= gold_rank <= POOL else 0.   (out-of-pool = the 0 class)
+
+GATES (Feynman-floor; see PLAN):
+  - group-CV by qid (the 6 voices of one query never leak across folds).
+  - NULL control x20: shuffle labels -> CV-AUC null dist; real must beat ALL 20.
+  - baseline floor: predictor must beat the BEST single feature; else report the feature (Bellard).
+
+Usage:
+  python3 08_predictor.py --synthetic            # self-test (no data needed)
+  python3 08_predictor.py scores_dump.json       # real run
+  python3 08_predictor.py scores_dump.json --pool 120
+"""
+import json, sys, argparse
+import numpy as np
+
+VOICES = ["orig", "terse", "verbose", "typos", "emotional", "oblique"]
+RNG = np.random.default_rng(42)
+
+# ---------- features (query-side, no gold needed) ----------
+def shape_features(top_scores):
+    s = np.asarray(top_scores, dtype=float)
+    s = s[np.isfinite(s)]
+    if s.size < 2:
+        return np.zeros(7)
+    srt = np.sort(s)[::-1]
+    top1 = srt[0]
+    margin = srt[0] - srt[1]
+    mean = s.mean()
+    std = s.std()
+    gap = srt[0] - srt[-1]
+    # softmax entropy over top-K (flat dist = no clear winner = likely hard/out-of-pool)
+    z = srt - srt.max()
+    p = np.exp(z); p /= p.sum()
+    entropy = float(-(p * np.log(p + 1e-12)).sum())
+    # decay slope: linear fit of sorted scores vs rank (steep = confident)
+    x = np.arange(srt.size)
+    slope = np.polyfit(x, srt, 1)[0]
+    return np.array([top1, margin, mean, std, gap, entropy, slope])
+
+FEATURE_NAMES = ["top1", "margin", "mean", "std", "gap", "entropy", "slope",
+                 "q_mean_idf", "q_max_idf"]
+
+def build_xy(records, pool):
+    X, y, qids, voices = [], [], [], []
+    for r in records:
+        feats = np.concatenate([shape_features(r["top_scores"]),
+                                [r.get("q_mean_idf", 0.0), r.get("q_max_idf", 0.0)]])
+        gr = r.get("gold_rank", -1)
+        in_pool = 1 if (gr is not None and 1 <= gr <= pool) else 0
+        X.append(feats); y.append(in_pool); qids.append(r["qid"]); voices.append(r.get("voice"))
+    return np.array(X), np.array(y), np.array(qids), np.array(voices)
+
+# ---------- numpy logistic regression ----------
+def standardize(Xtr, Xte):
+    mu = Xtr.mean(0); sd = Xtr.std(0); sd[sd == 0] = 1.0
+    return (Xtr - mu) / sd, (Xte - mu) / sd
+
+def fit_logreg(X, y, l2=1.0, iters=400, lr=0.5):
+    Xb = np.hstack([X, np.ones((X.shape[0], 1))])
+    w = np.zeros(Xb.shape[1])
+    n = len(y)
+    for _ in range(iters):
+        p = 1 / (1 + np.exp(-Xb @ w))
+        g = Xb.T @ (p - y) / n
+        g[:-1] += l2 * w[:-1] / n
+        w -= lr * g
+    return w
+
+def predict_logreg(w, X):
+    Xb = np.hstack([X, np.ones((X.shape[0], 1))])
+    return 1 / (1 + np.exp(-Xb @ w))
+
+# ---------- ROC-AUC (rank-based, Mann-Whitney) ----------
+def auc(y, scores):
+    y = np.asarray(y); scores = np.asarray(scores)
+    npos = (y == 1).sum(); nneg = (y == 0).sum()
+    if npos == 0 or nneg == 0:
+        return float("nan")
+    order = scores.argsort()
+    ranks = np.empty(len(scores)); ranks[order] = np.arange(1, len(scores) + 1)
+    # average ranks for ties
+    _, inv, cnt = np.unique(scores, return_inverse=True, return_counts=True)
+    sums = np.zeros(len(cnt)); np.add.at(sums, inv, ranks); avg = sums / cnt
+    ranks = avg[inv]
+    return float((ranks[y == 1].sum() - npos * (npos + 1) / 2) / (npos * nneg))
+
+# ---------- group K-fold by qid ----------
+def group_cv_scores(X, y, qids, k=5):
+    uq = np.array(sorted(set(qids))); RNG.shuffle(uq)
+    folds = np.array_split(uq, k)
+    oof = np.full(len(y), np.nan)
+    for f in folds:
+        te = np.isin(qids, f); tr = ~te
+        if (y[tr] == 1).sum() == 0 or (y[tr] == 0).sum() == 0:
+            continue
+        Xtr, Xte = standardize(X[tr], X[te])
+        w = fit_logreg(Xtr, y[tr])
+        oof[te] = predict_logreg(w, Xte)
+    return oof
+
+# ---------- evaluation ----------
+def evaluate(X, y, qids, voices, n_null=20):
+    oof = group_cv_scores(X, y, qids)
+    m = ~np.isnan(oof)
+    real = auc(y[m], oof[m])
+    # per-voice
+    pv = {}
+    for v in VOICES:
+        vm = m & (voices == v)
+        if vm.sum() and len(set(y[vm])) == 2:
+            pv[v] = auc(y[vm], oof[vm])
+    # null control: shuffle labels x N
+    nulls = []
+    for _ in range(n_null):
+        yn = y.copy(); RNG.shuffle(yn)
+        on = group_cv_scores(X, yn, qids)
+        mm = ~np.isnan(on)
+        nulls.append(auc(yn[mm], on[mm]))
+    nulls = np.array(nulls)
+    # single-feature baseline floor
+    base = {}
+    for i, name in enumerate(FEATURE_NAMES):
+        a = auc(y[m], X[m, i])
+        base[name] = max(a, 1 - a)  # feature may be anti-correlated
+    best_feat = max(base, key=base.get)
+    return {
+        "auc": real, "per_voice": pv,
+        "null_max": float(np.nanmax(nulls)), "null_mean": float(np.nanmean(nulls)),
+        "beats_null": bool(real > np.nanmax(nulls)),
+        "best_single_feature": best_feat, "best_single_auc": base[best_feat],
+        "beats_baseline": bool(real > base[best_feat]),
+        "feature_aucs": base,
+        "n": int(m.sum()), "pos": int(y[m].sum()), "neg": int((y[m] == 0).sum()),
+    }
+
+# ---------- synthetic self-test ----------
+def synthetic(n_q=150, pool=120):
+    """Plant a real signal: out-of-pool queries have FLATTER score dist + HIGHER idf.
+    oblique voice is hardest (more out-of-pool, weaker signal). Verifies the harness
+    recovers AUC>null on real data AND reports ~chance when the signal is removed."""
+    recs = []
+    for qi in range(n_q):
+        for v in VOICES:
+            hard = {"orig":0.05,"terse":0.12,"verbose":0.15,"typos":0.30,
+                    "emotional":0.18,"oblique":0.45}[v]
+            out = RNG.random() < hard
+            # REALISTIC: overlapping dists + noise; signal split across features so NO single
+            # feature separates (peak weak-but-noisy AND idf weak-but-noisy; only jointly informative).
+            peak = RNG.normal(0.30 if out else 0.45, 0.18)          # heavy overlap
+            base = RNG.normal(0.30, 0.08, size=pool)
+            base[0] += peak
+            base = np.sort(base)[::-1]
+            idf = RNG.normal(6.2 if out else 5.4, 2.2)              # weak, overlapping
+            recs.append({"qid": f"q{qi}", "voice": v,
+                         "top_scores": base.tolist(),
+                         "gold_rank": (-1 if out else int(RNG.integers(1, pool + 1))),
+                         "q_mean_idf": float(idf), "q_max_idf": float(idf + RNG.random())})
+    return recs
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump", nargs="?", help="scores_dump.json from 08a_dump.py")
+    ap.add_argument("--pool", type=int, default=120)
+    ap.add_argument("--synthetic", action="store_true")
+    a = ap.parse_args()
+    if a.synthetic:
+        print("[SELF-TEST on synthetic data — planted signal: out-of-pool = flat scores + high IDF]")
+        recs = synthetic(pool=a.pool)
+    else:
+        if not a.dump:
+            ap.error("give scores_dump.json or --synthetic")
+        recs = json.load(open(a.dump))
+    X, y, qids, voices = build_xy(recs, a.pool)
+    r = evaluate(X, y, qids, voices)
+    print(f"\nn={r['n']}  in-pool={r['pos']}  out-of-pool={r['neg']}  "
+          f"(out-of-pool rate {r['neg']/r['n']:.1%})")
+    print(f"\nROC-AUC (predict in-pool): {r['auc']:.3f}")
+    print(f"per-voice: " + "  ".join(f"{v} {r['per_voice'][v]:.3f}" for v in VOICES if v in r['per_voice']))
+    print(f"\nNULL (label-shuffle x20): max {r['null_max']:.3f}  mean {r['null_mean']:.3f}  "
+          f"-> beats null: {r['beats_null']}")
+    print(f"baseline floor: best single feature = '{r['best_single_feature']}' "
+          f"AUC {r['best_single_auc']:.3f}  -> beats baseline: {r['beats_baseline']}")
+    print("feature AUCs: " + "  ".join(f"{k} {v:.2f}" for k, v in
+          sorted(r['feature_aucs'].items(), key=lambda x: -x[1])))
+    # Feynman verdict
+    ok = r["beats_null"] and r["beats_baseline"]
+    print(f"\nVERDICT: {'SIGNAL (beats null AND single-feature floor)' if ok else 'NO real lift over floor — report the floor, not the model (Bellard)'}")
+
+if __name__ == "__main__":
+    main()

--- a/packages/eval/oop-gate/09_roleprobe.py
+++ b/packages/eval/oop-gate/09_roleprobe.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+09_roleprobe.py — P4 role-probe (the load-bearing part of PLAN-oop-predictor.md).
+
+AUC alone is NECESSARY but NOT SUFFICIENT for the claim "this predictor enables a held-out
+far set that makes the far-gate certify TRANSFER, not in-pool reorder." The role-probe is the
+falsifiable demonstration of that claim (-> feedback_probe_lever_role_before_claim).
+
+The argument (verified here on data, not prose):
+  A bridge is minted from in-pool far but MUST serve out-of-pool far (#129 transfer point).
+  - NAIVE held-out far set is ~85% in-pool. A "reorder-only" bridge (helps in-pool ranks,
+    can't touch out-of-pool) shows a big TOTAL far-lift -> a naive gate PASSES it.
+  - STRATIFIED held-out far set (predictor-balanced ~50/50) lets the gate read the OUT-OF-POOL
+    SLICE, where the reorder-only bridge does exactly nothing -> the gate correctly FAILS it.
+  => the predictor changes the gate verdict. That is its role.
+
+P4-NULL (anti-vanity, monitor own derivative -> idea_implicit_pick_label_blindspot):
+  if the naive set's out-of-pool slice is already large/measurable enough that its
+  out-of-pool-slice lift is read directly, stratification adds nothing -> say so.
+
+Uses TRUE in/out-of-pool labels to build the stratified set (in production the predictor
+ESTIMATES them; 08_predictor.py shows the estimate beats null+floor, so it can build this set).
+
+Usage:
+  python3 09_roleprobe.py --synthetic
+  python3 09_roleprobe.py scores_dump.json --pool 120
+"""
+import json, sys, argparse
+import numpy as np
+RNG = np.random.default_rng(42)
+K = 5            # recall@K the gate measures
+BOOST = 4        # reorder-only bridge: in-pool gold rank -> rank//BOOST (moves it up)
+
+def load(path, pool):
+    recs = json.load(open(path))
+    out = []
+    for r in recs:
+        if r.get("voice") == "orig":
+            continue  # far = reworded voices only
+        gr = r.get("gold_rank", -1)
+        in_pool = (gr is not None and 1 <= gr <= pool)
+        out.append({"rank": gr if in_pool else None, "in_pool": in_pool})
+    return out
+
+def synthetic(n=150, pool=120):
+    recs = []
+    for _ in range(n):
+        for v in ["terse","verbose","typos","emotional","oblique"]:
+            hard = {"terse":.12,"verbose":.15,"typos":.30,"emotional":.18,"oblique":.45}[v]
+            out = RNG.random() < hard
+            recs.append({"rank": None if out else int(RNG.integers(1, pool+1)),
+                         "in_pool": not out})
+    return recs
+
+def reorder_only(rank, in_pool):
+    """Bridge that only reshuffles WITHIN the pool. Out-of-pool stays unreachable."""
+    if not in_pool or rank is None:
+        return None              # cannot retrieve what's not in the pool
+    return max(1, rank // BOOST) # in-pool: moved up
+
+def recall_at_k(ranks):
+    r = [x for x in ranks if x is not None]
+    if not ranks: return 0.0
+    return sum(1 for x in r if x <= K) / len(ranks)
+
+def gate(subset):
+    before = [s["rank"] if s["in_pool"] else None for s in subset]
+    after  = [reorder_only(s["rank"], s["in_pool"]) for s in subset]
+    total_lift = recall_at_k(after) - recall_at_k(before)
+    oop = [s for s in subset if not s["in_pool"]]
+    if oop:
+        ob = [None for _ in oop]
+        oa = [reorder_only(s["rank"], s["in_pool"]) for s in oop]
+        oop_lift = recall_at_k(oa) - recall_at_k(ob)
+    else:
+        oop_lift = None
+    return total_lift, oop_lift, len(oop)/len(subset)
+
+def make_naive(recs, n=120):
+    idx = RNG.choice(len(recs), size=min(n, len(recs)), replace=False)
+    return [recs[i] for i in idx]
+
+def make_stratified(recs, n=120):
+    ins = [r for r in recs if r["in_pool"]]; outs = [r for r in recs if not r["in_pool"]]
+    half = min(n//2, len(ins), len(outs))
+    if half == 0: return make_naive(recs, n)
+    a = [ins[i] for i in RNG.choice(len(ins), half, replace=False)]
+    b = [outs[i] for i in RNG.choice(len(outs), half, replace=False)]
+    return a + b
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump", nargs="?"); ap.add_argument("--pool", type=int, default=120)
+    ap.add_argument("--synthetic", action="store_true")
+    a = ap.parse_args()
+    recs = synthetic(pool=a.pool) if a.synthetic else load(a.dump, a.pool)
+    nat_oop = sum(1 for r in recs if not r["in_pool"]) / len(recs)
+    print(f"far records: {len(recs)}  natural out-of-pool rate: {nat_oop:.1%}  "
+          f"(reorder-only bridge: in-pool rank//{BOOST}, out-of-pool untouched; gate=recall@{K})\n")
+
+    naive = make_naive(recs); strat = make_stratified(recs)
+    nt, no, nf = gate(naive)
+    st, so, sf = gate(strat)
+    print(f"NAIVE held-out far   (out-of-pool {nf:.0%}): total far-lift {nt:+.3f}  | "
+          f"out-of-pool-slice lift {no:+.3f}")
+    print(f"STRAT held-out far   (out-of-pool {sf:.0%}): total far-lift {st:+.3f}  | "
+          f"out-of-pool-slice lift {so:+.3f}")
+
+    print("\n--- verdict ---")
+    naive_passes = nt > 0.02                      # a naive gate keys on total far-lift
+    strat_oop_flat = (so is not None and abs(so) < 1e-9)
+    print(f"naive gate (keys on total far-lift) PASSES reorder-only bridge: {naive_passes} "
+          f"(lift {nt:+.3f}) — but it only reordered in-pool")
+    print(f"stratified gate reads out-of-pool slice = {so:+.3f} -> reorder-only bridge "
+          f"{'correctly FAILS the transfer test' if strat_oop_flat else 'shows lift (unexpected)'}")
+    role_real = naive_passes and strat_oop_flat
+    print(f"\nROLE: predictor-enabled stratification CHANGES the gate verdict: {role_real}")
+
+    # P4-NULL: would a naive set already expose the out-of-pool slice without the predictor?
+    print(f"\nP4-NULL check: naive set out-of-pool slice is {nf:.0%} of it; its slice-lift "
+          f"is already readable ({no:+.3f}). Stratification still matters because the naive "
+          f"gate's HEADLINE (total far-lift {nt:+.3f}) drowns it — a gate that reports only "
+          f"total lift is fooled; one that reports the out-of-pool slice is not. If a gate "
+          f"ALREADY reports the out-of-pool slice on a naive set, the predictor's only added "
+          f"value is making that slice big enough to be statistically stable.")
+
+if __name__ == "__main__":
+    main()

--- a/packages/eval/oop-gate/13_transfer_gate.py
+++ b/packages/eval/oop-gate/13_transfer_gate.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+13_transfer_gate.py — the #129 stratified TRANSFER gate (Tier A: public mechanism validation).
+
+daniel asked (in the #129 body, checkboxes "Refinement (per @zzallirog)") for a held-out gate that
+certifies a harvested bridge lifts the OUT-OF-POOL slice — real transfer — not just reorders in-pool
+far. A bridge is minted from in-pool far (Teacher 2 can only rescue what's already in the pool) but
+*mandated* to serve out-of-pool far; a naive held-out far set is ~85% in-pool, so a reorder-only
+bridge clears a naive far-lift gate while the residual it exists for is never measured.
+
+09_roleprobe.py is the proto-gate: it builds a predictor-stratified held-out far set and shows a
+reorder-only bridge passes a NAIVE gate (+total far-lift) but reads ~0 on the stratified out-of-pool
+slice. This file COMPLETES it into a real gate by adding the three pieces 09 lacks:
+
+  1. a POSITIVE control — a transfer bridge that actually pulls out-of-pool gold into the pool —
+     so the gate is shown to PASS a good bridge, not only FAIL a bad one (discrimination needs both);
+  2. a PAIRED, CONTINUOUS statistic — Delta-rank per out-of-pool case (gold rank with vs without the
+     bridge), median + Wilcoxon signed-rank + fraction crossing into the pool. Paired kills the
+     between-query variance that makes "52 out-of-pool cases" look hopeless; continuous extracts more
+     signal per case than a binary recall@K on ~10 cases;
+  3. SIGNIFICANCE + a negative control — Wilcoxon signed-rank over the non-zero Delta-ranks (the
+     transfer effect is minority-concentrated, so the median over ALL oop cases is 0 by design; the
+     test runs on the cases that moved), plus the reorder-only bridge as the empirical negative
+     control (it touches only in-pool, so its oop Delta is 0). A permutation/firing null is a Tier-B
+     instrument: it needs a real targeting signal (trigger-overlap firing) to permute — a modeled
+     bridge fires at random, so the permutation is degenerate here and is omitted (Bellard).
+
+HONEST SCOPE (load-bearing — read before quoting any number from this file):
+  Tier A validates the gate LOGIC on MODELED bridges over REAL dense-hard ranks. It proves the readout
+  (stratified out-of-pool paired Delta-rank) DISCRIMINATES transfer from reorder and survives the null.
+  It does NOT prove that real minted bridges pass: the effective sample is (out-of-pool cases) INTER
+  (queries a bridge actually fires on); the firing RULE is query-side (bridges.ts mintBridge:
+  trigger_terms = distinctiveTerms(query) — code-checked origin/main, reproducible publicly), so what
+  is vault-only is COVERAGE: the real harvested reaches + the #121 candidate-pool log = Tier B. Magnitudes here are ILLUSTRATIVE; what
+  is validated is the discrimination + null behaviour. shape-not-magnitude — same split as the #130
+  predictor: the exact number belongs to the production vault.
+
+  No k-fold here on purpose: k-fold guards mint/eval leakage, which only exists when bridges are MINTED
+  FROM DATA (Tier B, per-fold mint). Tier A models the bridges, so the statistic runs over the whole
+  stratified out-of-pool slice — nothing to fold against. Adding folds would be machinery that does no
+  work (Bellard).
+
+  4. SENSITIVITY (--power) — the power curve + MDE: the smallest crossed-in fraction the gate can
+     certify at 80% power on THIS slice's N. Turns "discriminates" (by-construction) into a calibrated
+     "detects a bridge crossing >= X% of out-of-pool gold on N=k" — and exposes the cost of the
+     predictor (its enriched tail has fewer cases, so a worse MDE than the true-label upper bound).
+
+Reuses 08_predictor (the #130 predictor) to ESTIMATE in/out-of-pool labels for stratification — the
+actual instrument daniel asked for; --true-labels gives the clean upper-bound demo (what 09 does).
+
+Usage:
+  python3 13_transfer_gate.py --synthetic
+  python3 13_transfer_gate.py scores_dump.json
+  python3 13_transfer_gate.py scores_dump.json --true-labels --pool 120
+  python3 13_transfer_gate.py scores_dump.json --power   # sensitivity / MDE
+"""
+import argparse
+import importlib
+import math
+
+import numpy as np
+
+pred = importlib.import_module("08_predictor")  # digit-prefixed: not a normal import
+
+VOICES = ["orig", "terse", "verbose", "typos", "emotional", "oblique"]
+POOL = 120
+K = 5            # recall@K reported alongside the rank stats (matches 09_roleprobe.K)
+BOOST = 4        # in-pool reorder strength (matches 09_roleprobe.BOOST)
+CORPUS_MISS = 5000  # deep rank assigned to a gold absent from the dump's full ranking (-1)
+RNG = np.random.default_rng(42)
+
+
+# ---------- load: keep the TRUE deep rank (09.load drops it to None for out-of-pool) ----------
+def load_deep(path, pool):
+    import json
+    recs = []
+    for r in json.load(open(path)):
+        if r.get("voice") == "orig":
+            continue  # far = reworded voices only
+        gr = r.get("gold_rank", -1)
+        rank = gr if (gr is not None and gr > 0) else CORPUS_MISS
+        recs.append({"qid": r["qid"], "voice": r.get("voice"), "rank": int(rank),
+                     "in_pool": bool(1 <= rank <= pool),
+                     "top_scores": r.get("top_scores", []),
+                     "q_mean_idf": r.get("q_mean_idf", 0.0), "q_max_idf": r.get("q_max_idf", 0.0)})
+    return recs
+
+
+# ---------- modeled bridges (deep-rank aware; supersede 09.reorder_only's None-for-oop) ----------
+def reorder_only(rank, in_pool, rng):
+    """Negative control: reshuffles WITHIN the pool, out-of-pool gold is untouched -> Delta=0."""
+    if in_pool:
+        return max(1, rank // BOOST)
+    return rank  # cannot reach what is not in the pool
+
+
+def transfer_bridge(rank, in_pool, rng, p=0.5):
+    """Positive control: with prob p a transfer bridge pulls an out-of-pool gold into the pool;
+    in-pool gold is reordered like reorder_only. Models a bridge that genuinely transfers."""
+    if in_pool:
+        return max(1, rank // BOOST)
+    if rng.random() < p:
+        return int(rng.integers(1, POOL + 1))  # crossed into the pool
+    return rank  # this firing missed
+
+
+# ---------- paired Delta-rank statistic on the out-of-pool slice ----------
+def _phi(z):
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def wilcoxon_signed_rank(deltas):
+    """One-sided (improvement = delta < 0). Normal approximation with tie-corrected ranks.
+    Returns (z, p_one_sided) for H1: median delta < 0."""
+    d = np.asarray([x for x in deltas if x != 0], dtype=float)
+    n = d.size
+    if n == 0:
+        return 0.0, 1.0
+    order = np.argsort(np.abs(d))
+    ranks = np.empty(n)
+    ranks[order] = np.arange(1, n + 1)
+    # average ranks for ties in |d|
+    _, inv, cnt = np.unique(np.abs(d), return_inverse=True, return_counts=True)
+    sums = np.zeros(len(cnt))
+    np.add.at(sums, inv, ranks)
+    ranks = (sums / cnt)[inv]
+    w_neg = ranks[d < 0].sum()   # rank mass of improvements
+    mean_w = n * (n + 1) / 4.0
+    sd_w = math.sqrt(n * (n + 1) * (2 * n + 1) / 24.0)
+    if sd_w == 0:
+        return 0.0, 1.0
+    z = (w_neg - mean_w) / sd_w           # positive z => improvements dominate
+    return z, 1.0 - _phi(z)               # small p => significant improvement
+
+
+def oop_delta_stats(subset, bridge, rng, pool):
+    """Paired Delta-rank over the OUT-OF-POOL slice of `subset` under `bridge`.
+    The transfer effect lands on a MINORITY of oop cases, so the median over all cases is
+    insensitive (>50% unmoved -> median 0). Headline numbers: crossed-in fraction
+    (production-relevant — oop gold pulled into the pool) and Wilcoxon signed-rank p over the
+    non-zero Delta-ranks (directional significance)."""
+    oop = [s for s in subset if not s["in_pool"]]
+    if not oop:
+        return {"n_oop": 0, "mean_delta": 0.0, "median_delta": 0.0, "p_wilcoxon": 1.0,
+                "frac_cross": 0.0, "recallK_lift": 0.0}
+    before = np.array([s["rank"] for s in oop], dtype=float)
+    after = np.array([bridge(s["rank"], s["in_pool"], rng) for s in oop], dtype=float)
+    deltas = after - before                       # negative = lifted toward / into the pool
+    _, p_wilcox = wilcoxon_signed_rank(deltas)
+    return {"n_oop": len(oop), "mean_delta": float(deltas.mean()),
+            "median_delta": float(np.median(deltas)), "p_wilcoxon": p_wilcox,
+            "frac_cross": float((after <= pool).mean()),
+            "recallK_lift": float((after <= K).mean() - (before <= K).mean())}
+
+
+# ---------- stratification (by a label key, so it works on true OR predicted labels) ----------
+def stratify(records, key, n, rng):
+    ins = [r for r in records if r[key]]
+    outs = [r for r in records if not r[key]]
+    half = min(n // 2, len(ins), len(outs))
+    if half == 0:
+        idx = rng.choice(len(records), size=min(n, len(records)), replace=False)
+        return [records[i] for i in idx]
+    a = [ins[i] for i in rng.choice(len(ins), half, replace=False)]
+    b = [outs[i] for i in rng.choice(len(outs), half, replace=False)]
+    return a + b
+
+
+def naive(records, n, rng):
+    idx = rng.choice(len(records), size=min(n, len(records)), replace=False)
+    return [records[i] for i in idx]
+
+
+def add_predicted_probs(records, pool):
+    """Reuse the #130 predictor (08): group-CV by qid, store P(in_pool) per record. We use the
+    RANKING (where its AUC lives), not a base-rate-fragile 0.5 threshold — at a 7% out-of-pool
+    base rate almost everything scores >0.5, so a threshold flags ~0 true out-of-pool.
+    Build X/y here (not pred.build_xy — that keys on 'gold_rank'; our records carry deep 'rank')."""
+    X = np.array([np.concatenate([pred.shape_features(r["top_scores"]),
+                                  [r["q_mean_idf"], r["q_max_idf"]]]) for r in records])
+    y = np.array([1 if r["in_pool"] else 0 for r in records])
+    qids = np.array([r["qid"] for r in records])
+    oof = pred.group_cv_scores(X, y, qids)
+    for r, p in zip(records, oof):
+        r["est_prob"] = float(p) if not np.isnan(p) else float(r["in_pool"])
+    m = ~np.isnan(oof)
+    return pred.auc(y[m], oof[m]) if m.sum() and len(set(y[m])) == 2 else float("nan")
+
+
+def stratify_prob(records, n):
+    """Predictor-built out-of-pool-enriched held-out set: the n records the #130 predictor ranks
+    LOWEST on P(in_pool) — its 'dig here for out-of-pool' tail. No ground truth used; this is the
+    production path daniel asked for. The true-oop rate of this tail vs the naive base rate is the
+    enrichment the predictor actually buys (bounded by its AUC, not the 50% of the --true-labels demo)."""
+    order = sorted(records, key=lambda r: r["est_prob"])
+    return order[:min(n, len(order))]
+
+
+# ---------- synthetic self-test (planted transfer signal; deep out-of-pool ranks) ----------
+def synthetic(n_q=150, pool=POOL):
+    recs = []
+    for qi in range(n_q):
+        for v in VOICES:
+            if v == "orig":
+                continue
+            hard = {"terse": .12, "verbose": .15, "typos": .30, "emotional": .18, "oblique": .45}[v]
+            out = RNG.random() < hard
+            rank = int(RNG.integers(pool + 1, 3000)) if out else int(RNG.integers(1, pool + 1))
+            # score-shape: out-of-pool = flatter top scores (so the predictor has something to learn)
+            peak = RNG.normal(0.30 if out else 0.45, 0.18)
+            base = RNG.normal(0.30, 0.08, size=pool)
+            base[0] += peak
+            base = np.sort(base)[::-1]
+            idf = RNG.normal(6.2 if out else 5.4, 2.2)
+            recs.append({"qid": f"q{qi}", "voice": v, "rank": rank,
+                         "in_pool": (not out), "top_scores": base.tolist(),
+                         "q_mean_idf": float(idf), "q_max_idf": float(idf + RNG.random())})
+    return recs
+
+
+def power_curve(strat, pool, ps=(0.05, 0.10, 0.15, 0.20, 0.30, 0.40, 0.50), trials=300):
+    """Sensitivity of the gate on THIS out-of-pool slice (its N + real rank distribution): for each
+    transfer strength p (prob an out-of-pool gold is pulled into the pool), what fraction of trials
+    does the gate certify (crossed-in>0 AND Wilcoxon p<0.05 AND mean Δrank<0)? Gives the MDE — the
+    smallest crossed-in fraction the gate can detect at 80% power. NOT a claim a bridge works; a clean
+    injected effect characterizing the instrument — a real (noisier) bridge's power is at most this."""
+    rows = []
+    for p in ps:
+        passes = 0
+        crossed = []
+        for t in range(trials):
+            rng = np.random.default_rng(10_000 + t)  # independent draw per trial
+            o = oop_delta_stats(strat, lambda r, ip, rg: transfer_bridge(r, ip, rg, p=p), rng, pool)
+            crossed.append(o["frac_cross"])
+            if o["frac_cross"] > 0 and o["p_wilcoxon"] < 0.05 and o["mean_delta"] < 0:
+                passes += 1
+        rows.append((p, passes / trials, float(np.mean(crossed))))
+    return rows
+
+
+def run(records, strat, pool, rng, n=200):
+    nv = naive(records, n, rng)
+    bridges = {"transfer (positive control)": transfer_bridge,
+               "reorder-only (negative control)": reorder_only}
+    out = {}
+    for name, br in bridges.items():
+        # naive read: total far-lift recall@K (what a naive gate keys on)
+        nb = np.array([s["rank"] for s in nv], dtype=float)
+        na = np.array([br(s["rank"], s["in_pool"], rng) for s in nv], dtype=float)
+        total_lift = float((na <= K).mean() - (nb <= K).mean())
+        out[name] = {"total_far_lift": total_lift, "oop": oop_delta_stats(strat, br, rng, pool)}
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump", nargs="?", help="scores_dump_*.json from 08a_dump.py")
+    ap.add_argument("--pool", type=int, default=POOL)
+    ap.add_argument("--synthetic", action="store_true")
+    ap.add_argument("--true-labels", action="store_true",
+                    help="stratify by true in/out (clean upper bound); default uses the #130 predictor")
+    ap.add_argument("--power", action="store_true",
+                    help="report the gate's sensitivity (power curve + MDE) on this oop slice's N")
+    a = ap.parse_args()
+
+    if a.synthetic:
+        print("[SELF-TEST on synthetic data — planted: out-of-pool = flat scores; transfer bridge p=0.5]")
+        records = synthetic(pool=a.pool)
+    else:
+        if not a.dump:
+            ap.error("give a scores_dump_*.json or --synthetic")
+        records = load_deep(a.dump, a.pool)
+
+    nat_oop = sum(1 for r in records if not r["in_pool"]) / len(records)
+    print(f"far records: {len(records)}  out-of-pool cases: {sum(1 for r in records if not r['in_pool'])}"
+          f"  (natural rate {nat_oop:.1%})  pool@{a.pool}\n")
+
+    if a.true_labels:
+        strat = stratify(records, "in_pool", 200, RNG)
+        print("stratifying by TRUE in/out-of-pool labels (clean upper-bound demo)\n")
+    else:
+        auc = add_predicted_probs(records, a.pool)
+        strat = stratify_prob(records, 200)
+        print(f"stratifying by the #130 PREDICTOR's ranking (ROC-AUC {auc:.3f}, group-CV; "
+              f"low P(in_pool) = likely out-of-pool)\n")
+
+    out = run(records, strat, a.pool, RNG)
+    strat_oop = sum(1 for s in strat if not s["in_pool"]) / len(strat)
+    print(f"stratified held-out far: {len(strat)} cases, out-of-pool {strat_oop:.0%} "
+          f"(was {nat_oop:.0%} naive)\n")
+
+    print(f"{'bridge':32} {'total far-lift':>14} | {'oop n':>5} {'mean Δrank':>11} "
+          f"{'crossed-in':>10} {'p(wilcox)':>9}")
+    print("-" * 92)
+    for name, r in out.items():
+        o = r["oop"]
+        print(f"{name:32} {r['total_far_lift']:+14.3f} | {o['n_oop']:5d} {o['mean_delta']:+11.0f} "
+              f"{o['frac_cross']:10.2f} {o['p_wilcoxon']:9.3f}")
+
+    t = out["transfer (positive control)"]["oop"]
+    ro = out["reorder-only (negative control)"]["oop"]
+    print("\n--- verdict (discrimination = PASS transfer AND FAIL reorder, both on the oop slice) ---")
+    transfer_pass = (t["frac_cross"] > 0) and (t["p_wilcoxon"] < 0.05) and (t["mean_delta"] < 0)
+    reorder_fail = (ro["frac_cross"] == 0.0) and (ro["p_wilcoxon"] > 0.05)
+    print(f"  transfer PASSES oop gate:    {transfer_pass}  "
+          f"(crossed-in {t['frac_cross']:.2f}, mean Δrank {t['mean_delta']:+.0f}, wilcoxon p {t['p_wilcoxon']:.3f})")
+    print(f"  reorder-only FAILS oop gate: {reorder_fail}  "
+          f"(crossed-in {ro['frac_cross']:.2f}, wilcoxon p {ro['p_wilcoxon']:.3f}) "
+          f"— but its TOTAL far-lift {out['reorder-only (negative control)']['total_far_lift']:+.3f} "
+          f"would PASS a naive gate")
+    print(f"\n  GATE DISCRIMINATES (Tier A mechanism validated): {transfer_pass and reorder_fail}")
+    print("  demotion (daniel's 'free'): a bridge with mean oop Δrank >= 0 IS the `fails` counterpart.")
+
+    if a.power:
+        n_oop = sum(1 for s in strat if not s["in_pool"])
+        print(f"\n--- sensitivity (power) on this slice: {n_oop} out-of-pool cases ---")
+        print(f"{'transfer p':>10} {'crossed-in':>11} {'detection@.05':>14}")
+        print("-" * 37)
+        curve = power_curve(strat, a.pool)
+        mde = None
+        for p, det, cross in curve:
+            print(f"{p:10.2f} {cross:11.2f} {det:14.2f}")
+            if mde is None and det >= 0.80:
+                mde = cross
+        if mde is not None:
+            print(f"\n  MDE: the gate certifies a bridge crossing >= {mde:.0%} of out-of-pool gold "
+                  f"at 80% power on N={n_oop}.")
+        else:
+            print(f"\n  UNDERPOWERED: even crossing {curve[-1][2]:.0%} of out-of-pool gold is detected "
+                  f"<80% of the time on N={n_oop} — this slice is too small; widen the corpus (Tier B "
+                  f"has the real N) before trusting a borderline gate verdict.")
+        print("  (clean injected effect — a real, noisier bridge's power is AT MOST this.)")
+    print("\nNOTE: Tier A = gate LOGIC on modeled bridges over real ranks. Real minted-bridge coverage/"
+          "verdict = Tier B (real Teacher-2 mint + harvested reaches + #121 log coverage, production vault).")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/eval/oop-gate/README.md
+++ b/packages/eval/oop-gate/README.md
@@ -1,0 +1,90 @@
+# Out-of-pool predictor + stratified transfer-gate
+
+An opt-in eval harness for the verification contract in #129, with the #130 out-of-pool predictor as
+the stratifier. Pure Python + numpy, no dependency on the core, nothing wired into recall — you run it
+against a score dump and it tells you whether a bridge earns promotion.
+
+## Why a *stratified* gate
+
+A bridge is minted from in-pool far: `harvestFarBridges` reranks only what's already in `entry.pool`,
+so Teacher 2 can only rescue a candidate that the pool already contained. But a bridge is *mandated to
+serve* out-of-pool far — the residual the candidate generator missed. A naively-drawn held-out far set
+is ~94% in-pool, so a bridge can clear a "far lift" gate by reordering in-pool far while the
+out-of-pool residual it exists for is never measured. The gate has to certify **transfer**, not
+in-pool reorder.
+
+The predictor builds the held-out set deliberately: it scores each far query on its first-stage
+score-shape (top-k entropy / std / score-gap) + query IDF and predicts whether the gold is in-pool,
+so you can oversample genuine out-of-pool cases. Then the gate reads the **out-of-pool slice only**.
+
+## Scripts
+
+- `08_predictor.py` — the out-of-pool predictor (#130). Logistic regression over score-shape + IDF,
+  group-CV by qid, null-controlled (label shuffle ×20), reported against the best single-feature floor.
+- `09_roleprobe.py` — shows the stratification *changes the verdict*: a reorder-only bridge clears a
+  naive far-lift gate but reads ~0 on the stratified out-of-pool slice.
+- `13_transfer_gate.py` — the gate. Builds the predictor-stratified held-out set, then for each
+  out-of-pool case measures the gold's rank with vs without a bridge — a paired Δrank, scored as the
+  crossed-into-pool fraction plus a Wilcoxon over the non-zero deltas. `--power` reports the MDE.
+
+All three carry a `--synthetic` self-test that runs with no data.
+
+## Input
+
+The scripts read a `scores_dump.json` — one record per (query, voice):
+
+```json
+{"qid": "...", "voice": "oblique", "top_scores": [<first-stage scores, descending>],
+ "gold_rank": 137, "q_mean_idf": 4.08, "q_max_idf": 6.63}
+```
+
+`gold_rank` is 1-based over the full ranking (so out-of-pool = `gold_rank > pool`). `top_scores` is the
+first-stage similarity distribution the predictor reads. Generate it however your stack produces
+first-stage rankings; the eval downstream is pure numpy.
+
+## Run
+
+```
+python3 08_predictor.py scores_dump.json            # the stratifier (ROC-AUC, null, floor)
+python3 13_transfer_gate.py scores_dump.json --power # the gate + sensitivity
+python3 13_transfer_gate.py --synthetic              # self-test, no data
+```
+
+## What a run shows (public MS MARCO, seed 42, dense-hard)
+
+```
+predictor ROC-AUC 0.804 (group-CV); stratified far out-of-pool 7% -> 16%
+bridge                       total far-lift |  oop n  mean Δrank  crossed-in  p(wilcox)
+transfer (positive control)         +0.165  |    33      -234        0.39       0.001   PASS
+reorder-only (negative control)     +0.165  |    33        +0        0.00       1.000   FAIL
+MDE: certifies a bridge crossing >= 19% of the out-of-pool slice at 80% power on N=33.
+```
+
+The reorder-only bridge posts the same healthy *total* far-lift a naive gate would pass — and the
+stratified out-of-pool readout correctly fails it. Demotion falls out for free: a bridge with median
+out-of-pool Δrank ≥ 0 is the `fails` counterpart.
+
+## Scope
+
+This validates the gate's *logic*, not real bridges. The positive control is a modeled transfer
+bridge (it crosses out-of-pool gold in by construction), so what's shown is that the readout
+discriminates transfer from reorder and survives the null — not that any harvested bridge transfers.
+It runs on a public MS MARCO proxy (e5-small dense ⊕ a lexical arm), so trust the direction, not the
+magnitude. And the out-of-pool N is small (~52 on the full far set, ~33 in the predictor's tail), so
+the MDE is ~10–19%; below that a verdict is underpowered. The promote/demote call on real harvested
+bridges belongs to a run on the production vault, with real reaches and the #121 candidate-pool log.
+
+## Notes from building it
+
+Three choices that aren't obvious until the implementation bites:
+
+1. The out-of-pool readout can't be a plain recall@k or its median — transfer hits a minority of the
+   slice, so more than half the cases are unmoved and a median sits at 0 even for a real bridge. The
+   paired Δrank (crossed-in fraction + Wilcoxon over the non-zero deltas) separates them.
+2. Stratify by the predictor's *ranking*, not a 0.5 threshold — at a ~6% out-of-pool base rate almost
+   everything scores in-pool, so a threshold flags nearly nothing. The low-probability tail (where the
+   AUC lives) is what enriches the held-out set.
+3. Report the MDE alongside the verdict — at small N a pass/fail can be underpowered noise, and the
+   power curve makes that explicit.
+
+Refs: #130 · #129 · #128 · #120 · #121 · #102 · #89.


### PR DESCRIPTION
Following up on #130 — here's the out-of-pool predictor written up as the opt-in eval tool, together with the stratified transfer-gate it was built to feed (#129). It lands under `packages/eval/oop-gate/` as standalone Python (numpy only): nothing imports the core, nothing is wired into recall, and each script has a `--synthetic` self-test that runs with no data.

The point of the gate is the transfer requirement we landed in #129. A bridge is minted from in-pool far — `harvestFarBridges` reranks only `entry.pool`, so Teacher 2 can only rescue what the pool already held — but it's mandated to serve out-of-pool far. A naive held-out far set is ~94% in-pool, so a bridge can clear a far-lift gate on in-pool reorder while the residual it exists for goes unmeasured. The predictor (score-shape + IDF, null-controlled, ROC-AUC ~0.72–0.80 on the hard voices) builds a held-out set deliberately enriched in out-of-pool cases, and the gate reads that slice only — a paired Δrank per case (crossed-into-pool fraction + Wilcoxon over the non-zero deltas), so it certifies transfer rather than reorder. Demotion falls out for free: median out-of-pool Δrank ≥ 0 is the `fails` counterpart.

On the public dense-hard set it does what it should — a reorder-only bridge posts a healthy total far-lift a naive gate would pass, and fails the stratified out-of-pool readout:

| bridge | total far-lift | oop n | crossed-in | p(wilcoxon) | |
|---|---|---|---|---|---|
| transfer | +0.165 | 33 | 0.39 | 0.001 | PASS |
| reorder-only | +0.165 | 33 | 0.00 | 1.000 | FAIL |

One honest caveat up front: this validates the gate's *logic*, not real bridges. The positive control is a modeled transfer bridge (it crosses out-of-pool gold in by construction), so what's shown is that the readout discriminates transfer from reorder and survives the null — not that a harvested bridge transfers. It runs on a public MS MARCO proxy (e5-small dense ⊕ a lexical arm), so it's direction not magnitude. And the out-of-pool N is small (~52 full, ~33 in the predictor's tail), so the gate reports its own MDE — on this N it can certify a bridge crossing ≥ ~10–19% of the slice at 80% power, and flags when a verdict is underpowered rather than reading noise as signal. The promote/demote call on real harvested bridges is a run on the production vault, with real reaches and the #121 log.

Input schema, run instructions, and the three implementation notes (why the readout can't be a plain recall@k, why you stratify by the predictor's ranking rather than a 0.5 threshold, why the MDE matters) are in `packages/eval/oop-gate/README.md`. Happy to adjust where it sits or fold it into the existing eval package — opt-in either way.

Refs: #130 · #129 · #128 · #120 · #121 · #102 · #89.
