### PR TITLE
Anti-thrash save semantics: terminal success note + consecutive-failure cap (#150)

### DIFF
--- a/packages/daemon/__tests__/save-anti-thrash.test.ts
+++ b/packages/daemon/__tests__/save-anti-thrash.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests für #150 — anti-thrash semantics on save_memory:
+ * consecutive-failure cap (terminal "STOP retrying" error) and the terminal
+ * success note. A failed memory side effect must never eat the turn.
+ *
+ * Runner: tsx --test packages/daemon/__tests__/save-anti-thrash.test.ts
+ */
+import { describe, it, beforeEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+import { Telemetry } from "../src/telemetry.js";
+import {
+  saveMemoryHandler,
+  noteSaveFailure,
+  resetSaveFailures,
+  SAVE_FAILURE_CAP,
+  SAVE_FAILURE_WINDOW_MS,
+  type ToolDeps,
+} from "../src/tool-handlers.js";
+
+// Invalid input only needs to survive until safeParse — deps are never touched.
+const DUMMY_DEPS = {} as ToolDeps;
+
+async function makeDeps(): Promise<{ deps: ToolDeps; close: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-thrash-test-"));
+  const vault = new Vault(dir);
+  await vault.init();
+  const search = new SearchIndex(vault);
+  search.start();
+  const deps: ToolDeps = { vault, search, telemetry: new Telemetry(), vaultPath: dir };
+  return {
+    deps,
+    close: async () => {
+      search.stop();
+      await vault.stop?.();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+const VALID_SAVE = {
+  title: "anti-thrash test memory",
+  type: "lesson",
+  summary: "a summary",
+  body: "a body",
+  topic_path: ["test"],
+  tags: ["test"],
+  scope: "test-scope",
+  recall_when: ["running the anti-thrash test"],
+};
+
+describe("#150: noteSaveFailure window semantics", () => {
+  beforeEach(() => resetSaveFailures());
+
+  it("counts consecutive failures", () => {
+    assert.equal(noteSaveFailure(1000), 1);
+    assert.equal(noteSaveFailure(2000), 2);
+    assert.equal(noteSaveFailure(3000), 3);
+  });
+
+  it("expired window restarts the streak", () => {
+    noteSaveFailure(1000);
+    noteSaveFailure(2000);
+    assert.equal(noteSaveFailure(2000 + SAVE_FAILURE_WINDOW_MS + 1), 1);
+  });
+});
+
+describe("#150: saveMemoryHandler failure cap", () => {
+  beforeEach(() => resetSaveFailures());
+
+  it("turns the error terminal at the cap and stays terminal", async () => {
+    for (let i = 1; i < SAVE_FAILURE_CAP; i++) {
+      await assert.rejects(
+        saveMemoryHandler(DUMMY_DEPS, { not: "valid" }),
+        (err: Error) => !err.message.includes("STOP retrying"),
+        `failure ${i} must stay a plain error`,
+      );
+    }
+    await assert.rejects(
+      saveMemoryHandler(DUMMY_DEPS, { not: "valid" }),
+      (err: Error) =>
+        err.message.includes("STOP retrying") && err.message.includes("last error:"),
+      "failure at cap must be terminal",
+    );
+    // A further retry stays terminal — no reset on the terminal path.
+    await assert.rejects(
+      saveMemoryHandler(DUMMY_DEPS, { not: "valid" }),
+      (err: Error) => err.message.includes("STOP retrying"),
+      "retry after terminal must stay terminal",
+    );
+  });
+
+  it("a successful save resets the streak and carries the terminal note", async () => {
+    const { deps, close } = await makeDeps();
+    try {
+      await assert.rejects(saveMemoryHandler(deps, { not: "valid" }));
+      await assert.rejects(saveMemoryHandler(deps, { not: "valid" }));
+
+      const result = await saveMemoryHandler(deps, VALID_SAVE);
+      assert.equal(result.created, true);
+      assert.match(result.note ?? "", /do not repeat/);
+
+      // Streak was reset by the success: the next failure is plain again.
+      await assert.rejects(
+        saveMemoryHandler(deps, { not: "valid" }),
+        (err: Error) => !err.message.includes("STOP retrying"),
+        "failure after success must be a plain error again",
+      );
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -426,6 +426,8 @@ export interface SaveMemoryResult {
   save_quality: SaveQualityResult;
   /** Present only when saveMemory auto-truncated an over-long summary. */
   summary_note?: string;
+  /** #150: terminal success marker — tells the model not to re-issue the save. */
+  note?: string;
 }
 
 export const GENERIC_TRIGGER_WORDS = new Set([
@@ -602,7 +604,57 @@ function scoreSaveQuality(deps: ToolDeps, input: SaveMemoryInput): SaveQualityRe
   };
 }
 
+// ─── #150: anti-thrash — consecutive-failure cap on save_memory ─────────
+// A repeatedly failing save (schema retry loop, path issue) must never eat
+// the turn: after SAVE_FAILURE_CAP consecutive failures the error turns
+// terminal ("STOP retrying") until a save succeeds or the window expires.
+// Deliberately daemon-global rather than per-session: this is a local
+// single-user daemon, the CC session id does not reach this handler, and the
+// time window bounds any cross-session bleed.
+export const SAVE_FAILURE_CAP = 3;
+export const SAVE_FAILURE_WINDOW_MS = 10 * 60_000;
+let saveFailureCount = 0;
+let saveFailureLastAt = 0;
+
+export function noteSaveFailure(now: number = Date.now()): number {
+  if (now - saveFailureLastAt > SAVE_FAILURE_WINDOW_MS) saveFailureCount = 0;
+  saveFailureLastAt = now;
+  saveFailureCount += 1;
+  return saveFailureCount;
+}
+
+export function resetSaveFailures(): void {
+  saveFailureCount = 0;
+  saveFailureLastAt = 0;
+}
+
 export async function saveMemoryHandler(
+  deps: ToolDeps,
+  rawArgs: unknown,
+): Promise<SaveMemoryResult> {
+  let result: SaveMemoryResult;
+  try {
+    result = await saveMemoryInner(deps, rawArgs);
+  } catch (err) {
+    const failures = noteSaveFailure();
+    if (failures >= SAVE_FAILURE_CAP) {
+      // No reset here: every further attempt stays terminal until a success
+      // or the window expiry clears the streak.
+      throw new Error(
+        `save_memory failed ${failures} times in a row — STOP retrying this save. ` +
+          `Continue with the user's actual task and report the failed save in your reply instead. ` +
+          `(last error: ${(err as Error).message})`,
+      );
+    }
+    throw err;
+  }
+  resetSaveFailures();
+  // Terminal success marker: no state echo beyond the advisory — a re-issued
+  // identical save is thrash, not diligence.
+  return { ...result, note: "Save complete — do not repeat this save_memory call." };
+}
+
+async function saveMemoryInner(
   deps: ToolDeps,
   rawArgs: unknown,
 ): Promise<SaveMemoryResult> {


### PR DESCRIPTION
## What

Closes #150 (v0.8 wave A).

- **Terminal success marker**: `save_memory` responses now end with `note: "Save complete — do not repeat this save_memory call."` — no vault-state echo beyond the existing advisory, so a successful save never invites a redundant re-issue.
- **Consecutive-failure cap**: after 3 consecutive failed saves within a 10-minute window, the thrown error turns terminal — *"STOP retrying this save. Continue with the user's actual task and report the failed save in your reply instead"* (original error appended) — and **stays** terminal until a success or window expiry clears the streak. A failed memory side effect must never block the user's actual task.
- Deliberately daemon-global rather than per-session (documented in code): local single-user daemon, the CC session id does not reach this handler, the window bounds cross-session bleed.
- `save_quality` advisory behavior is unchanged.

## Tests

New `save-anti-thrash.test.ts`: window semantics (streak count, expiry restart), plain→terminal transition at the cap, terminal persistence on further retries, and success-resets-streak + note presence against a real temp vault.

Full suite: 352 tests, 351 pass, 0 fail (todo = third survival arm → #153). `check:types` clean. Independent of #167/#168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)