### PR TITLE
Three-arm recall_when survival harness: lexical · hybrid · expanded + far-split (#103)

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -94,10 +94,12 @@ instinct for an **independent** probe. But for this product it is ecologically
 backwards: **nobody hand-writes the memories** (the AI saves them) **or
 hand-phrases the recall query** (the AI forms it). Production is model-mediated
 on *both* ends, so simulated queries are the faithful test; hand-written ones
-test a path that never happens. The retriever is lexical BM25 (no embedding
-space), so the only contamination risk from LLM-authored queries is
+test a path that never happens. The default retriever arm is lexical BM25 (no
+embedding space), so the only contamination risk from LLM-authored queries is
 **trigger-vocabulary leakage** — and the overlap score measures that directly,
-per query. Two guards keep it honest (see `__tests__/persona-diversity.test.ts`):
+per query. Since #103 the harness also runs a **hybrid arm** (production
+`recallHybrid` with per-arm dense embeddings) and an **expanded arm** (BM25 +
+write-time `recall_when_expanded`, #117) via `--arms lexical,hybrid,expanded`. Two guards keep it honest (see `__tests__/persona-diversity.test.ts`):
 the personas must be **distinct voices** (no mode collapse) and must **span the
 near↔far axis** (the gradient is emergent, not hand-binned).
 

--- a/packages/eval/__tests__/arm-plumbing.test.ts
+++ b/packages/eval/__tests__/arm-plumbing.test.ts
@@ -1,0 +1,173 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Vault } from "@bastra-recall/core";
+import {
+  buildIndex,
+  rankOf,
+  TREATMENT_RECALL_WHEN_BOOST,
+  EXPANDED_RECALL_WHEN_BOOST,
+} from "../src/index-config.js";
+
+/**
+ * Arm-plumbing guard for the three-arm survival harness (#103).
+ *
+ * The lexical and expanded arms are pure BM25 and must be exercisable WITHOUT
+ * Ollama (CI has none): the expanded treatment indexes recall_when_expanded at
+ * the production ×2 boost, every control strips BOTH trigger fields, and the
+ * multi-arm CLI reports the far in-pool/not-retrieved split per arm. The
+ * hybrid arm runs production recallHybrid and is skipped when no Ollama (with
+ * the embedding model) is reachable.
+ */
+
+const EVAL_DIR = resolve(import.meta.dirname, "..");
+const SCRIPT = join(EVAL_DIR, "src", "persona-lift.ts");
+const FIXTURE_VAULT = join(EVAL_DIR, "fixtures", "eval-vault");
+
+/** Run the persona-lift CLI against the synthetic fixture vault. */
+function runCli(args: string[]): ReturnType<typeof spawnSync<string>> {
+  return spawnSync(process.execPath, ["--import", "tsx", SCRIPT, ...args], {
+    cwd: EVAL_DIR,
+    encoding: "utf8",
+    timeout: 240_000,
+  });
+}
+
+test("expanded arm: recall_when_expanded is indexed by the treatment only", async () => {
+  const vault = new Vault(FIXTURE_VAULT);
+  await vault.init();
+  const memories = vault.list().filter((m) => !m.fm.obsolete);
+  const control = buildIndex(memories, { kind: "control" });
+  const lexical = buildIndex(memories, { kind: "treatment", boost: TREATMENT_RECALL_WHEN_BOOST });
+  const expanded = buildIndex(memories, {
+    kind: "treatment",
+    boost: TREATMENT_RECALL_WHEN_BOOST,
+    expandedBoost: EXPANDED_RECALL_WHEN_BOOST,
+  });
+  // "stampede" lives ONLY in backoff-jitter's recall_when_expanded — no other
+  // field of any fixture memory contains it. Control strips both trigger
+  // fields and the lexical treatment only adds recall_when, so only the
+  // expanded treatment can retrieve the gold for it.
+  assert.equal(rankOf(control.search("stampede"), "backoff-jitter"), 0, "control must not see expansions");
+  assert.equal(rankOf(lexical.search("stampede"), "backoff-jitter"), 0, "lexical treatment must not see expansions");
+  assert.equal(rankOf(expanded.search("stampede"), "backoff-jitter"), 1, "expanded treatment must index expansions");
+  await vault.stop();
+});
+
+test("CLI --arms lexical,expanded: multi-arm report with a consistent far-split", () => {
+  const dir = mkdtempSync(join(tmpdir(), "bastra-arm-plumbing-"));
+  try {
+    const out = join(dir, "report.json");
+    const r = runCli(["--arms", "lexical,expanded", "--out", out]);
+    assert.equal(r.status, 0, `CLI failed:\n${r.stderr}`);
+    assert.match(r.stdout, /multi-arm, #103/);
+    assert.match(r.stdout, /in-pool vs not-retrieved/);
+
+    const json = JSON.parse(readFileSync(out, "utf8")) as {
+      queries: number;
+      arms: Record<
+        string,
+        {
+          slices: Record<string, { n: number; control: number; treatment: number; lift: number }>;
+          survival: number | null;
+          farSplit: Record<string, { inPool: number; notRetrieved: number; meanGoldRank: number | null }>;
+          personaRecall: Record<string, number>;
+        }
+      >;
+    };
+    assert.equal(json.queries, 100);
+    for (const arm of ["lexical", "expanded"]) {
+      const a = json.arms[arm];
+      assert.ok(a, `arm "${arm}" missing from report`);
+      for (const slice of ["all", "near", "far"]) {
+        assert.equal(typeof a.slices[slice].treatment, "number", `${arm}/${slice} R@k missing`);
+      }
+      assert.equal(a.slices.all.n, 100);
+      assert.equal(a.slices.near.n + a.slices.far.n, a.slices.all.n);
+      // far-split must PARTITION the far slice, on both sides of the pair.
+      for (const side of ["control", "treatment"]) {
+        const s = a.farSplit[side];
+        assert.equal(
+          s.inPool + s.notRetrieved,
+          a.slices.far.n,
+          `${arm}/${side}: in-pool + not-retrieved must equal far n`,
+        );
+      }
+      assert.equal(Object.keys(a.personaRecall).length, 10);
+    }
+    // Both BM25 controls strip both trigger fields → identical numbers.
+    assert.equal(json.arms.lexical.slices.all.control, json.arms.expanded.slices.all.control);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI default (lexical only) keeps the legacy single-arm JSON shape", () => {
+  const dir = mkdtempSync(join(tmpdir(), "bastra-arm-legacy-"));
+  try {
+    const out = join(dir, "report.json");
+    const r = runCli(["--out", out]);
+    assert.equal(r.status, 0, `CLI failed:\n${r.stderr}`);
+    const json = JSON.parse(readFileSync(out, "utf8")) as Record<string, unknown>;
+    // Legacy top-level keys, and NO multi-arm nesting.
+    for (const key of ["liftAll", "liftNear", "liftFar", "survival", "personaRecall"]) {
+      assert.ok(key in json, `legacy key "${key}" missing`);
+    }
+    assert.ok(!("arms" in json), "lexical-only run must keep the legacy shape");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── hybrid arm (production recallHybrid) — needs a reachable Ollama ─────────
+
+const OLLAMA_URL = process.env.BASTRA_OLLAMA_URL ?? "http://localhost:11434";
+const EMBED_MODEL = process.env.BASTRA_EMBEDDING_MODEL ?? "embeddinggemma";
+
+/** Ollama up AND the embedding model pulled — otherwise the hybrid arm can't run. */
+async function ollamaUsable(): Promise<boolean> {
+  try {
+    const resp = await fetch(`${OLLAMA_URL.replace(/\/+$/, "")}/api/tags`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!resp.ok) return false;
+    const json = (await resp.json()) as { models?: { name?: string }[] };
+    return (json.models ?? []).some((m) => (m.name ?? "").startsWith(EMBED_MODEL));
+  } catch {
+    return false;
+  }
+}
+
+test("CLI --arms lexical,hybrid: hybrid arm runs production recallHybrid", { timeout: 300_000 }, async (t) => {
+  if (!(await ollamaUsable())) {
+    t.skip(`Ollama with model "${EMBED_MODEL}" not reachable at ${OLLAMA_URL} — hybrid arm untested`);
+    return;
+  }
+  const dir = mkdtempSync(join(tmpdir(), "bastra-arm-hybrid-"));
+  try {
+    const out = join(dir, "report.json");
+    const r = runCli(["--arms", "lexical,hybrid", "--out", out]);
+    assert.equal(r.status, 0, `CLI failed:\n${r.stderr}`);
+    const json = JSON.parse(readFileSync(out, "utf8")) as {
+      arms: Record<
+        string,
+        {
+          slices: Record<string, { n: number }>;
+          farSplit: Record<string, { inPool: number; notRetrieved: number }>;
+        }
+      >;
+    };
+    const h = json.arms.hybrid;
+    assert.ok(h, "hybrid arm missing from report");
+    assert.equal(h.slices.all.n, 100);
+    for (const side of ["control", "treatment"]) {
+      const s = h.farSplit[side];
+      assert.equal(s.inPool + s.notRetrieved, h.slices.far.n, `hybrid/${side}: far-split must partition`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/eval/__tests__/boost-drift.test.ts
+++ b/packages/eval/__tests__/boost-drift.test.ts
@@ -2,7 +2,11 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { BASE_BOOST, TREATMENT_RECALL_WHEN_BOOST } from "../src/index-config.js";
+import {
+  BASE_BOOST,
+  TREATMENT_RECALL_WHEN_BOOST,
+  EXPANDED_RECALL_WHEN_BOOST,
+} from "../src/index-config.js";
 
 /**
  * Drift guard. The ablation mirrors core's field weights by hand (the
@@ -19,6 +23,7 @@ const searchSrc = readFileSync(
 test("ablation field weights stay in sync with core SearchIndex", () => {
   const expected: Record<string, number> = {
     recall_when_flat: TREATMENT_RECALL_WHEN_BOOST,
+    recall_when_expanded_flat: EXPANDED_RECALL_WHEN_BOOST,
     title: BASE_BOOST.title,
     tags_flat: BASE_BOOST.tags_flat,
     topic_path_flat: BASE_BOOST.topic_path_flat,

--- a/packages/eval/fixtures/eval-vault/memories/backoff-jitter.md
+++ b/packages/eval/fixtures/eval-vault/memories/backoff-jitter.md
@@ -10,6 +10,9 @@ recall_when:
   - thundering herd when a service recovers
   - all clients retry at the same instant
   - retries hammer the API in sync
+recall_when_expanded:
+  - connection stampede after an outage ends
+  - spread reconnect attempts out randomly
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/css-flexbox-min-width-zero.md
+++ b/packages/eval/fixtures/eval-vault/memories/css-flexbox-min-width-zero.md
@@ -10,6 +10,9 @@ recall_when:
   - text not truncating inside a flex row
   - child stretches container instead of ellipsis
   - overflow ignored in flex layout
+recall_when_expanded:
+  - long label refuses to clip inside a flexible column
+  - content forces its box wider than the layout allows
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/debounce-vs-throttle.md
+++ b/packages/eval/fixtures/eval-vault/memories/debounce-vs-throttle.md
@@ -10,6 +10,9 @@ recall_when:
   - search box fires too many requests while typing
   - scroll handler runs too often
   - limit how often a callback runs
+recall_when_expanded:
+  - delay firing until the user stops interacting
+  - cap how frequently an expensive listener executes
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/docker-manifest-before-source.md
+++ b/packages/eval/fixtures/eval-vault/memories/docker-manifest-before-source.md
@@ -10,6 +10,9 @@ recall_when:
   - docker reinstalls deps on every build
   - slow image rebuilds after a code change
   - layer cache keeps invalidating
+recall_when_expanded:
+  - image rebuild repeats the dependency install unnecessarily
+  - order COPY steps to keep cached layers warm
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/focus-ring-keyboard.md
+++ b/packages/eval/fixtures/eval-vault/memories/focus-ring-keyboard.md
@@ -10,6 +10,9 @@ recall_when:
   - removed outline and keyboard nav disappeared
   - tab navigation has no visible indicator
   - accessibility focus state missing
+recall_when_expanded:
+  - tabbing through the form gives no visual cue where you are
+  - outline removal broke assistive navigation
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/git-rebase-autosquash-fixup.md
+++ b/packages/eval/fixtures/eval-vault/memories/git-rebase-autosquash-fixup.md
@@ -10,6 +10,9 @@ recall_when:
   - cleaning up commits before merge
   - squashing review feedback into the right commit
   - messy history before a PR
+recall_when_expanded:
+  - fold review corrections into their original changesets
+  - tidy a branch history before merging
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/money-not-float.md
+++ b/packages/eval/fixtures/eval-vault/memories/money-not-float.md
@@ -10,6 +10,9 @@ recall_when:
   - rounding errors adding prices
   - 0.1 plus 0.2 problem in totals
   - cents off by one in invoices
+recall_when_expanded:
+  - currency totals drift by fractions of a cent
+  - store prices as whole minor units instead of doubles
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/postgres-index-type-mismatch.md
+++ b/packages/eval/fixtures/eval-vault/memories/postgres-index-type-mismatch.md
@@ -10,6 +10,9 @@ recall_when:
   - query ignores the index I created
   - seq scan despite an index
   - why is my index not used
+recall_when_expanded:
+  - planner picks a full table walk over the btree
+  - EXPLAIN shows no index usage because the literal type differs
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/secrets-in-env.md
+++ b/packages/eval/fixtures/eval-vault/memories/secrets-in-env.md
@@ -10,6 +10,9 @@ recall_when:
   - api key accidentally pushed to git
   - rotating a leaked token
   - where to put credentials safely
+recall_when_expanded:
+  - credential leaked into version control history
+  - revoke and reissue a token that escaped
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/fixtures/eval-vault/memories/timestamps-store-utc.md
+++ b/packages/eval/fixtures/eval-vault/memories/timestamps-store-utc.md
@@ -10,6 +10,9 @@ recall_when:
   - times shift after deploy to another region
   - daylight saving breaks scheduling
   - wrong hour shown to users abroad
+recall_when_expanded:
+  - meeting times off by an hour after the clock change
+  - normalize instants to one reference zone before saving
 related: []
 related_via: []
 sensitivity: public

--- a/packages/eval/src/hybrid-arm.ts
+++ b/packages/eval/src/hybrid-arm.ts
@@ -1,0 +1,181 @@
+/**
+ * Hybrid-arm building blocks for persona-lift (#103).
+ *
+ * The lexical arms mirror core's BM25 by hand (index-config.ts) so they can
+ * vary one knob. The hybrid arm instead runs PRODUCTION `recallHybrid` — real
+ * `SearchIndex` + `EmbeddingIndex` + RRF — so the dense leg is measured, not
+ * simulated. The control/treatment split is enforced on BOTH legs:
+ *
+ *   control  : recall_when blanked in the in-memory frontmatter (BM25 leg) AND
+ *              excluded from the dense embed text — the stripping discipline
+ *              doc2query-lift applies, otherwise the trigger leaks through the
+ *              vector space and the ablation is circular.
+ *   treatment: recall_when present in both legs at production weights.
+ *
+ * `recall_when_expanded` is blanked on BOTH sides: the hybrid arm isolates the
+ * recall_when lever; write-time expansion is the `expanded` arm's job.
+ *
+ * Dense vectors are injected the way doc2query-lift does it: write each side's
+ * persistPath JSON (the exact {dim,provider,vectors} format EmbeddingIndex.load
+ * expects) with vectors computed via the SAME OllamaEmbeddingProvider — so the
+ * query/passage prefix convention is byte-identical to production and no silent
+ * backfill (which would re-embed WITH recall_when) can occur. The production
+ * embeddings.json (which baked in recall_when) is NEVER loaded.
+ */
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  Vault,
+  SearchIndex,
+  EmbeddingIndex,
+  OllamaEmbeddingProvider,
+} from "@bastra-recall/core";
+import type { Memory } from "@bastra-recall/core";
+
+/** Mirror daemon env handling for the Ollama provider (same envs doc2query-lift uses). */
+export function providerFromEnv(): OllamaEmbeddingProvider {
+  const baseURL = process.env.BASTRA_OLLAMA_URL ?? "http://localhost:11434";
+  const model = process.env.BASTRA_EMBEDDING_MODEL ?? "embeddinggemma";
+  const dimEnv = process.env.BASTRA_EMBEDDING_DIM;
+  const parsedDim = dimEnv ? Number.parseInt(dimEnv, 10) : undefined;
+  const dim = parsedDim !== undefined && Number.isFinite(parsedDim) ? parsedDim : undefined;
+  const keepAlive = process.env.BASTRA_OLLAMA_KEEP_ALIVE ?? "10m";
+  return new OllamaEmbeddingProvider({ baseURL, model, dim, keepAlive });
+}
+
+// ── Production-faithful embed text (replica of embeddings.ts:buildEmbedText) ──
+// `includeRecallWhen` is the ONE knob: false = control side (dense leg must not
+// see the trigger either), true = treatment side (production text, verbatim).
+// The provider applies the passage prefix, so this only controls the TEXT.
+function embedTextFor(m: Memory, includeRecallWhen: boolean): string {
+  const fm = m.fm;
+  const parts = [
+    fm.title,
+    fm.tags.join(" "),
+    includeRecallWhen ? fm.recall_when.join(" ") : "",
+    fm.summary,
+    m.body.slice(0, 4000),
+  ];
+  return parts.filter((p) => p && p.length > 0).join("\n");
+}
+
+// Write the {dim,provider,vectors} JSON EmbeddingIndex.load expects. base64-LE
+// float32, matching embeddings.ts:persist (same helper as doc2query-lift).
+async function writeVectorsJson(
+  persistPath: string,
+  provider: OllamaEmbeddingProvider,
+  ids: string[],
+  vectors: Float32Array[],
+): Promise<void> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < ids.length; i++) {
+    const v = vectors[i];
+    out[ids[i]] = Buffer.from(v.buffer, v.byteOffset, v.byteLength).toString("base64");
+  }
+  const data = { dim: provider.dim, provider: provider.id, vectors: out };
+  await fs.mkdir(path.dirname(persistPath), { recursive: true });
+  await fs.writeFile(persistPath, JSON.stringify(data));
+}
+
+/** Embed every memory's passage text in batches via the SAME provider (prefix-correct). */
+async function embedAll(
+  provider: OllamaEmbeddingProvider,
+  memories: Memory[],
+  includeRecallWhen: boolean,
+  label: string,
+): Promise<{ ids: string[]; vectors: Float32Array[] }> {
+  const ids: string[] = [];
+  const vectors: Float32Array[] = [];
+  const BATCH = 50;
+  for (let i = 0; i < memories.length; i += BATCH) {
+    const chunk = memories.slice(i, i + BATCH);
+    const texts = chunk.map((m) => embedTextFor(m, includeRecallWhen));
+    const vecs = await provider.embed(texts);
+    for (let j = 0; j < chunk.length; j++) {
+      ids.push(chunk[j].fm.id);
+      vectors.push(vecs[j]);
+    }
+    process.stderr.write(`  [${label}] embedded ${Math.min(i + BATCH, memories.length)}/${memories.length}\r`);
+  }
+  process.stderr.write("\n");
+  return { ids, vectors };
+}
+
+type Side = "control" | "treatment";
+
+export interface HybridArmSide {
+  search: SearchIndex;
+  emb: EmbeddingIndex;
+  vault: Vault;
+}
+
+export interface HybridArmPair {
+  control: HybridArmSide;
+  treatment: HybridArmSide;
+  /** stop indexes/vaults and delete the temp persist dirs. */
+  cleanup(): Promise<void>;
+}
+
+/**
+ * Build the hybrid control/treatment pair over `vaultPath`: two Vaults (so the
+ * in-memory frontmatter policies don't collide), production SearchIndex +
+ * EmbeddingIndex each, with per-side injected vectors.
+ */
+export async function buildHybridArmPair(vaultPath: string): Promise<HybridArmPair> {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "bastra-persona-hybrid-"));
+  const provider = providerFromEnv();
+
+  // Embed once per side from a pristine vault (original recall_when intact —
+  // embedTextFor decides per side whether the trigger enters the dense text).
+  const refVault = new Vault(vaultPath);
+  await refVault.init();
+  const mems = refVault.list();
+  const vaultSize = refVault.size();
+  const persist: Record<Side, string> = {
+    control: path.join(tmpRoot, "control", "embeddings.json"),
+    treatment: path.join(tmpRoot, "treatment", "embeddings.json"),
+  };
+  process.stderr.write(`[hybrid] embedding ${vaultSize} memories per side via ${provider.id}…\n`);
+  const c = await embedAll(provider, mems, false, "control");
+  await writeVectorsJson(persist.control, provider, c.ids, c.vectors);
+  const t = await embedAll(provider, mems, true, "treatment");
+  await writeVectorsJson(persist.treatment, provider, t.ids, t.vectors);
+  await refVault.stop();
+
+  async function buildSide(side: Side): Promise<HybridArmSide> {
+    const vault = new Vault(vaultPath);
+    await vault.init();
+    for (const m of vault.list()) {
+      if (side === "control") (m.fm as { recall_when: string[] }).recall_when = [];
+      (m.fm as { recall_when_expanded?: string[] }).recall_when_expanded = [];
+    }
+    const search = new SearchIndex(vault);
+    search.start(); // BM25 leg picks up the policy'd frontmatter
+    const emb = new EmbeddingIndex(vault, provider, persist[side]);
+    await emb.start(); // load() picks up our injected vectors; nothing missing → no backfill
+    search.useEmbeddings(emb);
+    // Sanity: confirm the injected vectors loaded (no silent backfill from buildEmbedText).
+    if (emb.size() < vault.size()) {
+      process.stderr.write(
+        `⚠ hybrid ${side}: only ${emb.size()}/${vault.size()} vectors loaded — injection may have missed memories\n`,
+      );
+    }
+    return { search, emb, vault };
+  }
+  const control = await buildSide("control");
+  const treatment = await buildSide("treatment");
+
+  return {
+    control,
+    treatment,
+    cleanup: async () => {
+      for (const side of [control, treatment]) {
+        side.search.stop();
+        side.emb.stop();
+        await side.vault.stop();
+      }
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    },
+  };
+}

--- a/packages/eval/src/index-config.ts
+++ b/packages/eval/src/index-config.ts
@@ -20,6 +20,9 @@ export const BASE_BOOST = {
 /** core's production weight for the dedicated trigger field. */
 export const TREATMENT_RECALL_WHEN_BOOST = 5;
 
+/** core's production weight for the doc2query expansions (#117). */
+export const EXPANDED_RECALL_WHEN_BOOST = 2;
+
 /** Search options pinned to core so the ablation is apples-to-apples. */
 const SEARCH_OPTIONS = {
   fuzzy: 0.2,
@@ -33,6 +36,7 @@ interface IndexDoc {
   summary: string;
   tags_flat: string;
   recall_when_flat: string;
+  recall_when_expanded_flat: string;
   topic_path_flat: string;
   body: string;
 }
@@ -46,6 +50,7 @@ function toDoc(m: Memory): IndexDoc {
     summary: fm.summary,
     tags_flat: fm.tags.join(" "),
     recall_when_flat: fm.recall_when.join(" \n "),
+    recall_when_expanded_flat: (fm.recall_when_expanded ?? []).join(" \n "),
     topic_path_flat: fm.topic_path.join(" "),
     body: m.body,
   };
@@ -53,15 +58,20 @@ function toDoc(m: Memory): IndexDoc {
 
 export type Arm =
   | { kind: "control" } // recall_when removed from the searchable fields
-  | { kind: "treatment"; boost: number }; // recall_when indexed at `boost`
+  // recall_when indexed at `boost`; when `expandedBoost` is set the #117
+  // doc2query field `recall_when_expanded` is ALSO indexed at that weight
+  // (core uses 2) — that's the persona-lift "expanded" arm's treatment.
+  | { kind: "treatment"; boost: number; expandedBoost?: number };
 
 /**
  * Build a BM25 index over `memories`.
  *
- * - control:   `recall_when` is NOT a searchable field at all (stripped). A
- *   query term that lives only in recall_when cannot retrieve the doc.
+ * - control:   `recall_when` is NOT a searchable field at all (stripped), and
+ *   neither is `recall_when_expanded`. A query term that lives only in the
+ *   trigger fields cannot retrieve the doc.
  * - treatment: `recall_when` indexed and boosted at `boost` (core uses 5),
- *   every other field weight identical to control.
+ *   every other field weight identical to control. With `expandedBoost` the
+ *   doc2query expansions are indexed too (core uses 2).
  *
  * Stripping the field outright (rather than zero-weighting it) avoids the
  * MiniSearch quirk where a boost of 0 still lets the doc surface at score 0.
@@ -72,6 +82,10 @@ export function buildIndex(memories: Memory[], arm: Arm): MiniSearch<IndexDoc> {
   if (arm.kind === "treatment") {
     fields.push("recall_when_flat");
     boost.recall_when_flat = arm.boost;
+    if (arm.expandedBoost !== undefined) {
+      fields.push("recall_when_expanded_flat");
+      boost.recall_when_expanded_flat = arm.expandedBoost;
+    }
   }
 
   const mini = new MiniSearch<IndexDoc>({

--- a/packages/eval/src/persona-lift.ts
+++ b/packages/eval/src/persona-lift.ts
@@ -33,9 +33,33 @@
  * Why simulated, not hand-written paraphrases? In production NOBODY hand-writes
  * the memories (the AI saves them) OR hand-phrases the recall query (the AI
  * forms it). Both ends are model-mediated, so simulated queries are the
- * ecologically faithful test. The retriever is lexical BM25 (no embedding
- * space), so the only contamination risk is trigger-vocabulary leakage — which
- * the overlap score measures directly. See README for the full rationale.
+ * ecologically faithful test. The default retriever is lexical BM25 (no
+ * embedding space), so the only contamination risk is trigger-vocabulary
+ * leakage — which the overlap score measures directly. See README.
+ *
+ * ── THREE ARMS (#103) — attribute the far-null to the right missing lever ──
+ * `--arms lexical,hybrid,expanded` runs up to three control/treatment pairs
+ * over the same persona queries. Every control strips BOTH trigger fields
+ * (recall_when AND recall_when_expanded); the arms differ ONLY in what the
+ * treatment adds back:
+ *
+ *   lexical  : BM25, treatment indexes recall_when at ×boost — the original
+ *              harness (default; exact legacy behavior + output).
+ *   hybrid   : production `recallHybrid` (BM25 + Ollama dense leg + RRF).
+ *              Control strips recall_when from BOTH legs — see hybrid-arm.ts.
+ *              Needs a reachable Ollama (BASTRA_OLLAMA_URL /
+ *              BASTRA_EMBEDDING_MODEL / BASTRA_EMBEDDING_DIM /
+ *              BASTRA_OLLAMA_KEEP_ALIVE, same envs doc2query-lift uses).
+ *   expanded : BM25, treatment ADDITIONALLY indexes the #117 write-time
+ *              expansions (recall_when_expanded) at the production ×2 boost.
+ *
+ * ── FAR-SPLIT (#103, per @zzallirog discussion #105) ──
+ * Every far query is also classified by WHERE the gold sat: `in-pool` (anywhere
+ * in the first-stage candidate pool — retrieved but possibly mis-ranked, a
+ * precision problem) vs `not-retrieved` (a recall-bound miss, the case an
+ * index-side lever must fix). Both slices are reported per arm together with a
+ * precision signal (mean gold rank among in-pool fars) so the two failure modes
+ * don't average into one number.
  *
  * IMPORTANT — read before citing a number:
  *   The bundled `fixtures/personas.json` runs against the tiny SYNTHETIC
@@ -46,6 +70,7 @@
  * Usage:
  *   npm run personas                          # bundled synthetic vault + personas
  *   npm run personas -- --k 3 --near 0.30     # tune @k and the near/far cut
+ *   npm run personas -- --arms lexical,hybrid,expanded   # three-arm (#103)
  *   BASTRA_VAULT_PATH=/v npm run personas -- --personas p.json --out survival.json
  *
  * Exit code: 0 always (a measurement, not a pass/fail gate).
@@ -53,8 +78,14 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { Vault } from "@bastra-recall/core";
-import type { Memory } from "@bastra-recall/core";
-import { buildIndex, rankOf, TREATMENT_RECALL_WHEN_BOOST } from "./index-config.js";
+import type { Memory, RecallHit, SearchIndex } from "@bastra-recall/core";
+import {
+  buildIndex,
+  rankOf,
+  TREATMENT_RECALL_WHEN_BOOST,
+  EXPANDED_RECALL_WHEN_BOOST,
+} from "./index-config.js";
+import { buildHybridArmPair } from "./hybrid-arm.js";
 
 // ── Persona fixtures ───────────────────────────────────────────
 
@@ -65,6 +96,9 @@ interface PersonaFile {
 
 // ── CLI ────────────────────────────────────────────────────────
 
+const ARM_NAMES = ["lexical", "hybrid", "expanded"] as const;
+type ArmName = (typeof ARM_NAMES)[number];
+
 interface Args {
   vault: string;
   personas: string;
@@ -72,6 +106,7 @@ interface Args {
   boost: number;
   k: number;
   near: number;
+  arms: ArmName[];
 }
 
 const DEFAULT_VAULT = resolve(import.meta.dirname, "../fixtures/eval-vault");
@@ -85,6 +120,7 @@ function parseArgs(argv: string[]): Args {
     boost: TREATMENT_RECALL_WHEN_BOOST,
     k: 3,
     near: 0.3,
+    arms: ["lexical"],
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -94,12 +130,16 @@ function parseArgs(argv: string[]): Args {
     else if (a === "--boost") args.boost = num(argv[++i], "--boost");
     else if (a === "--k") args.k = num(argv[++i], "--k");
     else if (a === "--near") args.near = num(argv[++i], "--near");
+    else if (a === "--arms") args.arms = parseArms(req(argv[++i], "--arms"));
     else if (a === "-h" || a === "--help") {
       console.log(
         "persona-lift — simulated-user survival of recall_when\n" +
           "  --vault <path>     vault to index (or BASTRA_VAULT_PATH)\n" +
           "  --personas <path>  personas JSON ({personas:{label:{id:query}}})\n" +
-          "  --boost <n>        treatment recall_when weight (default 5)\n" +
+          "  --arms <list>      comma list of lexical,hybrid,expanded (default: lexical;\n" +
+          "                     hybrid needs a reachable Ollama, see BASTRA_OLLAMA_URL)\n" +
+          "  --boost <n>        treatment recall_when weight (default 5; lexical/expanded\n" +
+          "                     arms only — hybrid always runs production weights)\n" +
           "  --k <n>            Recall@k (default 3)\n" +
           "  --near <0..1>      query↔trigger overlap cut for near/far (default 0.30)\n" +
           "  --out <path>       also write a JSON report",
@@ -108,6 +148,18 @@ function parseArgs(argv: string[]): Args {
     } else throw new Error(`unknown flag: ${a}`);
   }
   return args;
+}
+
+function parseArms(spec: string): ArmName[] {
+  const out: ArmName[] = [];
+  for (const raw of spec.split(",").map((s) => s.trim()).filter(Boolean)) {
+    if (!(ARM_NAMES as readonly string[]).includes(raw)) {
+      throw new Error(`--arms: unknown arm "${raw}" (valid: ${ARM_NAMES.join(", ")})`);
+    }
+    if (!out.includes(raw as ArmName)) out.push(raw as ArmName);
+  }
+  if (out.length === 0) throw new Error("--arms needs at least one arm");
+  return out;
 }
 
 function req(v: string | undefined, flag: string): string {
@@ -164,6 +216,86 @@ const recallK = (r: Run): number => (r.total ? r.hitK / r.total : 0);
 const pct = (x: number): string => `${(x * 100).toFixed(1)}%`;
 const signed = (x: number): string => `${x >= 0 ? "+" : ""}${(x * 100).toFixed(1)} pp`;
 
+// ── Far-split counters (#103 / discussion #105) ────────────────
+// Over FAR queries only: was the gold anywhere in the first-stage candidate
+// pool (`in-pool` = mis-ranking territory) or absent (`not-retrieved` = a
+// recall-bound miss)? goldRankSum/inPool is the precision signal.
+
+interface FarSplit {
+  inPool: number;
+  notRetrieved: number;
+  goldRankSum: number;
+}
+const emptySplit = (): FarSplit => ({ inPool: 0, notRetrieved: 0, goldRankSum: 0 });
+function recordFar(split: FarSplit, rank: number): void {
+  if (rank >= 1) {
+    split.inPool++;
+    split.goldRankSum += rank;
+  } else {
+    split.notRetrieved++;
+  }
+}
+const meanGoldRank = (s: FarSplit): number => (s.inPool ? s.goldRankSum / s.inPool : NaN);
+
+// ── Arm plumbing (#103) ────────────────────────────────────────
+// Every rank is the gold's 1-based position in the arm's FIRST-STAGE candidate
+// pool; 0 = not retrieved. For the BM25-only arms the pool mirrors core
+// recall()'s HOP_SEED_POOL = max(k*4, 20) (search.ts) — exactly the pool
+// onCandidatePool exposes (#121). For hybrid we capture that pool directly.
+
+type BmIndex = ReturnType<typeof buildIndex>;
+
+interface ArmRunner {
+  rank(side: "control" | "treatment", query: string, goldId: string): Promise<number> | number;
+  close?(): Promise<void>;
+}
+
+interface ArmCounters {
+  overallC: Run;
+  overallT: Run;
+  nearC: Run;
+  nearT: Run;
+  farC: Run;
+  farT: Run;
+  farSplitC: FarSplit;
+  farSplitT: FarSplit;
+  perPersonaT: Map<string, Run>;
+}
+const emptyCounters = (): ArmCounters => ({
+  overallC: emptyRun(),
+  overallT: emptyRun(),
+  nearC: emptyRun(),
+  nearT: emptyRun(),
+  farC: emptyRun(),
+  farT: emptyRun(),
+  farSplitC: emptySplit(),
+  farSplitT: emptySplit(),
+  perPersonaT: new Map(),
+});
+
+function bm25PoolRank(index: BmIndex, query: string, goldId: string, poolCap: number): number {
+  return rankOf(index.search(query).slice(0, poolCap), goldId);
+}
+
+/** Run production recallHybrid, capture the #121 pool, return the gold's pool rank. */
+async function hybridPoolRank(
+  search: SearchIndex,
+  query: string,
+  goldId: string,
+  k: number,
+): Promise<number> {
+  let captured: RecallHit[] = [];
+  await search.recallHybrid(query, {
+    k,
+    allow_private: true,
+    onCandidatePool: (pool) => {
+      captured = pool;
+    },
+  });
+  const idx = captured.findIndex((h) => h.id === goldId);
+  return idx === -1 ? 0 : idx + 1;
+}
+
 // ── Main ───────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
@@ -182,41 +314,92 @@ async function main(): Promise<void> {
     triggerToks.set(m.fm.id, t);
   }
 
-  const control = buildIndex(memories, { kind: "control" });
-  const treatment = buildIndex(memories, { kind: "treatment", boost: args.boost });
+  // First-stage pool cap for the BM25-only arms (see comment on bm25PoolRank).
+  const poolCap = Math.max(args.k * 4, 20);
 
-  const overallC = emptyRun(), overallT = emptyRun();
-  const nearC = emptyRun(), nearT = emptyRun();
-  const farC = emptyRun(), farT = emptyRun();
-  const perPersonaT = new Map<string, Run>();
+  // Every control strips BOTH trigger fields (buildIndex control indexes
+  // neither), so lexical + expanded share one control index.
+  const control = buildIndex(memories, { kind: "control" });
+  const runners = new Map<ArmName, ArmRunner>();
+  if (args.arms.includes("lexical")) {
+    const treatment = buildIndex(memories, { kind: "treatment", boost: args.boost });
+    runners.set("lexical", {
+      rank: (side, q, id) => bm25PoolRank(side === "control" ? control : treatment, q, id, poolCap),
+    });
+  }
+  if (args.arms.includes("expanded")) {
+    const withExpansions = memories.filter(
+      (m) => (m.fm.recall_when_expanded ?? []).length > 0,
+    ).length;
+    if (withExpansions === 0) {
+      console.error(
+        "⚠ expanded arm: no memory carries recall_when_expanded — treatment degenerates to lexical (#117 expansions missing on this vault)",
+      );
+    }
+    const treatment = buildIndex(memories, {
+      kind: "treatment",
+      boost: args.boost,
+      expandedBoost: EXPANDED_RECALL_WHEN_BOOST,
+    });
+    runners.set("expanded", {
+      rank: (side, q, id) => bm25PoolRank(side === "control" ? control : treatment, q, id, poolCap),
+    });
+  }
+  if (args.arms.includes("hybrid")) {
+    if (args.boost !== TREATMENT_RECALL_WHEN_BOOST) {
+      console.error(
+        `⚠ hybrid arm always runs production weights (recall_when ×${TREATMENT_RECALL_WHEN_BOOST}); --boost ${args.boost} only affects lexical/expanded arms`,
+      );
+    }
+    const pair = await buildHybridArmPair(args.vault);
+    runners.set("hybrid", {
+      rank: (side, q, id) =>
+        hybridPoolRank(side === "control" ? pair.control.search : pair.treatment.search, q, id, args.k),
+      close: pair.cleanup,
+    });
+  }
+
+  const counters = new Map<ArmName, ArmCounters>();
+  for (const arm of args.arms) counters.set(arm, emptyCounters());
   const unknownIds = new Set<string>();
   let totalQueries = 0;
 
   for (const [label, byMemory] of Object.entries(file.personas)) {
-    const pRun = emptyRun();
+    for (const arm of args.arms) counters.get(arm)!.perPersonaT.set(label, emptyRun());
     for (const [id, query] of Object.entries(byMemory)) {
       if (!known.has(id)) {
         unknownIds.add(id);
         continue;
       }
       totalQueries++;
-      const cRank = rankOf(control.search(query), id);
-      const tRank = rankOf(treatment.search(query), id);
       const cov = coverage(query, triggerToks.get(id) ?? new Set());
       const isNear = cov >= args.near;
-      record(overallC, cRank, args.k);
-      record(overallT, tRank, args.k);
-      record(isNear ? nearC : farC, cRank, args.k);
-      record(isNear ? nearT : farT, tRank, args.k);
-      record(pRun, tRank, args.k);
+      for (const arm of args.arms) {
+        const c = counters.get(arm)!;
+        const runner = runners.get(arm)!;
+        const cRank = await runner.rank("control", query, id);
+        const tRank = await runner.rank("treatment", query, id);
+        record(c.overallC, cRank, args.k);
+        record(c.overallT, tRank, args.k);
+        record(isNear ? c.nearC : c.farC, cRank, args.k);
+        record(isNear ? c.nearT : c.farT, tRank, args.k);
+        if (!isNear) {
+          recordFar(c.farSplitC, cRank);
+          recordFar(c.farSplitT, tRank);
+        }
+        record(c.perPersonaT.get(label)!, tRank, args.k);
+      }
     }
-    perPersonaT.set(label, pRun);
   }
+  for (const runner of runners.values()) await runner.close?.();
 
-  const liftAll = recallK(overallT) - recallK(overallC);
-  const liftNear = recallK(nearT) - recallK(nearC);
-  const liftFar = recallK(farT) - recallK(farC);
-  const survival = liftNear > 0 ? liftFar / liftNear : NaN;
+  const liftAllOf = (c: ArmCounters): number => recallK(c.overallT) - recallK(c.overallC);
+  const liftNearOf = (c: ArmCounters): number => recallK(c.nearT) - recallK(c.nearC);
+  const liftFarOf = (c: ArmCounters): number => recallK(c.farT) - recallK(c.farC);
+  const survivalOf = (c: ArmCounters): number => {
+    const near = liftNearOf(c);
+    return near > 0 ? liftFarOf(c) / near : NaN;
+  };
 
   // persona-diversity sanity (mean pairwise query Jaccard across shared ids)
   const labels = Object.keys(file.personas);
@@ -233,42 +416,119 @@ async function main(): Promise<void> {
   const meanSim = pairSims.length ? pairSims.reduce((a, b) => a + b, 0) / pairSims.length : 0;
 
   // ── report ──
+  // Single lexical arm → the exact legacy report + JSON (backward compatible,
+  // byte-for-byte). Anything else → the multi-arm report with the far-split.
+  const legacyOnly = args.arms.length === 1 && args.arms[0] === "lexical";
   const L: string[] = [];
-  L.push("# recall_when — Simulated-User Survival\n");
-  L.push(
-    `Vault: **${loaded}** memorys  ·  personas: **${labels.length}**  ·  ` +
-      `queries: **${totalQueries}**  ·  boost: **×${args.boost}**  ·  k = **${args.k}**  ·  ` +
-      `near/far cut: **${args.near}**\n`,
-  );
 
-  L.push("## Lift by recall-time vocabulary drift\n");
-  L.push("| query↔trigger | n | control R@" + args.k + " | treatment R@" + args.k + " | marginal lift |");
-  L.push("|---|---|---|---|---|");
-  L.push(`| **all** | ${overallT.total} | ${pct(recallK(overallC))} | ${pct(recallK(overallT))} | **${signed(liftAll)}** |`);
-  L.push(`| near (≥${args.near}) | ${nearT.total} | ${pct(recallK(nearC))} | ${pct(recallK(nearT))} | ${signed(liftNear)} |`);
-  L.push(`| far (<${args.near}) | ${farT.total} | ${pct(recallK(farC))} | ${pct(recallK(farT))} | ${signed(liftFar)} |`);
-  L.push("");
-  L.push(
-    `**survival = lift(far) / lift(near) = ${Number.isFinite(survival) ? survival.toFixed(2) : "n/a"}** — ` +
-      `the fraction of recall_when's benefit that holds when the recall-time query ` +
-      `drifts off the save-time trigger wording.\n`,
-  );
+  if (legacyOnly) {
+    const c = counters.get("lexical")!;
+    const { overallC, overallT, nearC, nearT, farC, farT, perPersonaT } = c;
+    const liftAll = liftAllOf(c);
+    const liftNear = liftNearOf(c);
+    const liftFar = liftFarOf(c);
+    const survival = survivalOf(c);
 
-  L.push("## Robustness envelope across user personas\n");
-  L.push(`Recall@${args.k} (treatment) per simulated user — the spread is the envelope:\n`);
-  L.push("| persona | queries | Recall@" + args.k + " |");
-  L.push("|---|---|---|");
-  const persRecalls: number[] = [];
-  for (const [label, r] of perPersonaT) {
-    persRecalls.push(recallK(r));
-    L.push(`| ${label} | ${r.total} | ${pct(recallK(r))} |`);
-  }
-  if (persRecalls.length) {
+    L.push("# recall_when — Simulated-User Survival\n");
+    L.push(
+      `Vault: **${loaded}** memorys  ·  personas: **${labels.length}**  ·  ` +
+        `queries: **${totalQueries}**  ·  boost: **×${args.boost}**  ·  k = **${args.k}**  ·  ` +
+        `near/far cut: **${args.near}**\n`,
+    );
+
+    L.push("## Lift by recall-time vocabulary drift\n");
+    L.push("| query↔trigger | n | control R@" + args.k + " | treatment R@" + args.k + " | marginal lift |");
+    L.push("|---|---|---|---|---|");
+    L.push(`| **all** | ${overallT.total} | ${pct(recallK(overallC))} | ${pct(recallK(overallT))} | **${signed(liftAll)}** |`);
+    L.push(`| near (≥${args.near}) | ${nearT.total} | ${pct(recallK(nearC))} | ${pct(recallK(nearT))} | ${signed(liftNear)} |`);
+    L.push(`| far (<${args.near}) | ${farT.total} | ${pct(recallK(farC))} | ${pct(recallK(farT))} | ${signed(liftFar)} |`);
     L.push("");
     L.push(
-      `Envelope: **${pct(Math.min(...persRecalls))} – ${pct(Math.max(...persRecalls))}** ` +
-        `across ${persRecalls.length} user styles.\n`,
+      `**survival = lift(far) / lift(near) = ${Number.isFinite(survival) ? survival.toFixed(2) : "n/a"}** — ` +
+        `the fraction of recall_when's benefit that holds when the recall-time query ` +
+        `drifts off the save-time trigger wording.\n`,
     );
+
+    L.push("## Robustness envelope across user personas\n");
+    L.push(`Recall@${args.k} (treatment) per simulated user — the spread is the envelope:\n`);
+    L.push("| persona | queries | Recall@" + args.k + " |");
+    L.push("|---|---|---|");
+    const persRecalls: number[] = [];
+    for (const [label, r] of perPersonaT) {
+      persRecalls.push(recallK(r));
+      L.push(`| ${label} | ${r.total} | ${pct(recallK(r))} |`);
+    }
+    if (persRecalls.length) {
+      L.push("");
+      L.push(
+        `Envelope: **${pct(Math.min(...persRecalls))} – ${pct(Math.max(...persRecalls))}** ` +
+          `across ${persRecalls.length} user styles.\n`,
+      );
+    }
+  } else {
+    L.push("# recall_when — Simulated-User Survival (multi-arm, #103)\n");
+    L.push(
+      `Vault: **${loaded}** memorys  ·  personas: **${labels.length}**  ·  ` +
+        `queries: **${totalQueries}**  ·  boost: **×${args.boost}**  ·  k = **${args.k}**  ·  ` +
+        `near/far cut: **${args.near}**  ·  arms: **${args.arms.join(", ")}**\n`,
+    );
+
+    L.push("## Lift by recall-time vocabulary drift — per arm\n");
+    L.push("| arm | query↔trigger | n | control R@" + args.k + " | treatment R@" + args.k + " | marginal lift |");
+    L.push("|---|---|---|---|---|---|");
+    for (const arm of args.arms) {
+      const c = counters.get(arm)!;
+      L.push(`| ${arm} | **all** | ${c.overallT.total} | ${pct(recallK(c.overallC))} | ${pct(recallK(c.overallT))} | **${signed(liftAllOf(c))}** |`);
+      L.push(`| ${arm} | near (≥${args.near}) | ${c.nearT.total} | ${pct(recallK(c.nearC))} | ${pct(recallK(c.nearT))} | ${signed(liftNearOf(c))} |`);
+      L.push(`| ${arm} | far (<${args.near}) | ${c.farT.total} | ${pct(recallK(c.farC))} | ${pct(recallK(c.farT))} | ${signed(liftFarOf(c))} |`);
+    }
+    L.push("");
+    L.push("**survival = lift(far) / lift(near)** per arm:\n");
+    for (const arm of args.arms) {
+      const s = survivalOf(counters.get(arm)!);
+      L.push(`- ${arm}: **${Number.isFinite(s) ? s.toFixed(2) : "n/a"}**`);
+    }
+    L.push("");
+
+    L.push("## Far slice — in-pool vs not-retrieved (per @zzallirog, #105)\n");
+    L.push(
+      `Where the gold sat on far queries. \`in-pool\` = somewhere in the first-stage ` +
+        `candidate pool (retrieved but possibly mis-ranked — a precision problem); ` +
+        `\`not-retrieved\` = a recall-bound miss (what an index-side lever must fix). ` +
+        `Pool = max(k·4, 20) = ${poolCap}, core's #121 candidate pool. Precision signal: ` +
+        `mean gold rank among in-pool fars (lower = better).\n`,
+    );
+    L.push("| arm | side | far n | in-pool | not-retrieved | mean gold rank (in-pool) |");
+    L.push("|---|---|---|---|---|---|");
+    for (const arm of args.arms) {
+      const c = counters.get(arm)!;
+      for (const [side, split] of [["control", c.farSplitC], ["treatment", c.farSplitT]] as const) {
+        const mgr = meanGoldRank(split);
+        L.push(
+          `| ${arm} | ${side} | ${split.inPool + split.notRetrieved} | ${split.inPool} | ` +
+            `${split.notRetrieved} | ${Number.isFinite(mgr) ? mgr.toFixed(2) : "n/a"} |`,
+        );
+      }
+    }
+    L.push("");
+
+    L.push("## Robustness envelope across user personas\n");
+    L.push(`Recall@${args.k} (treatment) per simulated user — the spread is the envelope:\n`);
+    L.push("| persona | queries | " + args.arms.join(" | ") + " |");
+    L.push("|---|---|" + args.arms.map(() => "---|").join(""));
+    for (const label of labels) {
+      const cells = args.arms.map((arm) => pct(recallK(counters.get(arm)!.perPersonaT.get(label)!)));
+      const n = counters.get(args.arms[0])!.perPersonaT.get(label)!.total;
+      L.push(`| ${label} | ${n} | ${cells.join(" | ")} |`);
+    }
+    L.push("");
+    for (const arm of args.arms) {
+      const rs = [...counters.get(arm)!.perPersonaT.values()].map(recallK);
+      if (rs.length) {
+        L.push(`- ${arm} envelope: **${pct(Math.min(...rs))} – ${pct(Math.max(...rs))}** across ${rs.length} user styles.`);
+      }
+    }
+    L.push("");
   }
 
   L.push("## Persona-diversity check\n");
@@ -285,21 +545,69 @@ async function main(): Promise<void> {
   console.log(report);
 
   if (args.out) {
-    const json = {
-      vault: args.vault,
-      vaultSize: loaded,
-      boost: args.boost,
-      k: args.k,
-      nearCut: args.near,
-      queries: totalQueries,
-      liftAll,
-      liftNear,
-      liftFar,
-      survival,
-      personaRecall: Object.fromEntries([...perPersonaT].map(([l, r]) => [l, recallK(r)])),
-      meanPairwiseSimilarity: meanSim,
-      unknownIds: [...unknownIds],
-    };
+    let json: Record<string, unknown>;
+    if (legacyOnly) {
+      const c = counters.get("lexical")!;
+      json = {
+        vault: args.vault,
+        vaultSize: loaded,
+        boost: args.boost,
+        k: args.k,
+        nearCut: args.near,
+        queries: totalQueries,
+        liftAll: liftAllOf(c),
+        liftNear: liftNearOf(c),
+        liftFar: liftFarOf(c),
+        survival: survivalOf(c),
+        personaRecall: Object.fromEntries([...c.perPersonaT].map(([l, r]) => [l, recallK(r)])),
+        meanPairwiseSimilarity: meanSim,
+        unknownIds: [...unknownIds],
+      };
+    } else {
+      const sliceJson = (cRun: Run, tRun: Run): Record<string, unknown> => ({
+        n: tRun.total,
+        control: recallK(cRun),
+        treatment: recallK(tRun),
+        lift: recallK(tRun) - recallK(cRun),
+      });
+      const splitJson = (s: FarSplit): Record<string, unknown> => ({
+        inPool: s.inPool,
+        notRetrieved: s.notRetrieved,
+        meanGoldRank: meanGoldRank(s), // NaN → null in JSON
+      });
+      json = {
+        vault: args.vault,
+        vaultSize: loaded,
+        boost: args.boost,
+        k: args.k,
+        nearCut: args.near,
+        poolCap,
+        queries: totalQueries,
+        arms: Object.fromEntries(
+          args.arms.map((arm) => {
+            const c = counters.get(arm)!;
+            return [
+              arm,
+              {
+                slices: {
+                  all: sliceJson(c.overallC, c.overallT),
+                  near: sliceJson(c.nearC, c.nearT),
+                  far: sliceJson(c.farC, c.farT),
+                },
+                survival: survivalOf(c), // NaN → null in JSON
+                farSplit: {
+                  control: splitJson(c.farSplitC),
+                  treatment: splitJson(c.farSplitT),
+                },
+                personaRecall: Object.fromEntries([...c.perPersonaT].map(([l, r]) => [l, recallK(r)])),
+              },
+            ];
+          }),
+        ),
+        meanPairwiseSimilarity: meanSim,
+        unknownIds: [...unknownIds],
+      };
+    }
     writeFileSync(args.out, JSON.stringify(json, null, 2));
     console.error(`\n[persona-lift] JSON written to ${args.out}`);
   }


### PR DESCRIPTION
## What

Implements the harness half of #103 (tasks 1+2): the survival measurement can now attribute a far-null correctly — embedding layer vs. missing write-time expansion — instead of reporting only the lexical ceiling.

- `npm run personas -- --arms lexical,hybrid,expanded` (default `lexical` = byte-identical legacy output, verified by diff).
- **hybrid** runs production `recallHybrid` — real `SearchIndex` + `EmbeddingIndex` + RRF, per-arm dense vectors via the `{dim,provider,vectors}` persist format with production prefixes. Control strips `recall_when` from **both** legs (BM25 frontmatter *and* dense embed text) — without that the trigger leaks through the vector space and the ablation is circular. `recall_when_expanded` is blanked on both sides so the arm isolates the recall_when lever.
- **expanded** = BM25 + `recall_when_expanded` (#117) at the production ×2 boost.
- **far-split** (per the #105 discussion): per arm, far queries split into gold-in-pool vs not-retrieved, plus mean gold rank among in-pool fars — recall-bound misses and mis-ranking stay separate.
- boost-drift CI guard extended (`recall_when_expanded_flat: 2` pinned against core).

## Tests

4 new arm-plumbing tests (expanded indexing without Ollama; CLI multi-arm with far-split partition invariant; legacy JSON shape guard; hybrid CLI test that skips when no Ollama is reachable — it ran for real against local Ollama here, 13 s). eval suite 7/7, root suite green, `check:types` clean.

The actual three-arm measurement against a real vault is the follow-up step in #103; command lines are documented in the harness header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)