### PR TITLE
Central pre-ingest scrubber: strip our own injections before heuristics/doc2query, flag at save (#149)

### DIFF
--- a/packages/core/__tests__/scrub.test.ts
+++ b/packages/core/__tests__/scrub.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests für scrub.ts (#149) — injected-context scrubbing.
+ * Nur komplette paired Blöcke werden entfernt; bare mentions (Memories, die
+ * die Hook-Formate selbst dokumentieren) bleiben unangetastet.
+ *
+ * Runner: tsx --test packages/core/__tests__/scrub.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  scrubInjectedBlocks,
+  containsInjectedBlock,
+  INJECTED_BLOCK_TAGS,
+} from "../src/scrub.js";
+
+function block(tag: string, attrs = "", body = "quoted scaffolding"): string {
+  return `<${tag}${attrs}>\n${body}\n</${tag}>`;
+}
+
+test("scrub removes a complete block for every inventoried tag", () => {
+  for (const tag of INJECTED_BLOCK_TAGS) {
+    const input = `before\n${block(tag)}\nafter`;
+    const { text, removed } = scrubInjectedBlocks(input);
+    assert.ok(!text.includes(`<${tag}`), `block <${tag}> should be gone`);
+    assert.match(text, /before/);
+    assert.match(text, /after/);
+    assert.deepEqual(removed, [tag]);
+  }
+});
+
+test("scrub removes blocks with attributes in the open tag", () => {
+  const input = `x ${block("recall-hints", ' surface="claude-code" trigger="bash-destructive"')} y`;
+  const { text, removed } = scrubInjectedBlocks(input);
+  assert.ok(!text.includes("recall-hints"));
+  assert.deepEqual(removed, ["recall-hints"]);
+});
+
+test("scrub removes multiple blocks of mixed families mid-text", () => {
+  const input = [
+    "user typed this",
+    block("session-context", ' surface="claude-code" project="x"', "- hint a: packages/a.ts"),
+    "more prose",
+    block("system-reminder", "", "As you answer..."),
+    block("save-eval", "", "suggestion body"),
+    "tail",
+  ].join("\n");
+  const { text, removed } = scrubInjectedBlocks(input);
+  assert.match(text, /user typed this/);
+  assert.match(text, /more prose/);
+  assert.match(text, /tail/);
+  assert.ok(!text.includes("packages/a.ts"), "content inside blocks must not survive");
+  assert.deepEqual(removed, ["session-context", "save-eval", "system-reminder"]);
+});
+
+test("bare tag mentions survive — memories documenting the hook format stay intact", () => {
+  const input = "Der Stop-Hook emittiert <save-eval>-Blöcke; der Session-Hook <vault-taxonomy>.";
+  const { text, removed } = scrubInjectedBlocks(input);
+  assert.equal(text, input);
+  assert.deepEqual(removed, []);
+  assert.deepEqual(containsInjectedBlock(input), []);
+});
+
+test("unterminated block (no close tag) is left untouched", () => {
+  const input = "<recall-hints surface=\"claude-code\">\n- dangling hint without close";
+  const { text, removed } = scrubInjectedBlocks(input);
+  assert.equal(text, input);
+  assert.deepEqual(removed, []);
+});
+
+test("scrub is idempotent and collapses leftover blank runs", () => {
+  const input = `a\n\n${block("bastra-update")}\n\nb`;
+  const once = scrubInjectedBlocks(input);
+  assert.ok(!/\n{3,}/.test(once.text), "no 3+ newline runs after scrub");
+  const twice = scrubInjectedBlocks(once.text);
+  assert.equal(twice.text, once.text);
+  assert.deepEqual(twice.removed, []);
+});
+
+test("containsInjectedBlock reports complete blocks without rewriting", () => {
+  const input = `t ${block("pending-save-suggestions", ' source="stop-hook"')} t`;
+  assert.deepEqual(containsInjectedBlock(input), ["pending-save-suggestions"]);
+});

--- a/packages/core/__tests__/trigger-expand.test.ts
+++ b/packages/core/__tests__/trigger-expand.test.ts
@@ -273,3 +273,15 @@ test("backfill expands every un-expanded memory, then is idempotent", async () =
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("buildExpandPrompt scrubs injected context blocks from source fields (#149)", () => {
+  const p = buildExpandPrompt(
+    fakeMemory({
+      summary:
+        'resignKey observer must respect attachedSheet <session-context surface="claude-code">- hint: packages/daemon/src/hook.ts</session-context>',
+    }),
+  );
+  assert.match(p, /resignKey observer must respect attachedSheet/);
+  assert.ok(!p.includes("session-context"), "scaffolding tag must not seed paraphrases");
+  assert.ok(!p.includes("packages/daemon/src/hook.ts"), "block content must not seed paraphrases");
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,9 @@ export type { Memory, MemoryType, Frontmatter } from "./schema.js";
 
 export { truncateSummaryTo, clampSummary, SUMMARY_MAX } from "./summary.js";
 
+export { scrubInjectedBlocks, containsInjectedBlock, INJECTED_BLOCK_TAGS } from "./scrub.js";
+export type { ScrubResult, InjectedBlockTag } from "./scrub.js";
+
 export { detectTopics, detectProject, extractContentExcerpt } from "./topics.js";
 export type { ToolIntent, TopicResult } from "./topics.js";
 

--- a/packages/core/src/scrub.ts
+++ b/packages/core/src/scrub.ts
@@ -1,0 +1,93 @@
+/**
+ * Injected-context scrubbing (#149) — the single inventory of block markers
+ * that bastra's own hooks (and the Claude Code harness) inject into
+ * conversations, plus helpers to strip complete blocks from text before it
+ * re-enters an ingest path (stop-hook transcript heuristics, doc2query prompt
+ * input) or to flag them at save time (save_quality advisory).
+ *
+ * Only a COMPLETE paired block (`<tag …>` … `</tag>`) counts as injected
+ * context. A bare mention of a tag name — e.g. a memory documenting the hook
+ * format itself — is deliberately left untouched, so memories ABOUT bastra's
+ * own hooks stay writable.
+ *
+ * Why this exists: recalled context that gets quoted in a turn can otherwise
+ * be re-captured as new memory content and re-indexed by doc2query — a
+ * recursive pollution loop that skews trigger vocabulary and the heuristics'
+ * file-token scans.
+ *
+ * Leaf module by design (like summary.ts): dependency-free, importable from
+ * both core and daemon without creating import cycles.
+ */
+
+/**
+ * Block tags treated as injected conversation scaffolding. First the blocks
+ * bastra's hooks emit (see the hook sources in packages/daemon/src), then the
+ * Claude Code harness blocks that appear inside transcripts.
+ */
+export const INJECTED_BLOCK_TAGS = [
+  // bastra hook output
+  "recall-hints",
+  "session-context",
+  "vault-taxonomy",
+  "bastra-update",
+  "pending-save-suggestions",
+  "bastra-product-docs",
+  "save-eval",
+  "taxonomy-drift",
+  // Claude Code harness injections
+  "system-reminder",
+  "command-name",
+  "local-command-caveat",
+] as const;
+
+export type InjectedBlockTag = (typeof INJECTED_BLOCK_TAGS)[number];
+
+/**
+ * Fresh regex per call — a shared global-flagged RegExp carries lastIndex
+ * state across calls, which is a classic source of skipped matches. The
+ * construction cost is negligible at this call volume (≤ ~30 turns × 11 tags
+ * per stop-hook run).
+ */
+function blockRe(tag: string): RegExp {
+  return new RegExp(`<${tag}(?:\\s[^>]*)?>[\\s\\S]*?</${tag}>`, "g");
+}
+
+export interface ScrubResult {
+  text: string;
+  /** Tags whose complete blocks were removed (deduped, inventory order). */
+  removed: InjectedBlockTag[];
+}
+
+/**
+ * Remove every complete injected block from `text`. Runs of 3+ newlines left
+ * behind by removed blocks are collapsed to a blank line; everything else is
+ * preserved verbatim. Idempotent.
+ */
+export function scrubInjectedBlocks(text: string): ScrubResult {
+  const removed: InjectedBlockTag[] = [];
+  let out = text;
+  for (const tag of INJECTED_BLOCK_TAGS) {
+    // Quick reject before paying for the regex — most texts carry no marker.
+    if (!out.includes(`<${tag}`)) continue;
+    const next = out.replace(blockRe(tag), "");
+    if (next !== out) {
+      removed.push(tag);
+      out = next;
+    }
+  }
+  if (removed.length > 0) out = out.replace(/\n{3,}/g, "\n\n");
+  return { text: out, removed };
+}
+
+/**
+ * Detect complete injected blocks without rewriting — for advisory paths
+ * (save_quality) where content must never be silently modified.
+ */
+export function containsInjectedBlock(text: string): InjectedBlockTag[] {
+  const found: InjectedBlockTag[] = [];
+  for (const tag of INJECTED_BLOCK_TAGS) {
+    if (!text.includes(`<${tag}`)) continue;
+    if (blockRe(tag).test(text)) found.push(tag);
+  }
+  return found;
+}

--- a/packages/core/src/trigger-expand.ts
+++ b/packages/core/src/trigger-expand.ts
@@ -32,6 +32,7 @@ import matter from "gray-matter";
 import type { Vault } from "./vault.js";
 import type { EmbeddingIndex } from "./embeddings.js";
 import type { Memory } from "./schema.js";
+import { scrubInjectedBlocks } from "./scrub.js";
 
 /** Injected chat function: prompt in, raw model reply out (same shape the
  *  learned-recall reranker uses, so the daemon can pass `ollamaChat`). */
@@ -170,8 +171,12 @@ export function sourceHash(m: Memory): string {
 }
 
 /** Build the doc2query prompt: ask for short, reworded search phrases in the
- *  vault's bilingual register, deliberately avoiding the existing trigger words. */
+ *  vault's bilingual register, deliberately avoiding the existing trigger words.
+ *  Source fields are scrubbed of injected context blocks (#149) so quoted hook
+ *  scaffolding never seeds paraphrases; sourceHash stays on the RAW fields —
+ *  re-expansion keys on author edits, not on scrub behavior. */
 export function buildExpandPrompt(m: Memory): string {
+  const clean = (s: string) => scrubInjectedBlocks(s).text;
   return [
     "A user saved this personal memory. Write 3-5 alternative search queries they",
     "might type WEEKS LATER to find it again, using DIFFERENT words than the memory",
@@ -187,9 +192,9 @@ export function buildExpandPrompt(m: Memory): string {
     "- Mix German and English naturally (the vault is bilingual).",
     "- One query per line. No numbering, no quotes, no commentary, no headings.",
     "",
-    `Title: ${m.fm.title}`,
-    `Summary: ${m.fm.summary}`,
-    `Existing triggers: ${m.fm.recall_when.join(" | ")}`,
+    `Title: ${clean(m.fm.title)}`,
+    `Summary: ${clean(m.fm.summary)}`,
+    `Existing triggers: ${m.fm.recall_when.map(clean).join(" | ")}`,
   ].join("\n");
 }
 

--- a/packages/daemon/__tests__/stop-hook.test.ts
+++ b/packages/daemon/__tests__/stop-hook.test.ts
@@ -272,3 +272,47 @@ describe("stop-hook: parseTranscriptFile", () => {
     assert.deepEqual(parseTranscriptFile("not json at all"), []);
   });
 });
+
+describe("stop-hook: #149 injected-context scrubbing in normalizeTurns", () => {
+  const HINT_BLOCK =
+    '<recall-hints surface="claude-code" trigger="todo-plan">\n' +
+    `- lesson foo: edited ${FIVE_SOURCE_FILES}\n` +
+    "</recall-hints>";
+
+  it("strips embedded injected blocks but keeps surrounding prose", () => {
+    const items = [{ role: "user", content: `kurze frage\n${HINT_BLOCK}\nund noch text` }];
+    const turns = normalizeTurns(items);
+    assert.equal(turns[0].role, "user");
+    assert.match(turns[0].content, /kurze frage/);
+    assert.match(turns[0].content, /und noch text/);
+    assert.ok(!turns[0].content.includes("recall-hints"));
+    assert.ok(!turns[0].content.includes("stop-hook.ts"), "file tokens inside the block must be gone");
+  });
+
+  it("feature-completion does not count file tokens quoted inside injected blocks", () => {
+    // Without the scrub this fires: user confirms a commit and an injected
+    // hint block carries 5 repo-relative source paths.
+    const items = [
+      { role: "user", content: "ok, bitte git commit machen" },
+      { role: "user", content: HINT_BLOCK },
+    ];
+    const turns = normalizeTurns(items);
+    assert.equal(detectFeatureCompletion(turns, ALL_EXIST), null);
+  });
+
+  it("feature-completion still fires when the same files appear as real prose", () => {
+    const items = [
+      { role: "user", content: "ok, bitte git commit machen" },
+      { role: "assistant", content: FIVE_SOURCE_FILES },
+    ];
+    const turns = normalizeTurns(items);
+    assert.ok(detectFeatureCompletion(turns, ALL_EXIST));
+  });
+
+  it("prefix-injected turns keep their system-injected role (scrub runs after classification)", () => {
+    const items = [{ role: "user", content: "<system-reminder>\nwieder wieder wieder wieder\n</system-reminder>" }];
+    const turns = normalizeTurns(items);
+    assert.equal(turns[0].role, "system-injected");
+    assert.ok(!turns[0].content.includes("system-reminder"));
+  });
+});

--- a/packages/daemon/src/stop-hook.ts
+++ b/packages/daemon/src/stop-hook.ts
@@ -30,6 +30,7 @@ import { request } from "node:http";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
+import { scrubInjectedBlocks } from "@bastra-recall/core";
 import { envFirst, envInt } from "./env.js";
 import { defaultLogDir } from "./telemetry.js";
 import { writePendingSuggestion } from "./pending-suggestions.js";
@@ -307,21 +308,32 @@ function normalizeTurns(items: unknown[]): TranscriptTurn[] {
     const directRole = obj.role;
     const directContent = obj.content;
     if (typeof directRole === "string") {
-      out.push({ role: effectiveRole(directRole, directContent), content: stringifyContent(directContent) });
+      out.push({ role: effectiveRole(directRole, directContent), content: scrubTurnContent(stringifyContent(directContent)) });
       continue;
     }
     const msg = obj.message;
     if (msg && typeof msg === "object") {
       const m = msg as Record<string, unknown>;
       const role = typeof m.role === "string" ? m.role : "unknown";
-      out.push({ role: effectiveRole(role, m.content), content: stringifyContent(m.content) });
+      out.push({ role: effectiveRole(role, m.content), content: scrubTurnContent(stringifyContent(m.content)) });
       continue;
     }
     if (typeof obj.text === "string") {
-      out.push({ role: "unknown", content: obj.text });
+      out.push({ role: "unknown", content: scrubTurnContent(obj.text) });
     }
   }
   return out;
+}
+
+// #149: our own hook injections (<recall-hints>, <session-context>, …) quote
+// file paths and trigger vocabulary. Embedded mid-turn they survive the
+// prefix-based role reclassification above, and detectFeatureCompletion scans
+// EVERY role's text for file tokens — so recalled context could count toward
+// its own re-capture. Scrub complete blocks AFTER role classification (the
+// prefix match in effectiveRole needs the raw text) so every heuristic sees
+// clean prose.
+function scrubTurnContent(text: string): string {
+  return scrubInjectedBlocks(text).text;
 }
 
 function stringifyContent(content: unknown): string {

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -18,6 +18,7 @@ import {
   truncateSummaryTo,
   SaveMemoryInput,
   stripAutoRelatedSection,
+  containsInjectedBlock,
   type Vault,
   type SearchIndex,
   type StageListener,
@@ -537,6 +538,25 @@ function scoreSaveQuality(deps: ToolDeps, input: SaveMemoryInput): SaveQualityRe
     issues.push(`generic tags: ${genericTags.join(", ")}`);
     suggestions.push("add at least one project/component/outcome tag so future matches are narrower");
     score -= Math.min(24, genericTags.length * 12);
+  }
+
+  // #149: a complete hook/context block quoted in memory content is
+  // conversation scaffolding, not memory — it re-enters the index via body
+  // search and (title/summary) doc2query. Advisory only: save content is never
+  // silently rewritten; the agent removes the block and re-saves.
+  const injectedTags = Array.from(
+    new Set([
+      ...containsInjectedBlock(input.title),
+      ...containsInjectedBlock(input.summary),
+      ...containsInjectedBlock(input.body),
+    ]),
+  );
+  if (injectedTags.length > 0) {
+    issues.push(`injected context blocks in content: <${injectedTags.join(">, <")}>`);
+    suggestions.push(
+      "remove quoted hook/context blocks (<recall-hints>, <session-context>, <system-reminder>, …) — they are conversation scaffolding, not memory content",
+    );
+    score -= 20;
   }
 
   const duplicateQuery = [input.title, input.summary, ...input.recall_when, ...input.tags].join(" ");


### PR DESCRIPTION
## What

Closes #149 (v0.8 wave A).

Recalled context that gets quoted in a turn could re-enter the vault and the index — hook hint blocks carry file paths and trigger vocabulary, so they could count toward their own re-capture (stop-hook file-token scan) and seed doc2query paraphrases.

**New core leaf module `scrub.ts`** — single inventory of all injected block markers (8 bastra hook families + 3 Claude Code harness tags) with `scrubInjectedBlocks` / `containsInjectedBlock`. Only **complete paired blocks** are treated as scaffolding; bare tag mentions survive, so memories documenting the hook formats themselves stay writable.

**Three boundaries wired:**
1. **stop-hook** — `normalizeTurns` scrubs every turn after role classification; all heuristics (incl. `detectFeatureCompletion`, which scans every role's text) now see clean prose.
2. **doc2query** — `buildExpandPrompt` scrubs title/summary/recall_when; `sourceHash` stays on raw fields.
3. **save_quality** — advisory issue/suggestion when saved content carries a complete block; save content is never silently rewritten.

## Tests

- `packages/core/__tests__/scrub.test.ts`: every tag family, attributes, mid-text, multiples, bare-mention survival, unterminated block untouched, idempotency, newline collapse.
- stop-hook: injected hint block with 5 repo-relative source paths no longer triggers feature-completion; same paths as real prose still do; prefix-injected turns keep their `system-injected` role.
- trigger-expand: scaffolding never reaches the expand prompt.

Full suite: 348 tests, 347 pass, 0 fail (the remaining one is the pre-existing `test.todo` third survival arm → #153). `check:types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)