### PR TITLE
parseExpansions: drop slug-chains the prompt can't reliably suppress

### DIFF
--- a/packages/core/__tests__/trigger-expand.test.ts
+++ b/packages/core/__tests__/trigger-expand.test.ts
@@ -16,6 +16,7 @@ import type { Memory } from "../src/schema.js";
 import {
   TriggerExpander,
   buildExpandPrompt,
+  isSlugChain,
   parseExpansions,
   sourceHash,
 } from "../src/trigger-expand.js";
@@ -101,6 +102,51 @@ test("parseExpansions drops empties + over-long lines and caps at max", () => {
   const raw = ["a", "", "   ", "x".repeat(200), "b", "c", "d"].join("\n");
   const out = parseExpansions(raw, [], 3);
   assert.deepEqual(out, ["a", "b", "c"]);
+});
+
+test("isSlugChain flags multi-segment / mixed-delimiter glue, keeps real search tokens", () => {
+  // slug-chains the model emits despite the prompt — must be dropped
+  for (const slug of [
+    "panel-close-fix",
+    "Bastra-Branding-finalisierung-von-nexus-recall",
+    "min-width-zero-effect",
+    "api-load-distribution-changes",
+    "timestamps-store-utc",
+    "some_id_token",
+    "path/to/file.md",
+  ]) {
+    assert.equal(isSlugChain(slug), true, `should flag slug: ${slug}`);
+  }
+  // real single-token search terms — must be kept (regression: a length filter
+  // can't tell these from slugs; an over-eager "any hyphen" filter eats them)
+  for (const term of [
+    "fenster",
+    "z-index",
+    "min-width",
+    "ci/cd",
+    "gpt-4",
+    "read-only",
+    "doc2query",
+  ]) {
+    assert.equal(isSlugChain(term), false, `should keep term: ${term}`);
+  }
+  // any whitespace → a real query, never a slug
+  assert.equal(isSlugChain("why does my panel close by itself"), false);
+});
+
+test("parseExpansions drops slug-chains but keeps clean phrases and legit hyphen terms", () => {
+  const raw = [
+    "why does my panel close by itself", // keep: real phrase
+    "panel-close-fix", // drop: slug-chain
+    "z-index", // keep: 2-segment term
+    "min-width-zero-effect", // drop: slug-chain
+    "fenster schließt sich von selbst", // keep: real phrase
+  ].join("\n");
+  assert.deepEqual(parseExpansions(raw, [], 5), [
+    "why does my panel close by itself",
+    "z-index",
+    "fenster schließt sich von selbst",
+  ]);
 });
 
 test("sourceHash is stable and changes when recall_when/title/summary change", () => {

--- a/packages/core/src/trigger-expand.ts
+++ b/packages/core/src/trigger-expand.ts
@@ -194,10 +194,30 @@ export function buildExpandPrompt(m: Memory): string {
 }
 
 /**
+ * A slug/tag/id/filename chain — a single whitespace-free token glued by 2+
+ * delimiters, or by mixed delimiters. The prompt forbids these ("NOT a slug ...
+ * like panel-close-fix"), but a small local model emits them anyway, and a
+ * length filter can't catch them (a slug is short). They poison the BM25 index
+ * with noise terms, so they're dropped structurally rather than trusted to the
+ * prompt.
+ *
+ * Deliberately keeps real single-token search terms: a clean word ("fenster"),
+ * a 2-segment term ("z-index", "min-width", "ci/cd"), a version ("gpt-4"). Only
+ * 3+-segment or mixed-delimiter glue reads as a slug. (A phrase with any
+ * whitespace is a real query and never a slug.)
+ */
+export function isSlugChain(phrase: string): boolean {
+  if (/\s/.test(phrase)) return false;
+  const delims = phrase.match(/[-_/.]/g) ?? [];
+  return delims.length >= 2 || new Set(delims).size >= 2;
+}
+
+/**
  * Parse the model's reply into clean phrases: split on lines, strip bullets/
- * numbering/quotes, drop empties and over-long lines, dedupe (case-insensitive)
- * against each other AND the existing triggers (a paraphrase that just repeats a
- * trigger is dead weight), cap at `max`.
+ * numbering/quotes, drop empties, over-long lines, and slug-chains (see
+ * isSlugChain), dedupe (case-insensitive) against each other AND the existing
+ * triggers (a paraphrase that just repeats a trigger is dead weight), cap at
+ * `max`.
  */
 export function parseExpansions(raw: string, existing: string[], max: number): string[] {
   const seen = new Set(existing.map((t) => t.trim().toLowerCase()));
@@ -207,7 +227,7 @@ export function parseExpansions(raw: string, existing: string[], max: number): s
       .replace(/^\s*(?:[-*•]|\d+[.)])\s*/, "") // bullet / "1." / "1)"
       .replace(/^["'`]|["'`]$/g, "") // wrapping quotes
       .trim();
-    if (!phrase || phrase.length > MAX_PHRASE_LEN) continue;
+    if (!phrase || phrase.length > MAX_PHRASE_LEN || isSlugChain(phrase)) continue;
     const key = phrase.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);


### PR DESCRIPTION
## Problem
The shipped sharpened prompt (493c04e) forbids slug-chains, but qwen2.5:3b still
emits them — and `parseExpansions` only filters by length, which a slug (short)
passes. They land in `recall_when_expanded` and poison the BM25 index. This is
the post-filter task from #143.

## Fix
Drop slug-chains structurally instead of trusting the prompt: a whitespace-free
token glued by 2+ delimiters (or mixed delimiters) is a slug. A clean word
("fenster"), a 2-segment term ("z-index", "min-width", "ci/cd"), or a version
("gpt-4") is kept. Write-time only — query path byte-identical, no hot-path cost.

## Measured (qwen2.5:3b, bastra eval+sample fixtures, n=790 generated phrases)
| gate | slug-kill (62 confirmed-garbage) | legit hyphen terms kept (14 real terms) |
|---|---|---|
| current (`length<=80`) | 0/62 | 14/14 |
| word-count `>=2` | 62/62 | 0/14 |
| **this PR (segment-aware)** | **62/62** | **13/14** |

The shipped filter leaks every slug; a naive word/hyphen filter eats real terms
like `z-index`. Segment-aware kills the garbage and keeps the terms (only miss:
`left-to-right`). A stronger model (7b -> 0% slugs) or prompt tweak lowers the
rate but never to zero on a 3b — so the gate is the guarantee, not the model.

## Scope
Refs #143. Addresses the post-filter task. The vault re-expand (`strip --apply`)
and the recall-quality lift on the eval harness remain open.
