### PR TITLE
Trivial-prompt gate: skip candidate injection for acks and slash commands (#151)

### DIFF
--- a/packages/daemon/__tests__/prompt-hook.test.ts
+++ b/packages/daemon/__tests__/prompt-hook.test.ts
@@ -15,6 +15,7 @@ import {
   detectRetrieval,
   extractPrompt,
   formatHintBlock,
+  isTrivialPrompt,
   type RecallHit,
 } from "../src/prompt-hook.ts";
 
@@ -262,4 +263,35 @@ test("integration — wrong hook_event_name emits empty object", async () => {
   } finally {
     await daemon.close();
   }
+});
+
+// ─── #151: trivial-prompt gate ───────────────────────────────────────────
+
+test("isTrivialPrompt gates bare acks DE+EN (trailing punctuation tolerated)", () => {
+  for (const p of ["ok", "OK!", "ja", "Ja.", "danke", "passt", "yes", "thanks", "weiter", "nö", "go"]) {
+    assert.equal(isTrivialPrompt(p), true, `should gate: ${p}`);
+  }
+});
+
+test("isTrivialPrompt gates slash-command invocations, typed and expanded", () => {
+  assert.equal(isTrivialPrompt("/fast"), true);
+  assert.equal(isTrivialPrompt("/code-review ultra 123"), true);
+  assert.equal(isTrivialPrompt("<command-name>/effort</command-name>\nstdout follows"), true);
+  assert.equal(isTrivialPrompt("<local-command-caveat>...</local-command-caveat>"), true);
+});
+
+test("isTrivialPrompt does NOT gate paths, retrieval queries, or real prose", () => {
+  assert.equal(isTrivialPrompt("/Users/n0mad/Projekte/x bitte lesen"), false);
+  assert.equal(isTrivialPrompt("find my rental contract"), false);
+  assert.equal(isTrivialPrompt("such mal meinen mietvertrag"), false);
+  assert.equal(isTrivialPrompt("wo ist die config für den daemon"), false);
+  assert.equal(isTrivialPrompt("ok, aber warum schlägt der test fehl?"), false);
+});
+
+test("gate wins over retrieval regex on expanded command payloads", () => {
+  // An expanded slash-command payload whose body happens to contain a
+  // retrieval-shaped phrase must still be gated — the phrase is skill/command
+  // scaffolding, not user intent.
+  const payload = "<command-name>/deep-research</command-name>\nfind all sources about X";
+  assert.equal(isTrivialPrompt(payload), true);
 });

--- a/packages/daemon/src/prompt-hook.ts
+++ b/packages/daemon/src/prompt-hook.ts
@@ -113,6 +113,41 @@ export function detectRetrieval(prompt: string): boolean {
   return RETRIEVAL_DE.test(trimmed) || RETRIEVAL_EN.test(trimmed);
 }
 
