### PR TITLE
Widen the acted_on measuring surface: Bash act-signal on every completed command (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **What it is** — A long-term memory for any AI assistant or agent: Claude (Code, Desktop, Web), ChatGPT (via Custom GPT Actions), Cursor, and anything else that speaks MCP or HTTP. Whenever you correct it, state a rule, or commit to a decision, it gets saved as a small note. In your next chat — days or weeks later, in any tool — the AI pulls those notes back automatically. No more repeating yourself. Everything stays on your own Mac as plain Markdown files (Obsidian-compatible). All your AI tools share the same memory at the same time.
 
-**Status** — 🟢 Early beta. M0 (eval) and M1 (read path) done, M2 (save path) functional, and the Claude Code reflex layer ships with hooks for `SessionStart`, `UserPromptSubmit`, `PreToolUse` file edits / todos / bash safety, `PostToolUse` bash failures, plus optional `Stop` save-eval. Distribution and multi-surface hardening are active. See [PLAN.md](./PLAN.md).
+**Status** — 🟢 Early beta. M0 (eval) and M1 (read path) done, M2 (save path) functional, and the Claude Code reflex layer ships with hooks for `SessionStart`, `UserPromptSubmit`, `PreToolUse` file edits / todos / bash safety, `PostToolUse` bash act-signals + failure recall, plus optional `Stop` save-eval. Distribution and multi-surface hardening are active. See [PLAN.md](./PLAN.md).
 
 ### Why
 
@@ -305,7 +305,7 @@ Built by [@n0mad-ai](https://github.com/n0mad-ai).
 
 **Was es ist** — Ein Langzeit-Gedächtnis für jeden AI-Assistenten oder Agent: Claude (Code, Desktop, Web), ChatGPT (via Custom GPT Actions), Cursor und alles andere, was MCP oder HTTP spricht. Sobald du etwas korrigierst, eine Regel aufstellst oder eine Entscheidung triffst, wird das als kleine Notiz gespeichert. In der nächsten Sitzung — Tage oder Wochen später, in jedem Tool — holt die AI diese Notizen automatisch wieder hervor. Schluss mit ewigem Wiederholen. Alles bleibt lokal auf deinem Mac als reine Markdown-Dateien (Obsidian-kompatibel). Alle deine AI-Tools teilen sich dasselbe Gedächtnis gleichzeitig.
 
-**Status** — 🟢 Frühe Beta. M0 (Eval) und M1 (Read-Path) fertig, M2 (Save-Path) funktional, und der Claude-Code-Reflex-Layer liefert Hooks für `SessionStart`, `UserPromptSubmit`, `PreToolUse` (Datei-Edits / Todos / Bash-Safety), `PostToolUse` (Bash-Fehler) plus optionalen `Stop` Save-Eval. Distribution und Multi-Surface-Hardening laufen. Siehe [PLAN.md](./PLAN.md).
+**Status** — 🟢 Frühe Beta. M0 (Eval) und M1 (Read-Path) fertig, M2 (Save-Path) funktional, und der Claude-Code-Reflex-Layer liefert Hooks für `SessionStart`, `UserPromptSubmit`, `PreToolUse` (Datei-Edits / Todos / Bash-Safety), `PostToolUse` (Bash Act-Signal + Fehler-Recall) plus optionalen `Stop` Save-Eval. Distribution und Multi-Surface-Hardening laufen. Siehe [PLAN.md](./PLAN.md).
 
 ### Warum
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -35,7 +35,7 @@ After `npm run build` the daemon package exposes these bin entries:
 | `bastra-recall-prompt-hook`       | `UserPromptSubmit` | — (every user message)                    | Lookup-mode reflex (#33)                                  |
 | `bastra-recall-todo-hook`         | `PreToolUse`       | `TodoWrite`                               | Topology recall before multi-step plans (#36)             |
 | `bastra-recall-bash-pre-hook`     | `PreToolUse`       | `Bash` (destructive/risky)                | Safety recall before destructive shell ops (#34)          |
-| `bastra-recall-bash-fail-hook`    | `PostToolUse`      | `Bash` (non-zero exit)                    | Lesson recall when a Bash command fails (#37)             |
+| `bastra-recall-bash-fail-hook`    | `PostToolUse`      | `Bash` (every completed command)          | Act-signal for acted_on (#144); lesson recall on failure (#37) |
 | `bastra-recall-stop-hook`         | `Stop`             | —                                         | Optional autonomous save-eval at end of session (#35)      |
 
 ## Activation snippet for `~/.claude/settings.json`
@@ -147,19 +147,27 @@ Does **not** block. The agent decides whether to proceed.
 Telemetry: `bash_hook_call` with `matched_pattern, severity, hit_count,
 top_score, status`.
 
-### `bastra-recall-bash-fail-hook` (#37)
+### `bastra-recall-bash-fail-hook` (#37, #144)
 
-Fires on `PostToolUse` for Bash when `exit_code !== 0` (excluding 130 =
-Ctrl-C). Extracts the command head + last interesting error lines, recalls
-similar failure-mode memories, and emits
-`<recall-hints surface="claude-code" trigger="bash-fail">`.
+Fires on `PostToolUse` for every completed Bash command (excluding 130 =
+Ctrl-C) and does two jobs:
 
-Throttled to one hint per 30 s per session (marker file in
-`$TMPDIR/bastra-hook/fail-throttle-<session>.ts`). Skips its own
-`bastra-recall-*` invocations to avoid loops.
+1. **Act-signal (#144), every command — success and failure.** Sends the
+   command text as a lightweight telemetry-only ping to `POST /hook/act`;
+   the daemon matches it against open loaded-memory episodes so shell-driven
+   applications of a memory can score `acted_on`. No recall, no injection,
+   never throttled; failures are swallowed within a ≤120 ms budget.
+2. **Fail-recall (#37), `exit_code !== 0` only.** Extracts the command head +
+   last interesting error lines, recalls similar failure-mode memories, and
+   emits `<recall-hints surface="claude-code" trigger="bash-fail">`.
+
+The fail-recall is throttled to one hint per 30 s per session (marker file in
+`$TMPDIR/bastra-hook/fail-throttle-<session>.ts`); the act-signal is not.
+Skips its own `bastra-recall-*` invocations to avoid loops.
 
 Telemetry: `bash_fail_hook_call` with `exit_code, command_head, hit_count,
-top_score, status`.
+top_score, status` (hook side) and `hook_act` with `tool_name, excerpt_chars,
+matched_episodes, exit_code` (daemon side).
 
 ### `bastra-recall-stop-hook` (#35, opt-in)
 

--- a/packages/daemon/__tests__/bash-fail-hook.test.ts
+++ b/packages/daemon/__tests__/bash-fail-hook.test.ts
@@ -102,3 +102,120 @@ describe("bash-fail-hook: throttle", () => {
     assert.equal(await isThrottled(SESSION), true);
   });
 });
+
+// ─── #144: act-signal integration (mock daemon + spawned hook) ────────────
+
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
+
+const __dirname144 = dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH_144 = resolvePath(__dirname144, "..", "src", "bash-fail-hook.ts");
+
+interface SeenRequest {
+  path: string;
+  body: Record<string, unknown>;
+}
+
+function startRecordingDaemon(): Promise<{ port: number; seen: SeenRequest[]; close: () => Promise<void> }> {
+  const seen: SeenRequest[] = [];
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    let raw = "";
+    req.on("data", (c: Buffer) => (raw += c.toString()));
+    req.on("end", () => {
+      seen.push({ path: req.url ?? "", body: raw ? (JSON.parse(raw) as Record<string, unknown>) : {} });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (req.url === "/hook/act") res.end(JSON.stringify({ matched: 0 }));
+      else res.end(JSON.stringify({ hits: [], vault_size: 0, latency_ms: 1, recall_id: "t" }));
+    });
+  });
+  return new Promise((ok) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      ok({ port, seen, close: () => new Promise<void>((done) => server.close(() => done())) });
+    });
+  });
+}
+
+function runFailHook(payload: object, port: number): Promise<string> {
+  return new Promise((ok, ko) => {
+    const child = spawn("npx", ["tsx", HOOK_PATH_144], {
+      env: { ...process.env, BASTRA_HTTP_URL: `http://127.0.0.1:${port}`, BASTRA_TELEMETRY: "off" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.on("error", ko);
+    child.on("close", () => ok(stdout));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+describe("bash-fail-hook: #144 act-signal", () => {
+  it("successful command sends /hook/act only and emits {}", async () => {
+    const daemon = await startRecordingDaemon();
+    try {
+      const stdout = await runFailHook(
+        {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          session_id: `act-ok-${Date.now()}`,
+          tool_input: { command: "npm test" },
+          tool_response: { exit_code: 0 },
+        },
+        daemon.port,
+      );
+      assert.equal(stdout.trim(), "{}");
+      const paths = daemon.seen.map((r) => r.path);
+      assert.deepEqual(paths, ["/hook/act"]);
+      assert.equal(daemon.seen[0].body.tool_input_excerpt, "npm test");
+      assert.equal(daemon.seen[0].body.exit_code, 0);
+    } finally {
+      await daemon.close();
+    }
+  });
+
+  it("failed command sends /hook/act AND the fail-recall", async () => {
+    const daemon = await startRecordingDaemon();
+    try {
+      await runFailHook(
+        {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          session_id: `act-fail-${Date.now()}`,
+          tool_input: { command: "npm run build" },
+          tool_response: { exit_code: 1, stderr: "Error: tsc failed with TS2304" },
+        },
+        daemon.port,
+      );
+      const paths = daemon.seen.map((r) => r.path);
+      assert.deepEqual(paths, ["/hook/act", "/hook/recall"]);
+      assert.equal(daemon.seen[0].body.exit_code, 1);
+    } finally {
+      await daemon.close();
+    }
+  });
+
+  it("Ctrl-C (130) sends nothing at all", async () => {
+    const daemon = await startRecordingDaemon();
+    try {
+      const stdout = await runFailHook(
+        {
+          hook_event_name: "PostToolUse",
+          tool_name: "Bash",
+          session_id: `act-int-${Date.now()}`,
+          tool_input: { command: "npm run dev" },
+          tool_response: { exit_code: 130 },
+        },
+        daemon.port,
+      );
+      assert.equal(stdout.trim(), "{}");
+      assert.equal(daemon.seen.length, 0);
+    } finally {
+      await daemon.close();
+    }
+  });
+});

--- a/packages/daemon/__tests__/hook-act.test.ts
+++ b/packages/daemon/__tests__/hook-act.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests für POST /hook/act (#144) — der leichte Act-Signal-Endpoint.
+ * Kein Recall, keine Injektion: matcht den Excerpt gegen offene
+ * loadedMemories-Episoden, damit shell-getriebene Memory-Anwendungen
+ * acted_on schließen können.
+ *
+ * Runner: tsx --test packages/daemon/__tests__/hook-act.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { request } from "node:http";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+import { startHttpServer } from "../src/http.js";
+import { Telemetry } from "../src/telemetry.js";
+
+function memoryMarkdown(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: lesson",
+    `summary: ${title}`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: act-test",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+function httpPost(port: number, path: string, payload: unknown): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload);
+    const req = request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body).toString(),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") }));
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+async function makeServer(): Promise<{ port: number; telemetry: Telemetry; close: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-act-test-"));
+  await writeFile(join(dir, "m1.md"), memoryMarkdown("m1", "deploy staging lesson"), "utf8");
+  const vault = new Vault(dir);
+  await vault.init();
+  const search = new SearchIndex(vault);
+  search.start();
+  const telemetry = new Telemetry();
+  const handle = await startHttpServer({
+    port: 0,
+    vault,
+    search,
+    telemetry,
+    version: "test",
+    toolDeps: { vault, search, telemetry, vaultPath: dir },
+    documentWriteEnabled: false,
+    embedding: { on: false, providerId: null, source: "none" },
+  });
+  return {
+    port: handle.port!,
+    telemetry,
+    close: async () => {
+      search.stop();
+      await vault.stop?.();
+      await handle.close();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("/hook/act without excerpt is a 400", async () => {
+  const srv = await makeServer();
+  try {
+    const res = await httpPost(srv.port, "/hook/act", { tool_name: "Bash", exit_code: 0 });
+    assert.equal(res.status, 400);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("/hook/act closes an open loaded-memory episode on token overlap", async () => {
+  const srv = await makeServer();
+  try {
+    srv.telemetry.recordLoadedMemory({
+      memory_id: "m1",
+      distinctive_tokens: ["deploystaging", "portflag"],
+      hook_hint: null,
+    });
+    const res = await httpPost(srv.port, "/hook/act", {
+      tool_name: "Bash",
+      tool_input_excerpt: "npm run deploystaging -- with portflag enabled",
+      exit_code: 0,
+    });
+    assert.equal(res.status, 200);
+    assert.equal((JSON.parse(res.body) as { matched: number }).matched, 1);
+  } finally {
+    await srv.close();
+  }
+});
+
+test("/hook/act miss leaves the episode OPEN — a later matching act still closes it", async () => {
+  // The act-signal fires on every Bash command; an unrelated `git status`
+  // must not kill an open episode with acted_on=false (closeOnMiss=false).
+  const srv = await makeServer();
+  try {
+    srv.telemetry.recordLoadedMemory({
+      memory_id: "m1",
+      distinctive_tokens: ["deploystaging", "portflag"],
+      hook_hint: null,
+    });
+    const miss = await httpPost(srv.port, "/hook/act", {
+      tool_name: "Bash",
+      tool_input_excerpt: "ls -la && git status",
+      exit_code: 0,
+    });
+    assert.equal(miss.status, 200);
+    assert.equal((JSON.parse(miss.body) as { matched: number }).matched, 0);
+
+    // The episode survived the miss: the real application still scores.
+    const hit = await httpPost(srv.port, "/hook/act", {
+      tool_name: "Bash",
+      tool_input_excerpt: "npm run deploystaging -- portflag",
+      exit_code: 0,
+    });
+    assert.equal((JSON.parse(hit.body) as { matched: number }).matched, 1);
+  } finally {
+    await srv.close();
+  }
+});

--- a/packages/daemon/scripts/stats.ts
+++ b/packages/daemon/scripts/stats.ts
@@ -206,6 +206,19 @@ function summarizeFollowThrough(events: AnyEvent[]): void {
   }
 }
 
+// #144: PostToolUse:Bash act-signals — the widened acted_on measuring surface.
+// Every completed Bash command pings /hook/act; matched_episodes > 0 means the
+// signal closed episodes that were previously structurally invisible.
+function summarizeActSignals(events: AnyEvent[]): void {
+  const acts = events.filter((e) => e.kind === "hook_act");
+  if (acts.length === 0) return;
+  const matched = acts.reduce((sum, e) => sum + Number(e.matched_episodes ?? 0), 0);
+  const success = acts.filter((e) => Number(e.exit_code ?? -1) === 0).length;
+  console.log(`\n## Act-signals  (#144 — PostToolUse Bash pings closing episodes)`);
+  console.log(`  pings:            ${acts.length}  (${success} from successful commands)`);
+  console.log(`  episodes closed:  ${matched}`);
+}
+
 function summarizeUseRate(events: AnyEvent[]): void {
   const hookRecalls = events.filter((e) => e.kind === "hook_recall" && Array.isArray(e.hits));
   const episodes = events.filter((e) => e.kind === "recall_episode");
@@ -460,6 +473,7 @@ async function main(): Promise<void> {
   summarizeMcp(events);
   summarizeFollowThrough(events);
   summarizeUseRate(events);
+  summarizeActSignals(events);
   summarizeContextROI(events);
   summarizeBridges(events);
   summarizeOllamaLifecycle(events);

--- a/packages/daemon/src/bash-fail-hook.ts
+++ b/packages/daemon/src/bash-fail-hook.ts
@@ -80,7 +80,7 @@ async function main(): Promise<void> {
   // `tool_response` have both been observed. Accept either.
   const result = (payload.tool_result ?? payload.tool_response ?? {}) as Record<string, unknown>;
   const exitCode = readExitCode(result);
-  if (exitCode === null || exitCode === 0) return emitEmpty();
+  if (exitCode === null) return emitEmpty();
   if (exitCode === 130) return emitEmpty(); // SIGINT — user Ctrl-C
 
   const toolInput = (payload.tool_input ?? {}) as Record<string, unknown>;
@@ -90,6 +90,30 @@ async function main(): Promise<void> {
   // No loop on our own binaries.
   if (/\bbastra-recall(?:-[a-z-]+)?\b/.test(command)) return emitEmpty();
 
+  const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
+  const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? String(DEFAULT_PORT);
+  const url = httpURL ?? `http://127.0.0.1:${httpPort}`;
+
+  // #144: act-signal for EVERY completed Bash command (success AND failure).
+  // Telemetry-only — no recall, no injection, never throttled: the daemon
+  // matches the command text against open loadedMemories episodes so
+  // shell-driven applications of a memory can score acted_on. Failures are
+  // swallowed; the signal must never delay the fail-recall below.
+  await postAct(
+    url,
+    {
+      tool_name: "Bash",
+      tool_input_excerpt: command.slice(0, 1000),
+      exit_code: exitCode,
+      session_id: typeof payload.session_id === "string" ? payload.session_id : null,
+    },
+    Math.min(120, Math.max(50, HOOK_TIMEOUT_MS - (Date.now() - startedAt))),
+  );
+
+  // Success path ends here — the act-signal was the only job. The daemon-side
+  // hook_act event is the telemetry record; no hint, no local log line.
+  if (exitCode === 0) return emitEmpty();
+
   const sessionId = typeof payload.session_id === "string" ? payload.session_id : "default";
   if (await isThrottled(sessionId)) return emitEmpty();
 
@@ -98,9 +122,6 @@ async function main(): Promise<void> {
   const errKeywords = extractErrorKeywords(errorContext);
   const query = `${commandHead} ${errKeywords}`.trim().slice(0, 300);
 
-  const httpURL = envFirst("BASTRA_HTTP_URL", "NEXUS_HTTP_URL");
-  const httpPort = envFirst("BASTRA_HTTP_PORT", "NEXUS_HTTP_PORT") ?? String(DEFAULT_PORT);
-  const url = httpURL ?? `http://127.0.0.1:${httpPort}`;
   const remainingMs = Math.max(50, HOOK_TIMEOUT_MS - (Date.now() - startedAt));
 
   let resp: RecallResponse | null = null;
@@ -334,6 +355,50 @@ function postRecall(
       req.destroy(new Error("timeout"));
     });
     req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+/** #144: fire the act-signal at /hook/act. Best-effort — resolves on any
+ *  outcome (error, timeout, non-2xx); the act-signal must never break or
+ *  delay the hook's main job. */
+function postAct(
+  baseUrl: string,
+  body: { tool_name: string; tool_input_excerpt: string; exit_code: number; session_id: string | null },
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve) => {
+    let url: URL;
+    try {
+      url = new URL("/hook/act", baseUrl);
+    } catch {
+      resolve();
+      return;
+    }
+    const payload = Buffer.from(JSON.stringify(body), "utf8");
+    const req = request(
+      {
+        method: "POST",
+        hostname: url.hostname,
+        port: url.port || 80,
+        path: url.pathname,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": payload.byteLength.toString(),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        res.resume(); // drain — response content is irrelevant
+        res.on("end", () => resolve());
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      resolve();
+    });
+    req.on("error", () => resolve());
     req.write(payload);
     req.end();
   });

--- a/packages/daemon/src/cli/adapters/claude-code.ts
+++ b/packages/daemon/src/cli/adapters/claude-code.ts
@@ -50,7 +50,7 @@ function hookDefinitions(opts: { includeStop?: boolean } = {}): HookDef[] {
     { event: "PreToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", bin: PRE_TOOL_HOOK_BIN, timeout: 2, note: "bastra-recall PreToolUse hook" },
     { event: "PreToolUse", matcher: "TodoWrite", bin: TODO_HOOK_BIN, timeout: 2, note: "bastra-recall TodoWrite hook (topology-recall, #36)" },
     { event: "PreToolUse", matcher: "Bash", bin: BASH_PRE_HOOK_BIN, timeout: 2, note: "bastra-recall Bash-pre hook (safety, #34)" },
-    { event: "PostToolUse", matcher: "Bash", bin: BASH_FAIL_HOOK_BIN, timeout: 2, note: "bastra-recall Bash-fail hook (lesson recall on fail, #37)" },
+    { event: "PostToolUse", matcher: "Bash", bin: BASH_FAIL_HOOK_BIN, timeout: 2, note: "bastra-recall Bash post hook (act-signal #144 + lesson recall on fail #37)" },
   ];
   if (opts.includeStop) {
     defs.push({ event: "Stop", bin: STOP_HOOK_BIN, timeout: 3, note: "bastra-recall Stop hook (optional autonomous save-eval, #35)" });

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -330,6 +330,15 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
       return;
     }
 
+    // #144: lightweight act-signal (PostToolUse:Bash). No recall, no injection —
+    // only matches the excerpt against open loadedMemories episodes so
+    // shell-driven applications of a memory can close them. Loopback-only
+    // (Host-Gate above), no auth — same trust level as /hook/recall.
+    if (method === "POST" && url === "/hook/act") {
+      handleHookAct(req, res, telemetry);
+      return;
+    }
+
     // Selbstlernende Taxonomie (#64): Konventions-Liste für die Session-Hook-
     // Injection (#66) und Drift-Analyse für den Stop-Hook (#67). Beides
     // loopback-only (Host-Gate oben), read-only, kein Auth — wie /hook/recall.
@@ -475,6 +484,46 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
       });
     });
   });
+}
+
+// ─── /hook/act handler (#144) ────────────────────────────────────
+
+function handleHookAct(req: IncomingMessage, res: ServerResponse, telemetry: Telemetry): void {
+  readJsonBody(req, MAX_BODY_BYTES)
+    .then(async (body) => {
+      const excerpt = typeof body.tool_input_excerpt === "string"
+        ? body.tool_input_excerpt.slice(0, 4096)
+        : "";
+      if (!excerpt) {
+        sendJson(res, 400, { error: "tool_input_excerpt is required" });
+        return;
+      }
+      const toolName = typeof body.tool_name === "string" ? body.tool_name : null;
+      const sessionId = typeof body.session_id === "string" ? body.session_id : null;
+      const exitCode = typeof body.exit_code === "number" ? body.exit_code : null;
+
+      const episodes = telemetry.matchLoadedMemories({
+        tool_name: toolName,
+        tool_input_excerpt: excerpt,
+        session_id: sessionId,
+        // High-frequency signal: only MATCHING episodes close; an unrelated
+        // command must not kill an open episode with acted_on=false.
+        closeOnMiss: false,
+      });
+      for (const episode of episodes) {
+        fireAndForget(telemetry.logRecallEpisode(episode));
+      }
+      fireAndForget(
+        telemetry.logHookAct({
+          tool_name: toolName,
+          excerpt_chars: excerpt.length,
+          matched_episodes: episodes.length,
+          exit_code: exitCode,
+        }),
+      );
+      sendJson(res, 200, { matched: episodes.length });
+    })
+    .catch(() => sendJson(res, 400, { error: "invalid JSON body" }));
 }
 
 // ─── /hook/recall handler ────────────────────────────────────────

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -33,6 +33,7 @@ export type TelemetryEvent =
   | LoadMemoryEvent
   | SaveMemoryEvent
   | HookRecallEvent
+  | HookActEvent
   | RecallEpisodeEvent
   | OllamaLifecycleEvent;
 
@@ -131,6 +132,18 @@ export interface SaveMemoryEvent extends BaseEvent {
   overwrite: boolean;
   created: boolean;
   follows_recall: string | null;
+}
+
+/** #144: lightweight act-signal from the PostToolUse:Bash hook — no recall,
+ *  no injection; only widens the acted_on measuring surface so shell-driven
+ *  applications of a memory can close their recall_episode. */
+export interface HookActEvent extends BaseEvent {
+  kind: "hook_act";
+  tool_name: string | null;
+  excerpt_chars: number;
+  /** How many open loadedMemories episodes this act-signal closed. */
+  matched_episodes: number;
+  exit_code: number | null;
 }
 
 /** Recall served from the HTTP /hook/recall endpoint (server-side view). */
@@ -412,7 +425,14 @@ export class Telemetry {
     tool_name: string | null;
     tool_input_excerpt: string;
     session_id?: string | null;
+    /** #144: when false, a non-matching entry stays OPEN instead of closing
+     *  with acted_on=false. The high-frequency Bash act-signal must not let
+     *  an unrelated `git status` kill an episode before the real application
+     *  arrives; the low-frequency file-edit path keeps the historical
+     *  close-on-miss semantics ("the next tool input decides"). */
+    closeOnMiss?: boolean;
   }): Omit<RecallEpisodeEvent, "kind" | "ts" | "session_id">[] {
+    const closeOnMiss = payload.closeOnMiss !== false;
     const now = Date.now();
     const current = this.currentTurn(payload.session_id ?? null);
     const inputTokens = tokenize(payload.tool_input_excerpt);
@@ -430,6 +450,7 @@ export class Telemetry {
       for (const token of entry.distinctive_tokens) {
         if (inputTokens.has(token)) matchStrength++;
       }
+      if (!closeOnMiss && matchStrength < 2) continue; // stays open (#144)
       entry.closed = true;
       episodes.push({
         turn_id: entry.turn_id,
@@ -504,6 +525,18 @@ export class Telemetry {
     if (!this.enabled) return;
     await this.write({
       kind: "hook_recall",
+      ts: new Date().toISOString(),
+      session_id: this.sessionId,
+      ...payload,
+    });
+  }
+
+  async logHookAct(
+    payload: Omit<HookActEvent, "kind" | "ts" | "session_id">,
+  ): Promise<void> {
+    if (!this.enabled) return;
+    await this.write({
+      kind: "hook_act",
       ts: new Date().toISOString(),
       session_id: this.sessionId,
       ...payload,


### PR DESCRIPTION
## What

Closes #144 — the last structural gap of the v0.7 telemetry milestone, and the data-quality dependency of v0.8 wave E (#154/#160).

**Problem**: `acted_on` could only ever fire on file-edits and risky Bash — a lesson whose application *is* a shell command (build/test/git/deploy, the dominant action class) could never be scored, biasing USE-rate against shell-driven memory use.

**Change**:
- New lightweight `POST /hook/act` (loopback-only): matches an excerpt against open loaded-memory episodes, closes the matching ones, logs an additive `hook_act` JSONL event. No recall, no injection, no schema/markdown change — all #69 constraints honored.
- The already-registered PostToolUse:Bash hook now pings `/hook/act` with the command text on **every** completed command (success and failure), never throttled, ≤120 ms budget, failures swallowed; the fail-recall path is byte-for-byte unchanged and still fires only on non-zero exits.
- **Semantics guard**: `matchLoadedMemories` gains `closeOnMiss` (default true = historical behavior for the low-frequency file-edit path). The act path passes `false` — an unrelated `git status` must not kill an open episode with `acted_on=false` before the real application arrives. Without this, the widened surface would have *degraded* measurement quality. Pinned by test.
- `stats.ts` gains an **Act-signals** section; acceptance criterion (USE-rate shows a non-empty non-edit class) becomes observable as live data accumulates.

## Tests

- `hook-act.test.ts` (real HTTP server): 400 without excerpt; token-overlap closes an episode; **miss leaves the episode open and a later matching act still closes it**.
- `bash-fail-hook.test.ts` integration (mock daemon + spawned hook): success → `/hook/act` only + `{}`; failure → `/hook/act` **and** fail-recall; Ctrl-C → nothing.

Full suite: 365 tests, 364 pass, 0 fail (todo = third survival arm → #153). `check:types` clean. docs/hooks.md + README (EN+DE) mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)