### PR TITLE
fix(deps): bump js-yaml to 3.15.0 (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1911,9 +1911,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Lockfile-only bump within gray-matter's `^3.13` range — no code or API change.

Fixes the quadratic-complexity DoS in merge-key handling ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68), moderate) reported by the Scorecard Vulnerabilities check as code-scanning alert #22. The alert closes on the next Scorecard run.

`npm audit --omit=dev`: 0 vulnerabilities. Full suite after rebuild: 362 tests, 361 pass, 0 fail (todo = third survival arm → #153).

Companion change (repo settings, no code): Dependabot security alerts + automated security-fix PRs are now enabled, so future CVEs surface immediately instead of via the weekly Scorecard SARIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)