+// #151: trivial-prompt gate. Bare acks, one-worders and slash-command
+// invocations cannot act on recalled context — injecting there is pure
+// context tax (and with BASTRA_PROMPT_HOOK_MODE=all the hook otherwise fires
+// on EVERY prompt). Deterministic DE+EN check, runs before any recall work.
+const TRIVIAL_ACKS = new Set([
+  // EN
+  "ok", "okay", "k", "kk", "yes", "yep", "yeah", "no", "nope", "thx",
+  "thanks", "thank you", "cool", "nice", "great", "perfect", "go",
+  "continue", "proceed", "stop", "wait", "done", "sure",
+  // DE
+  "ja", "jo", "jep", "nein", "ne", "nö", "danke", "super", "top", "passt",
+  "perfekt", "weiter", "mach", "mach weiter", "los", "gut", "genau",
+  "richtig", "stimmt", "erledigt", "fertig",
+]);
+
+// A typed slash command: "/name" or "/name args". The first token must not
+// contain a second "/" so absolute paths ("/Users/… bitte lesen") never gate.
+const SLASH_COMMAND_RE = /^\/[a-z0-9][a-z0-9_-]*(?:\s|$)/i;
+
+export function isTrivialPrompt(prompt: string): boolean {
+  const trimmed = prompt.trim();
+  if (trimmed.length === 0) return true;
+  // Slash-command invocations — typed directly, or already expanded by
+  // Claude Code into <command-name>/<local-command-*> blocks. The retrieval
+  // regex would otherwise match phrases inside the expanded command/skill
+  // body instead of user intent.
+  if (SLASH_COMMAND_RE.test(trimmed) && !trimmed.includes("\n")) return true;
+  if (trimmed.includes("<command-name>") || trimmed.startsWith("<local-command-")) return true;
+  // Bare ack / one-worder (trailing punctuation tolerated).
+  const bare = trimmed.toLowerCase().replace(/[\s!.?…]+$/u, "");
+  if (TRIVIAL_ACKS.has(bare)) return true;
+  if (bare.length <= 2) return true;
+  return false;
+}
+
 export function extractPrompt(payload: ClaudeHookPayload): string | null {
   const raw =
     typeof payload.prompt === "string"
@@ -143,6 +178,25 @@ async function main(): Promise<void> {
 
   const prompt = extractPrompt(payload);
   if (!prompt) return emitEmpty();
+
+  // #151: gate before any recall work — the saved tokens surface in stats
+  // via status:"gated" + gated:true.
+  if (isTrivialPrompt(prompt)) {
+    emitEmpty();
+    await writeTelemetry({
+      detected_mode: "none",
+      gated: true,
+      prompt_chars: prompt.length,
+      daemon_url: null,
+      daemon_reachable: false,
+      hint_count: 0,
+      top_score: null,
+      latency_ms_total: Date.now() - startedAt,
+      status: "gated",
+      error: null,
+    });
+    return;
+  }
 
   const isRetrieval = detectRetrieval(prompt);
   let detectedMode: DetectedMode;
@@ -369,13 +423,15 @@ function postRecall(
 
 interface PromptHookTelemetry {
   detected_mode: DetectedMode;
+  /** #151: true when the trivial-prompt gate suppressed injection. */
+  gated?: boolean;
   prompt_chars: number;
   daemon_url: string | null;
   daemon_reachable: boolean;
   hint_count: number;
   top_score: number | null;
   latency_ms_total: number;
-  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" | "gated";
   error: string | null;
 }
 


### PR DESCRIPTION
## What

Closes #151 (v0.8 wave A).

Telemetry shows hint tokens spent on turns that cannot use them. This adds a deterministic DE+EN gate in the prompt-hook that runs **before any recall work**:

- **Bare acks / one-worders** (`ok`, `ja`, `danke`, `thanks`, `weiter`, …) — trailing punctuation tolerated.
- **Slash-command invocations** — typed (`/fast`, `/code-review ultra`) and already-expanded payloads (`<command-name>`/`<local-command-*>` blocks). The anchored retrieval regex could otherwise match phrases inside an expanded command/skill body and inject on scaffolding instead of user intent.
- Absolute paths never gate (first token must not contain a second slash), so `/Users/… bitte lesen` passes through; real retrieval queries and prose are untouched.

Gated turns log `status:"gated"` + `gated:true` with `prompt_chars`, so stats can report the saved tokens (net-context-ROI numerator stays honest).

Scope note: the PreToolUse hooks need no equivalent — they are tool-event-driven (no prompt input) and already have their own skip-gates (#20).

## Tests

isTrivialPrompt unit tests: DE+EN acks, typed + expanded slash commands, path false-positive guard, retrieval queries and mixed prose stay un-gated, and the gate-wins-over-retrieval-regex case on expanded payloads.

Full suite: 352 tests, 351 pass, 0 fail (remaining todo = third survival arm → #153). `check:types` clean.

Independent of #167 (different sites in prompt-hook.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)