### PR TITLE
Semantic-recall activation made discoverable: bastra embeddings, install prompt, doctor note (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,21 @@ bash packages/skill/install-hook.sh   # registers the 6 default reflex-layer hoo
 
 ### Semantic recall (optional)
 
-Recall is hybrid: BM25 keyword search always works, and a semantic layer kicks in once an embedding provider is set up. On macOS, `bastra install` detects Ollama and — if it's missing — offers to install it via Homebrew, pull the `embeddinggemma` model (~600 MB), and start it as a local login service. Use `--ollama` to set it up non-interactively, `--no-ollama` to skip; the login service is a toggle (`bastra config set ollama.autostart off`). The daemon also re-starts a stopped local Ollama on boot (probe-first, loopback only, honours the same toggle). Without Ollama, recall stays on BM25 — nothing breaks. `bastra status` shows the active mode.
+Recall is hybrid: BM25 keyword search is the always-on default, and a semantic layer — an optional, configurable second pass — kicks in once an embedding provider is set up. Enabling it is one command:
+
+```bash
+bastra embeddings on       # installs Ollama via Homebrew (if missing), pulls embeddinggemma (~620 MB), persists the choice
+bastra embeddings status   # effective provider + how it was resolved (env / cli-settings / default) + model presence
+bastra embeddings off      # back to BM25 keyword-only
+```
+
+At the end of a successful `bastra install`, bastra asks once whether to enable semantic recall (interactive terminals only — never with `--yes` or `--dry-run`, and never in scripts; those print the `bastra embeddings on` hint instead of hanging). `--ollama` sets it up without asking, `--no-ollama` skips. The Ollama login service is a toggle (`bastra config set ollama.autostart off`); the daemon also re-starts a stopped local Ollama on boot (probe-first, loopback only, honours the same toggle). Without an embedding provider, recall stays on BM25 — nothing breaks. `bastra status` shows the active mode, and `bastra doctor` says explicitly when semantic recall is off or the model is missing.
+
+Manual (no Homebrew): install + start [Ollama](https://ollama.com), `ollama pull embeddinggemma`, then `bastra embeddings on`. Note: `--yes` does **not** trigger the Ollama download (use `--ollama`). Homebrew and the model come from third parties (Homebrew core, ollama.com). Full details: **[System Requirements](https://github.com/n0mad-ai/bastra-recall/wiki/System-Requirements)** (wiki).
 
 ### Bastra Commons (beta)
 
 `bastra commons enable` adds a second, read-only recall source: [Bastra Commons](https://github.com/n0mad-ai/bastra-commons), a community vault of **verified engineering recipes** — solutions with their failed paths, proven by use, where best-practice status is *earned through independent verification records, never declared*. Commons hits surface in `recall` with `scope: commons`, ranked just below your personal memories; the clone is git-synced (`bastra commons update`) and the daemon never writes into it. (The Commons repository opens to the public with its launch — see the [wiki page](../../wiki/Bastra-Commons) for the model.)
-
-Manual: `brew install ollama && ollama pull embeddinggemma && bastra config set embedding.provider ollama`. Note: `--yes` does **not** trigger the Ollama download (use `--ollama`). Homebrew and the model come from third parties (Homebrew core, ollama.com).
-
-Full details: **[System Requirements](https://github.com/n0mad-ai/bastra-recall/wiki/System-Requirements)** (wiki).
 
 ### Product docs (optional)
 
@@ -488,15 +494,21 @@ bash packages/skill/install-hook.sh   # registriert die 6 Standard-Reflex-Layer-
 
 ### Semantischer Recall (optional)
 
-Recall ist hybrid: BM25-Stichwortsuche funktioniert immer, eine semantische Schicht kommt dazu, sobald ein Embedding-Provider eingerichtet ist. Auf macOS erkennt `bastra install` Ollama und bietet — falls es fehlt — an, es via Homebrew zu installieren, das Modell `embeddinggemma` (~600 MB) zu ziehen und als lokalen Login-Service zu starten. `--ollama` richtet ohne Nachfrage ein, `--no-ollama` überspringt; der Login-Service ist abschaltbar (`bastra config set ollama.autostart off`). Der Daemon startet ein gestopptes lokales Ollama beim Boot auch selbst neu (probe-first, nur Loopback, respektiert denselben Toggle). Ohne Ollama bleibt Recall bei BM25 — nichts bricht. `bastra status` zeigt den aktiven Modus.
+Recall ist hybrid: BM25-Stichwortsuche ist der immer aktive Default, eine semantische Schicht — ein optionaler, konfigurierbarer zweiter Pass — kommt dazu, sobald ein Embedding-Provider eingerichtet ist. Einschalten ist ein Befehl:
+
+```bash
+bastra embeddings on       # installiert Ollama via Homebrew (falls nötig), zieht embeddinggemma (~620 MB), persistiert die Wahl
+bastra embeddings status   # effektiver Provider + Auflösungsweg (env / cli-settings / Default) + Modell-Präsenz
+bastra embeddings off      # zurück zu reiner BM25-Stichwortsuche
+```
+
+Am Ende eines erfolgreichen `bastra install` fragt bastra einmal, ob semantischer Recall aktiviert werden soll (nur in interaktiven Terminals — nie mit `--yes` oder `--dry-run` und nie in Skripten; dort erscheint statt einer hängenden Abfrage der Hinweis auf `bastra embeddings on`). `--ollama` richtet ohne Nachfrage ein, `--no-ollama` überspringt. Der Ollama-Login-Service ist abschaltbar (`bastra config set ollama.autostart off`); der Daemon startet ein gestopptes lokales Ollama beim Boot auch selbst neu (probe-first, nur Loopback, respektiert denselben Toggle). Ohne Embedding-Provider bleibt Recall bei BM25 — nichts bricht. `bastra status` zeigt den aktiven Modus, und `bastra doctor` sagt explizit, wenn semantischer Recall aus ist oder das Modell fehlt.
+
+Manuell (ohne Homebrew): [Ollama](https://ollama.com) installieren + starten, `ollama pull embeddinggemma`, dann `bastra embeddings on`. Hinweis: `--yes` löst den Ollama-Download **nicht** aus (dafür `--ollama`). Homebrew und das Modell kommen von Dritten (Homebrew Core, ollama.com). Details: **[System Requirements](https://github.com/n0mad-ai/bastra-recall/wiki/System-Requirements)** (Wiki).
 
 ### Bastra Commons (Beta)
 
 `bastra commons enable` fügt eine zweite, schreibgeschützte Recall-Quelle hinzu: [Bastra Commons](https://github.com/n0mad-ai/bastra-commons), ein Community-Vault **verifizierter Engineering-Rezepte** — Lösungen samt ihrer Irrwege, durch Anwendung bewiesen. Best-Practice-Status wird dort *durch unabhängige Verifikations-Records verdient, nie erklärt*. Commons-Treffer erscheinen in `recall` mit `scope: commons`, leicht unter den persönlichen Memories gerankt; der Clone wird per git aktualisiert (`bastra commons update`), der Daemon schreibt nie hinein. (Das Commons-Repository wird mit seinem Launch öffentlich — Modell siehe [Wiki-Seite](../../wiki/Bastra-Commons).)
-
-Manuell: `brew install ollama && ollama pull embeddinggemma && bastra config set embedding.provider ollama`. Hinweis: `--yes` löst den Ollama-Download **nicht** aus (dafür `--ollama`). Homebrew und das Modell kommen von Dritten (Homebrew Core, ollama.com).
-
-Details: **[System Requirements](https://github.com/n0mad-ai/bastra-recall/wiki/System-Requirements)** (Wiki).
 
 ### Produkt-Doku (optional)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,15 +77,16 @@ It then applies staleness reranking based on lifecycle fields such as `valid_unt
 
 ### Hybrid Recall
 
-Embeddings are optional. `BASTRA_EMBEDDING_PROVIDER` controls the provider:
+Embeddings are an optional, configurable second pass; BM25 keyword search is the default. The provider is resolved in one shared place (`resolveEmbeddingChoice` in `packages/daemon/src/settings.ts`, used by the daemon, the bridge, and the CLI) with the precedence env > cli-settings > API-key > none:
 
-| Value | Behavior |
-|---|---|
-| `none` | disable embeddings |
-| `ollama` | use local Ollama `/v1/embeddings` |
-| `openai` | use OpenAI embeddings with `OPENAI_API_KEY` or `BASTRA_EMBEDDING_KEY` |
-| unset + API key | use OpenAI for backwards compatibility |
-| unset + no API key | BM25 only |
+| Source | Value | Behavior |
+|---|---|---|
+| env `BASTRA_EMBEDDING_PROVIDER` | `none` / `ollama` / `openai` | always wins over the settings file |
+| `~/.bastra/cli-settings.json` `embedding.provider` | `none` / `ollama` / `openai` | written by `bastra embeddings on\|off` (or the `bastra install` end prompt); used when no env is set |
+| unset + API key (`OPENAI_API_KEY` / `BASTRA_EMBEDDING_KEY`) | — | use OpenAI for backwards compatibility |
+| unset + no API key | — | BM25 only |
+
+`ollama` uses local Ollama `/v1/embeddings`; `openai` requires an API key. `bastra embeddings status` shows the effective provider and which source decided it.
 
 When an `EmbeddingIndex` is attached, `recallHybrid(...)` combines BM25 and vector rankings with Reciprocal Rank Fusion. Vectors are stored as base64-encoded floats in `<vault>/.bastra/embeddings.json`.
 

--- a/packages/daemon/__tests__/embedding-resolve.test.ts
+++ b/packages/daemon/__tests__/embedding-resolve.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for resolveEmbeddingChoice (src/settings.ts) — the ONE shared
+ * embedding-provider resolution used by index.ts, bridge.ts and the CLI (#79).
+ *
+ * Precedence under test: env BASTRA_EMBEDDING_PROVIDER > cli-settings.json
+ * embedding.provider > API-key backwards-compat > none. Env + file are both
+ * injectable, so this never reads the real environment or ~/.bastra.
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/embedding-resolve.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveEmbeddingChoice, setEmbeddingProvider, type EmbeddingProviderName } from "../src/settings.js";
+
+async function withTempFile<T>(fn: (path: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-embed-resolve-"));
+  try {
+    return await fn(join(dir, "cli-settings.json"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("default: nothing configured anywhere → none via 'none'", async () => {
+  await withTempFile(async (path) => {
+    const c = await resolveEmbeddingChoice({ path, env: {} });
+    assert.deepEqual(c, { provider: "none", source: "none" });
+  });
+});
+
+test("cli-settings wins over the default (the #79 activation path)", async () => {
+  await withTempFile(async (path) => {
+    await setEmbeddingProvider("ollama", path);
+    const c = await resolveEmbeddingChoice({ path, env: {} });
+    assert.deepEqual(c, { provider: "ollama", source: "cli-settings" });
+  });
+});
+
+test("env wins over cli-settings — both directions", async () => {
+  await withTempFile(async (path) => {
+    await setEmbeddingProvider("ollama", path);
+    const off = await resolveEmbeddingChoice({ path, env: { BASTRA_EMBEDDING_PROVIDER: "none" } });
+    assert.deepEqual(off, { provider: "none", source: "env" });
+
+    await setEmbeddingProvider("none", path);
+    const on = await resolveEmbeddingChoice({ path, env: { BASTRA_EMBEDDING_PROVIDER: "ollama" } });
+    assert.deepEqual(on, { provider: "ollama", source: "env" });
+  });
+});
+
+test("env value is case-insensitive", async () => {
+  await withTempFile(async (path) => {
+    const c = await resolveEmbeddingChoice({ path, env: { BASTRA_EMBEDDING_PROVIDER: "OLLAMA" } });
+    assert.deepEqual(c, { provider: "ollama", source: "env" });
+  });
+});
+
+test("invalid env value falls through to cli-settings and surfaces the typo", async () => {
+  await withTempFile(async (path) => {
+    await setEmbeddingProvider("ollama", path);
+    let warned: string | null = null;
+    const c = await resolveEmbeddingChoice({
+      path,
+      env: { BASTRA_EMBEDDING_PROVIDER: "olama" },
+      onInvalidEnv: (raw) => (warned = raw),
+    });
+    // A typo must NOT silently disable embeddings and shadow a valid file choice.
+    assert.deepEqual(c, { provider: "ollama", source: "cli-settings" });
+    assert.equal(warned, "olama");
+  });
+});
+
+test("openai via env: honoured with a key, degraded-but-explained without", async () => {
+  await withTempFile(async (path) => {
+    const withKey = await resolveEmbeddingChoice({
+      path,
+      env: { BASTRA_EMBEDDING_PROVIDER: "openai", OPENAI_API_KEY: "sk-test" },
+    });
+    assert.deepEqual(withKey, { provider: "openai", source: "env" });
+
+    const withoutKey = await resolveEmbeddingChoice({ path, env: { BASTRA_EMBEDDING_PROVIDER: "openai" } });
+    // provider none, but `requested` keeps WHY, so status/doctor can explain.
+    assert.deepEqual(withoutKey, { provider: "none", source: "env", requested: "openai" });
+  });
+});
+
+test("openai via cli-settings without a key → none, requested preserved", async () => {
+  await withTempFile(async (path) => {
+    await setEmbeddingProvider("openai", path);
+    const c = await resolveEmbeddingChoice({ path, env: {} });
+    assert.deepEqual(c, { provider: "none", source: "cli-settings", requested: "openai" });
+  });
+});
+
+test("backwards-compat: bare API key with no explicit choice → openai via 'api-key'", async () => {
+  await withTempFile(async (path) => {
+    for (const env of [{ OPENAI_API_KEY: "sk-test" }, { BASTRA_EMBEDDING_KEY: "sk-test" }]) {
+      const c = await resolveEmbeddingChoice({ path, env });
+      assert.deepEqual(c, { provider: "openai", source: "api-key" });
+    }
+  });
+});
+
+test("explicit file 'none' beats the API-key backwards-compat", async () => {
+  await withTempFile(async (path) => {
+    await setEmbeddingProvider("none", path);
+    const c = await resolveEmbeddingChoice({ path, env: { OPENAI_API_KEY: "sk-test" } });
+    assert.deepEqual(c, { provider: "none", source: "cli-settings" });
+  });
+});
+
+test("every stored provider name round-trips through the resolver", async () => {
+  await withTempFile(async (path) => {
+    const cases: [EmbeddingProviderName, EmbeddingProviderName][] = [
+      ["ollama", "ollama"],
+      ["none", "none"],
+    ];
+    for (const [stored, effective] of cases) {
+      await setEmbeddingProvider(stored, path);
+      const c = await resolveEmbeddingChoice({ path, env: {} });
+      assert.equal(c.provider, effective);
+      assert.equal(c.source, "cli-settings");
+    }
+  });
+});

--- a/packages/daemon/__tests__/embeddings-cmd.test.ts
+++ b/packages/daemon/__tests__/embeddings-cmd.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for `bastra embeddings <on|off|status>` + the install-end prompt
+ * guards + the doctor note (#79).
+ *
+ * Only paths that never spawn a subprocess or touch the network are exercised:
+ * `on` is tested via the env-override short-circuit (persists, refuses to
+ * download), the acting path stays untested like in ollama-ensure.test.ts.
+ * Settings go to a temp file via the injectable settingsPath.
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/embeddings-cmd.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  cmdEmbeddings,
+  decideInstallRecallAction,
+  formatEmbeddingDoctorLines,
+  RECALL_OFF_NOTE,
+} from "../src/cli/embeddings-cmd.js";
+import { getEmbeddingProvider, setEmbeddingProvider } from "../src/settings.js";
+
+async function withTempFile<T>(fn: (path: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-embed-cmd-"));
+  try {
+    return await fn(join(dir, "cli-settings.json"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Runs fn with BASTRA_EMBEDDING_PROVIDER set (or deleted), capturing stdout.
+ * Also clears OPENAI_API_KEY / BASTRA_EMBEDDING_KEY for the duration — a key
+ * leaked from the test machine's shell would flip the api-key tier and make
+ * these assertions environment-dependent.
+ */
+async function withEnvAndStdout(
+  envValue: string | null,
+  fn: () => Promise<number>,
+): Promise<{ rc: number; out: string }> {
+  const prev: Record<string, string | undefined> = {
+    BASTRA_EMBEDDING_PROVIDER: process.env.BASTRA_EMBEDDING_PROVIDER,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    BASTRA_EMBEDDING_KEY: process.env.BASTRA_EMBEDDING_KEY,
+  };
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.BASTRA_EMBEDDING_KEY;
+  if (envValue === null) delete process.env.BASTRA_EMBEDDING_PROVIDER;
+  else process.env.BASTRA_EMBEDDING_PROVIDER = envValue;
+  const origWrite = process.stdout.write.bind(process.stdout);
+  let out = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    out += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const rc = await fn();
+    return { rc, out };
+  } finally {
+    process.stdout.write = origWrite;
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+// ─── subcommand handlers ─────────────────────────────────────────────────────
+
+test("embeddings off: persists none, prints the re-enable one-liner", async () => {
+  await withTempFile(async (path) => {
+    const { rc, out } = await withEnvAndStdout(null, () => cmdEmbeddings({ sub: "off", settingsPath: path }));
+    assert.equal(rc, 0);
+    assert.equal(await getEmbeddingProvider(path), "none");
+    assert.match(out, /✓ embedding\.provider = none/);
+    assert.match(out, /Re-enable: bastra embeddings on/);
+  });
+});
+
+test("embeddings off: warns when an env override will shadow the setting", async () => {
+  await withTempFile(async (path) => {
+    const { rc, out } = await withEnvAndStdout("ollama", () => cmdEmbeddings({ sub: "off", settingsPath: path }));
+    assert.equal(rc, 0);
+    assert.match(out, /BASTRA_EMBEDDING_PROVIDER=ollama \(env\) overrides this/);
+  });
+});
+
+test("embeddings on: setting is persisted even when env overrides (no download for a shadowed choice)", async () => {
+  await withTempFile(async (path) => {
+    // env=none blocks provisioning (ensureOllama env-override guard, no
+    // subprocess/network) — but the user's declared intent must survive.
+    const { rc, out } = await withEnvAndStdout("none", () => cmdEmbeddings({ sub: "on", settingsPath: path }));
+    assert.equal(rc, 0);
+    assert.equal(await getEmbeddingProvider(path), "ollama");
+    assert.match(out, /✓ embedding\.provider = ollama/);
+    assert.match(out, /overrides the config file/);
+  });
+});
+
+test("embeddings status: default state names the default source and the OFF note", async () => {
+  await withTempFile(async (path) => {
+    const { rc, out } = await withEnvAndStdout(null, () => cmdEmbeddings({ sub: "status", settingsPath: path }));
+    assert.equal(rc, 0);
+    assert.match(out, /effective provider: none/);
+    assert.match(out, /resolved via: default \(nothing configured\)/);
+    assert.match(out, /Enable: bastra embeddings on/);
+  });
+});
+
+test("embeddings status: env override over a different file value is called out", async () => {
+  await withTempFile(async (path) => {
+    await setEmbeddingProvider("ollama", path);
+    // env=openai without a key → effective none via env, requested=openai.
+    const { out } = await withEnvAndStdout("openai", () => cmdEmbeddings({ sub: "status", settingsPath: path }));
+    assert.match(out, /BASTRA_EMBEDDING_PROVIDER=openai \(env\) overrides embedding\.provider=ollama \(cli-settings\)/);
+    assert.match(out, /openai is requested but no API key/);
+  });
+});
+
+test("embeddings: unknown subcommand → usage + exit 2", async () => {
+  await withTempFile(async (path) => {
+    const { rc } = await withEnvAndStdout(null, () => cmdEmbeddings({ sub: "enable", settingsPath: path }));
+    assert.equal(rc, 2);
+  });
+});
+
+// ─── install-end prompt guards (pure decision, no TTY needed) ────────────────
+
+test("install step: --no-ollama skips when no provider is effective", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: "skip", effectiveProvider: "none", interactive: true, yes: false, dryRun: false });
+  assert.equal(a, "skip");
+});
+
+test("install step: --no-ollama with an already-effective provider stays silent (it skips provisioning, it disables nothing — e.g. `bastra update`'s hard-skip)", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: "skip", effectiveProvider: "ollama", interactive: true, yes: false, dryRun: false });
+  assert.equal(a, "silent");
+});
+
+test("install step: --ollama provisions without asking (flag = consent)", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: "auto", effectiveProvider: "none", interactive: false, yes: true, dryRun: false });
+  assert.equal(a, "provision");
+});
+
+test("install step: an already-effective provider (env or setting) stays silent", () => {
+  for (const p of ["ollama", "openai"] as const) {
+    const a = decideInstallRecallAction({ ollamaFlag: null, effectiveProvider: p, interactive: true, yes: false, dryRun: false });
+    assert.equal(a, "silent");
+  }
+});
+
+test("install step: non-TTY never prompts (never hangs) — hint instead", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: null, effectiveProvider: "none", interactive: false, yes: false, dryRun: false });
+  assert.equal(a, "hint");
+});
+
+test("install step: --yes suppresses the prompt (non-interactive convention) — hint instead", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: null, effectiveProvider: "none", interactive: true, yes: true, dryRun: false });
+  assert.equal(a, "hint");
+});
+
+test("install step: --dry-run never prompts and never writes — hint instead", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: null, effectiveProvider: "none", interactive: true, yes: false, dryRun: true });
+  assert.equal(a, "hint");
+});
+
+test("install step: interactive TTY with no effective provider → ask once", () => {
+  const a = decideInstallRecallAction({ ollamaFlag: null, effectiveProvider: "none", interactive: true, yes: false, dryRun: false });
+  assert.equal(a, "prompt");
+});
+
+// ─── doctor note ─────────────────────────────────────────────────────────────
+
+test("doctor: effective none → the exact OFF note, as a note (not a failure)", () => {
+  const lines = formatEmbeddingDoctorLines({
+    choice: { provider: "none", source: "none" },
+    fileProvider: undefined,
+    envValue: undefined,
+    probe: null,
+  });
+  assert.equal(lines[0], "→ semantic recall");
+  assert.equal(lines[1], `  note: ${RECALL_OFF_NOTE}`);
+  assert.equal(RECALL_OFF_NOTE, "Semantic recall is OFF — recall is keyword-only (BM25). Enable: bastra embeddings on");
+});
+
+test("doctor: configured ollama with the model missing → actionable warning", () => {
+  const lines = formatEmbeddingDoctorLines({
+    choice: { provider: "ollama", source: "cli-settings" },
+    fileProvider: "ollama",
+    envValue: undefined,
+    probe: { ok: true, detail: "running (0.9.1)", hasModel: false },
+  });
+  assert.ok(lines.some((l) => /⚠ configured \(ollama, source: cli-settings\) but the embeddinggemma model is missing/.test(l)));
+  assert.ok(lines.some((l) => /Fix: bastra embeddings on/.test(l)));
+});
+
+test("doctor: configured ollama but server unreachable → actionable warning with the probe detail", () => {
+  const lines = formatEmbeddingDoctorLines({
+    choice: { provider: "ollama", source: "env" },
+    fileProvider: undefined,
+    envValue: "ollama",
+    probe: { ok: false, detail: "installed but server not running", hasModel: false },
+  });
+  assert.ok(lines.some((l) => /⚠ configured \(ollama, source: env\) but installed but server not running/.test(l)));
+});
+
+test("doctor: env overriding a different file value is mentioned", () => {
+  const lines = formatEmbeddingDoctorLines({
+    choice: { provider: "none", source: "env" },
+    fileProvider: "ollama",
+    envValue: "none",
+    probe: null,
+  });
+  assert.ok(lines.some((l) => l === "  note: BASTRA_EMBEDDING_PROVIDER=none (env) overrides embedding.provider=ollama (cli-settings)"));
+});
+
+test("doctor: healthy ollama → quiet ok line, no warnings", () => {
+  const lines = formatEmbeddingDoctorLines({
+    choice: { provider: "ollama", source: "cli-settings" },
+    fileProvider: "ollama",
+    envValue: undefined,
+    probe: { ok: true, detail: "running (0.9.1)", hasModel: true },
+  });
+  assert.ok(lines.some((l) => /✓ ok: ollama running \(0\.9\.1\), model embeddinggemma present \(source: cli-settings\)/.test(l)));
+  assert.ok(!lines.some((l) => l.includes("⚠")));
+});

--- a/packages/daemon/src/bridge.ts
+++ b/packages/daemon/src/bridge.ts
@@ -49,6 +49,7 @@ import {
   DOCS_MODES,
   getSharedRecallEnabled,
   getSharedRecallLanguage,
+  resolveEmbeddingChoice,
 } from "./settings.js";
 import { expandQuery, BridgePool } from "./learned-recall/bridges.js";
 import { isSupportedLanguage, type SupportedLanguage } from "./learned-recall/language.js";
@@ -57,19 +58,18 @@ import readline from "node:readline";
 import * as path from "node:path";
 
 /**
- * Aktiviert Embeddings basierend auf BASTRA_EMBEDDING_PROVIDER:
- *   - "ollama": Lokal via Ollama (Standard für neue Setups). Optional
- *               BASTRA_OLLAMA_URL und BASTRA_EMBEDDING_MODEL.
- *   - "openai": Cloud via OpenAI. Braucht OPENAI_API_KEY oder BASTRA_EMBEDDING_KEY.
- *   - "none" / unset: Embeddings disabled (Recall fällt auf reines BM25).
+ * Aktiviert Embeddings über die EINE geteilte Auflösung (settings.ts,
+ * resolveEmbeddingChoice — dieselbe wie index.ts und die CLI, #79):
+ *   env BASTRA_EMBEDDING_PROVIDER > cli-settings.json embedding.provider >
+ *   API-Key (Backwards-Compat) > none (Recall fällt auf reines BM25).
  *
- * Default-Verhalten (kein BASTRA_EMBEDDING_PROVIDER gesetzt):
- *   Wenn ein OpenAI-Key gesetzt ist → openai (Backwards-Compat).
- *   Sonst disabled. Wer auf Ollama umstellen will, setzt explizit
- *   BASTRA_EMBEDDING_PROVIDER=ollama.
+ * Env gewinnt immer — die Pro-App gibt ihre Wahl im Spawn-Env mit und wird
+ * von der Datei nie überstimmt. Setzt die App KEIN Env, greift die per
+ * `bastra embeddings on` persistierte Wahl, damit semantischer Recall den
+ * Daemon unabhängig vom spawnenden Client erreicht.
  */
 async function attachEmbeddings(search: SearchIndex, vault: Vault): Promise<void> {
-  const { provider, status } = resolveEmbedding();
+  const { provider, status } = await resolveEmbedding();
   // Same wording as the daemon (index.ts) via the shared helper; bridge keeps
   // its own tag. Logged on every path including success (the silence was #79).
   process.stderr.write(embeddingStatusLine(status, "[bastra-recall.bridge]") + "\n");
@@ -142,26 +142,26 @@ async function probeDaemonHealth(): Promise<boolean> {
 }
 
 /**
- * Env-only provider resolution for the bridge (the Pro app passes the choice in
- * the spawn env). Deliberately does NOT read cli-settings.json — that file is
- * the OSS CLI's; mixing it in could make the app and CLI disagree. Env always
- * wins, so OSS activation never silently overrides the app on a shared machine.
+ * Provider resolution via the shared resolveEmbeddingChoice (settings.ts) —
+ * identical precedence to index.ts and the CLI: env > cli-settings.json >
+ * API-key > none. Env always wins, so the Pro app's spawn-env choice is never
+ * overridden by the file; the file only fills the gap when no env is set
+ * (owner decision on #79: the persisted setting reaches the daemon regardless
+ * of which client spawned it).
  */
-function resolveEmbedding(): { provider: EmbeddingProvider | null; status: EmbeddingStatus } {
-  const requested = (process.env.BASTRA_EMBEDDING_PROVIDER ?? "").toLowerCase();
-  const apiKey = process.env.OPENAI_API_KEY ?? process.env.BASTRA_EMBEDDING_KEY;
-
-  if (requested === "none") return offE("env");
-  if (requested === "ollama") return ollamaE("env");
-  if (requested === "openai") return apiKey ? openaiE("env", apiKey) : offE("env");
-  if (requested) {
-    process.stderr.write(
-      `[bastra-recall.bridge] ignoring invalid BASTRA_EMBEDDING_PROVIDER ${JSON.stringify(process.env.BASTRA_EMBEDDING_PROVIDER)} — falling back to API-key / BM25\n`,
-    );
+async function resolveEmbedding(): Promise<{ provider: EmbeddingProvider | null; status: EmbeddingStatus }> {
+  const choice = await resolveEmbeddingChoice({
+    onInvalidEnv: (raw) =>
+      process.stderr.write(
+        `[bastra-recall.bridge] ignoring invalid BASTRA_EMBEDDING_PROVIDER ${JSON.stringify(raw)} — falling through to cli-settings / API-key\n`,
+      ),
+  });
+  if (choice.provider === "ollama") return ollamaE(choice.source);
+  if (choice.provider === "openai") {
+    const apiKey = process.env.OPENAI_API_KEY ?? process.env.BASTRA_EMBEDDING_KEY;
+    if (apiKey) return openaiE(choice.source, apiKey);
   }
-  // Backwards-compat: no explicit provider but an API key is present.
-  if (apiKey) return openaiE("api-key", apiKey);
-  return offE("none");
+  return offE(choice.source);
 }
 
 function ollamaE(source: EmbeddingSource): { provider: EmbeddingProvider; status: EmbeddingStatus } {

--- a/packages/daemon/src/cli.ts
+++ b/packages/daemon/src/cli.ts
@@ -20,6 +20,7 @@ import {
 import { cmdStatus } from "./cli/status.js";
 import { cmdUpdate } from "./cli/update.js";
 import { cmdConfig } from "./cli/config-cmd.js";
+import { cmdEmbeddings } from "./cli/embeddings-cmd.js";
 import { cmdToken } from "./cli/token.js";
 import { cmdCommons } from "./cli/commons.js";
 import { cmdBridges } from "./cli/bridges.js";
@@ -44,6 +45,7 @@ async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
       return rc;
     }
     case "config": return cmdConfig(args);
+    case "embeddings": return cmdEmbeddings({ sub: args.surface });
     case "token": return cmdToken({ sub: args.surface, json: args.json });
     case "commons": return cmdCommons({ sub: args.surface, positional: args.positional });
     case "bridges": return cmdBridges({ sub: args.surface, positional: args.positional });

--- a/packages/daemon/src/cli/commands.ts
+++ b/packages/daemon/src/cli/commands.ts
@@ -1,6 +1,6 @@
 import { ADAPTERS, resolveTargets } from "./registry.js";
 import { VERSION, formatStatus } from "./helpers.js";
-import { ensureOllama } from "./ollama.js";
+import { installSemanticRecallStep, printEmbeddingDoctorNote } from "./embeddings-cmd.js";
 import { getEmbeddingProvider } from "../settings.js";
 import type { InstallOpts, ParsedArgs } from "./types.js";
 
@@ -17,6 +17,11 @@ Commands:
   uninstall <surface|all>    Remove the registration (skill is kept; it's shared)
   update                     brew upgrade (if brew-installed) + re-register +
                              daemon restart. Use this after pulling new code.
+  embeddings <on|off|status> Semantic recall (multilingual vector search):
+                             'on' sets up Ollama + the embeddinggemma model
+                             (~620 MB) and persists the choice; 'off' returns
+                             to BM25 keyword-only; 'status' shows the effective
+                             provider and how it was resolved
   config get <key>           Read a setting (e.g. update.mode)
   config set <key> <value>   Write a setting (update.mode = notify|auto|off,
                              docs.mode = off|suggest|auto, docs.language = en|de|…)
@@ -49,7 +54,7 @@ Options:
   --json                     Output status in JSON format (status command only)
   -q, --quiet                Suppress output, return exit code only (status command only)
   --yes, -y                  Skip confirmation prompts (replace a foreign statusLine)
-  --ollama                   Set up Ollama for semantic recall without asking (installs via Homebrew, downloads ~600 MB)
+  --ollama                   Set up Ollama for semantic recall without asking (installs via Homebrew, downloads ~620 MB)
   --no-ollama                Skip the Ollama setup (semantic recall uses BM25 keyword search)
   --fix                      With doctor: repair non-ok surfaces (on 'all', won't set up ones never installed)
   --with-stop-hook           Install optional Stop save-eval hook
@@ -131,12 +136,6 @@ export async function cmdInstall(args: ParsedArgs): Promise<number> {
     return 2;
   }
 
-  // Ollama is a global concern (one daemon, one embedding engine), so it runs
-  // once here — not per surface. An Ollama failure never fails the install:
-  // surface registration is the job; semantic recall is an enhancement.
-  const ollama = await ensureOllama({ dryRun: args.dryRun, mode: args.ollama });
-  process.stdout.write(`→ semantic recall: ${ollama.message}\n\n`);
-
   const vaultPath = resolveVaultPath(args.vaultPath);
   const opts: InstallOpts = {
     dryRun: args.dryRun,
@@ -160,7 +159,14 @@ export async function cmdInstall(args: ParsedArgs): Promise<number> {
     }
     process.stdout.write("\n");
   }
-  return hadError ? 1 : 0;
+  if (hadError) return 1;
+
+  // Semantic recall is a global concern (one daemon, one embedding engine), so
+  // it runs ONCE at the end of a successful install — not per surface (#79).
+  // Prompts only on a TTY without --yes and only when no provider is effective;
+  // an Ollama failure never fails the install: surface registration is the job.
+  await installSemanticRecallStep({ dryRun: args.dryRun, yes: args.yes, ollama: args.ollama });
+  return 0;
 }
 
 export async function cmdUninstall(args: ParsedArgs): Promise<number> {
@@ -192,7 +198,7 @@ export async function cmdUninstall(args: ParsedArgs): Promise<number> {
   if (args.surface === "all" && (await getEmbeddingProvider()) === "ollama") {
     process.stdout.write(
       "→ semantic recall: Ollama stays configured and its login service may still run.\n" +
-        "  Disable recall: bastra config set embedding.provider none\n" +
+        "  Disable recall: bastra embeddings off\n" +
         "  Stop the service: brew services stop ollama\n\n",
     );
   }
@@ -241,5 +247,11 @@ export async function cmdDoctor(args: ParsedArgs): Promise<number> {
     }
     process.stdout.write("\n");
   }
+
+  // Semantic recall is global, not a surface — reported as a NOTE (or an
+  // actionable ⚠), never as a failure: BM25-only recall is degraded, not
+  // broken, so it never flips doctor's exit code (#79).
+  await printEmbeddingDoctorNote();
+
   return hadBroken ? 1 : 0;
 }

--- a/packages/daemon/src/cli/config-cmd.ts
+++ b/packages/daemon/src/cli/config-cmd.ts
@@ -113,7 +113,7 @@ async function cmdConfigSet(key: KnownKey, value: string | null): Promise<number
       }
       process.stdout.write("  restart the daemon to apply (activates on next boot).\n");
       if (value === "ollama") {
-        process.stdout.write("  needs Ollama + the embeddinggemma model — run `bastra install --ollama` if not set up.\n");
+        process.stdout.write("  needs Ollama + the embeddinggemma model — run `bastra embeddings on` if not set up.\n");
       }
       return 0;
     }

--- a/packages/daemon/src/cli/embeddings-cmd.ts
+++ b/packages/daemon/src/cli/embeddings-cmd.ts
@@ -1,0 +1,274 @@
+/**
+ * `bastra embeddings <on|off|status>` — the discoverable switch for semantic
+ * recall (#79). Recall stays BM25-by-default (the embedding layer is an
+ * optional, configurable 2nd pass); this command makes turning it on a single
+ * line instead of a hidden env/config dance.
+ *
+ *   on     persist embedding.provider=ollama, then provision (Homebrew install
+ *          if missing, pull embeddinggemma ~620 MB, start login service).
+ *          The setting survives a failed download — status/doctor then say
+ *          "configured but model missing" instead of a silent none.
+ *   off    persist embedding.provider=none (recall = BM25 keyword search only).
+ *   status effective provider + WHERE it came from (env / cli-settings /
+ *          API-key / default) + Ollama server & model presence.
+ *
+ * Also home of the install-end prompt (installSemanticRecallStep) and the
+ * doctor note (printEmbeddingDoctorNote) so every surface points at the same
+ * one-liner.
+ */
+import {
+  getEmbeddingProvider,
+  setEmbeddingProvider,
+  resolveEmbeddingChoice,
+  settingsFilePath,
+  type EmbeddingChoice,
+  type EmbeddingProviderName,
+} from "../settings.js";
+import { enableSemanticRecall, ensureOllama, probeOllama } from "./ollama.js";
+import { confirm, isInteractive } from "./prompt.js";
+
+const ENABLE_HINT = "bastra embeddings on";
+
+/** The one OFF wording every surface shares (doctor, install hint, status). */
+export const RECALL_OFF_NOTE = `Semantic recall is OFF — recall is keyword-only (BM25). Enable: ${ENABLE_HINT}`;
+/** Same message behind the install step's "→ semantic recall:" prefix. */
+const INSTALL_OFF_HINT = `→ semantic recall: OFF — recall is keyword-only (BM25). Enable: ${ENABLE_HINT}`;
+
+export const INSTALL_PROMPT_QUESTION =
+  "Enable semantic recall (multilingual vector search)? Downloads the embeddinggemma model (~620 MB) via Ollama (installed with Homebrew if missing).";
+
+function write(line: string): void {
+  process.stdout.write(line + "\n");
+}
+
+export async function cmdEmbeddings(opts: { sub: string | null; settingsPath?: string }): Promise<number> {
+  switch (opts.sub) {
+    case "on":
+      return cmdOn(opts.settingsPath);
+    case "off":
+      return cmdOff(opts.settingsPath);
+    case "status":
+      return cmdStatus(opts.settingsPath);
+    default:
+      process.stderr.write("usage: bastra embeddings <on|off|status>\n");
+      process.stderr.write(`  on      enable semantic recall (persists the setting + sets up Ollama/embeddinggemma)\n`);
+      process.stderr.write(`  off     disable semantic recall (recall = BM25 keyword search only)\n`);
+      process.stderr.write(`  status  show the effective provider, how it was resolved, and model presence\n`);
+      return 2;
+  }
+}
+
+async function cmdOn(settingsPath?: string): Promise<number> {
+  const r = await enableSemanticRecall({ dryRun: false }, settingsPath);
+  write(`✓ embedding.provider = ollama`);
+  write(`  stored in ${settingsPath ?? settingsFilePath()}`);
+  write(`→ semantic recall: ${r.message}`);
+  if (r.status === "already-active") {
+    write("  restart the daemon to apply (restart your AI client, or it applies on the next boot).");
+  }
+  if (r.status === "error" || r.status === "unsupported") {
+    write("  setting saved — semantic recall turns ON once Ollama + the embeddinggemma model are ready;");
+    write(`  recall stays keyword-only (BM25) until then. Finish setup, then re-run: ${ENABLE_HINT}`);
+    return 1;
+  }
+  return 0;
+}
+
+async function cmdOff(settingsPath?: string): Promise<number> {
+  await setEmbeddingProvider("none", settingsPath);
+  write(`✓ embedding.provider = none`);
+  write(`  stored in ${settingsPath ?? settingsFilePath()}`);
+  write(`  semantic recall OFF — recall is keyword-only (BM25). Re-enable: ${ENABLE_HINT}`);
+  const env = process.env.BASTRA_EMBEDDING_PROVIDER;
+  if (env && env.toLowerCase() !== "none") {
+    write(`  ⚠ BASTRA_EMBEDDING_PROVIDER=${env} (env) overrides this — unset it for the setting to take effect.`);
+  }
+  write("  restart the daemon to apply (activates on next boot).");
+  return 0;
+}
+
+async function cmdStatus(settingsPath?: string): Promise<number> {
+  const choice = await resolveEmbeddingChoice({ path: settingsPath });
+  const fileProvider = await getEmbeddingProvider(settingsPath);
+  const envRaw = process.env.BASTRA_EMBEDDING_PROVIDER;
+
+  write(`effective provider: ${choice.provider}`);
+  write(`  resolved via: ${sourceLabel(choice, fileProvider, envRaw, settingsPath)}`);
+
+  if (choice.requested === "openai" && choice.provider === "none") {
+    write("  ⚠ openai is requested but no API key is set (OPENAI_API_KEY / BASTRA_EMBEDDING_KEY) — falling back to none");
+  }
+  if (choice.source === "env" && fileProvider && envRaw && envRaw.toLowerCase() !== fileProvider) {
+    write(`  note: BASTRA_EMBEDDING_PROVIDER=${envRaw} (env) overrides embedding.provider=${fileProvider} (cli-settings)`);
+  }
+
+  if (choice.provider === "ollama") {
+    const o = await probeOllama();
+    if (!o.ok) {
+      write(`  ⚠ ${o.detail} — recall falls back to BM25. Fix: ${ENABLE_HINT}`);
+    } else {
+      write(`  ollama: ${o.detail}`);
+      write(`  model embeddinggemma: ${o.hasModel ? "present" : `MISSING — recall falls back to BM25. Fix: ${ENABLE_HINT}`}`);
+    }
+  } else if (choice.provider === "none") {
+    write(`  ${RECALL_OFF_NOTE}`);
+  }
+  return 0;
+}
+
+function sourceLabel(
+  choice: EmbeddingChoice,
+  fileProvider: EmbeddingProviderName | undefined,
+  envRaw: string | undefined,
+  settingsPath?: string,
+): string {
+  switch (choice.source) {
+    case "env":
+      return `BASTRA_EMBEDDING_PROVIDER=${envRaw} (env — wins over cli-settings)`;
+    case "cli-settings":
+      return `embedding.provider=${fileProvider} (${settingsPath ?? settingsFilePath()})`;
+    case "api-key":
+      return "OPENAI_API_KEY present, no explicit provider (backwards-compat)";
+    case "none":
+      return "default (nothing configured)";
+  }
+}
+
+// ─── install-end prompt (#79) ────────────────────────────────────────────────
+
+export type InstallRecallAction = "skip" | "provision" | "silent" | "prompt" | "hint";
+
+/**
+ * Pure decision for the end-of-install semantic-recall step — exported so the
+ * TTY/--yes guards are unit-testable without a terminal:
+ *   --ollama               → provision without asking (explicit flag = consent)
+ *   provider already effective (env or setting) → silent — also under
+ *                            --no-ollama (the flag skips provisioning, it
+ *                            never disables anything, so there is nothing to
+ *                            report; keeps `bastra update`'s hard-skip quiet)
+ *   --no-ollama            → skip (one skip line)
+ *   dry-run / --yes / non-TTY → hint line, NEVER a prompt (never hangs)
+ *   otherwise              → ask once ([Y/n])
+ */
+export function decideInstallRecallAction(i: {
+  ollamaFlag: "auto" | "skip" | null;
+  effectiveProvider: EmbeddingProviderName;
+  interactive: boolean;
+  yes: boolean;
+  dryRun: boolean;
+}): InstallRecallAction {
+  if (i.ollamaFlag === "auto") return "provision";
+  if (i.effectiveProvider !== "none") return "silent";
+  if (i.ollamaFlag === "skip") return "skip";
+  if (i.dryRun || i.yes || !i.interactive) return "hint";
+  return "prompt";
+}
+
+/** Runs at the END of a successful `bastra install` (never on a failed one). */
+export async function installSemanticRecallStep(args: {
+  dryRun: boolean;
+  yes: boolean;
+  ollama: "auto" | "skip" | null;
+}): Promise<void> {
+  const choice = await resolveEmbeddingChoice();
+  const action = decideInstallRecallAction({
+    ollamaFlag: args.ollama,
+    effectiveProvider: choice.provider,
+    interactive: isInteractive(),
+    yes: args.yes,
+    dryRun: args.dryRun,
+  });
+
+  if (action === "silent") return;
+  if (action === "skip") {
+    const r = await ensureOllama({ dryRun: args.dryRun, mode: "skip" });
+    write(`→ semantic recall: ${r.message}`);
+    return;
+  }
+  if (action === "hint") {
+    write(INSTALL_OFF_HINT);
+    return;
+  }
+  if (action === "prompt") {
+    const accepted = await confirm(INSTALL_PROMPT_QUESTION, { defaultYes: true });
+    if (!accepted) {
+      write(INSTALL_OFF_HINT);
+      return;
+    }
+  }
+  // "provision", or the prompt was accepted — same path as `bastra embeddings on`.
+  const r = await enableSemanticRecall({ dryRun: args.dryRun });
+  write(`→ semantic recall: ${r.message}`);
+  if (r.persisted && (r.status === "error" || r.status === "unsupported")) {
+    write(`  setting saved — finish setup, then re-run: ${ENABLE_HINT}`);
+  }
+}
+
+// ─── doctor note (#79) ───────────────────────────────────────────────────────
+
+export interface OllamaProbeResult {
+  ok: boolean;
+  detail: string;
+  hasModel: boolean;
+}
+
+/**
+ * Pure formatter for the doctor's semantic-recall block (exported for tests).
+ * A NOTE, never a failure — BM25-only is degraded, not broken, so doctor's
+ * exit code is untouched.
+ */
+export function formatEmbeddingDoctorLines(i: {
+  choice: EmbeddingChoice;
+  fileProvider: EmbeddingProviderName | undefined;
+  envValue: string | undefined;
+  /** probeOllama() result when the effective provider is ollama, else null. */
+  probe: OllamaProbeResult | null;
+}): string[] {
+  const lines: string[] = ["→ semantic recall"];
+  const { choice } = i;
+
+  if (choice.provider === "none") {
+    lines.push(`  note: ${RECALL_OFF_NOTE}`);
+    if (choice.requested === "openai") {
+      lines.push(`  note: openai is requested (source: ${choice.source}) but no API key is set (OPENAI_API_KEY / BASTRA_EMBEDDING_KEY)`);
+    }
+  } else if (choice.provider === "ollama") {
+    if (i.probe && !i.probe.ok) {
+      lines.push(`  ⚠ configured (ollama, source: ${choice.source}) but ${i.probe.detail} — recall falls back to BM25. Fix: ${ENABLE_HINT}`);
+    } else if (i.probe && !i.probe.hasModel) {
+      lines.push(`  ⚠ configured (ollama, source: ${choice.source}) but the embeddinggemma model is missing — recall falls back to BM25. Fix: ${ENABLE_HINT}`);
+    } else {
+      lines.push(`  ✓ ok: ollama ${i.probe?.detail ?? "configured"}, model embeddinggemma present (source: ${choice.source})`);
+    }
+  } else {
+    lines.push(`  ✓ ok: openai (source: ${choice.source})`);
+  }
+
+  if (
+    i.envValue &&
+    i.fileProvider &&
+    i.envValue.toLowerCase() !== i.fileProvider
+  ) {
+    lines.push(`  note: BASTRA_EMBEDDING_PROVIDER=${i.envValue} (env) overrides embedding.provider=${i.fileProvider} (cli-settings)`);
+  }
+  return lines;
+}
+
+/** Doctor's semantic-recall block: gathers state, prints, never throws. */
+export async function printEmbeddingDoctorNote(): Promise<void> {
+  try {
+    const choice = await resolveEmbeddingChoice();
+    const fileProvider = await getEmbeddingProvider();
+    const probe = choice.provider === "ollama" ? await probeOllama() : null;
+    const lines = formatEmbeddingDoctorLines({
+      choice,
+      fileProvider,
+      envValue: process.env.BASTRA_EMBEDDING_PROVIDER,
+      probe,
+    });
+    for (const line of lines) write(line);
+    write("");
+  } catch {
+    /* a diagnostics NOTE must never break doctor */
+  }
+}

--- a/packages/daemon/src/cli/ollama.ts
+++ b/packages/daemon/src/cli/ollama.ts
@@ -1,21 +1,24 @@
 /**
- * Ollama provisioning for `bastra install` (#79).
+ * Ollama provisioning for `bastra embeddings on` and `bastra install` (#79).
  *
- * OSS-side, autonomous: detect Ollama + the embeddinggemma model, and — when
- * the user opts in — install it via Homebrew, start it, pull the model, and
- * persist `embedding.provider=ollama` into ~/.bastra/cli-settings.json. We
- * delegate the *install* to Homebrew (we bundle no binary — that stays Pro);
- * we own the *lifecycle* so semantic recall works without the Mac app.
+ * OSS-side, autonomous: detect Ollama + the embeddinggemma model, install it
+ * via Homebrew (if missing), start it, pull the model, and persist
+ * `embedding.provider=ollama` into ~/.bastra/cli-settings.json. We delegate
+ * the *install* to Homebrew (we bundle no binary — that stays Pro); we own
+ * the *lifecycle* so semantic recall works without the Mac app.
+ *
+ * Consent lives with the CALLERS (`bastra embeddings on` is the consent; the
+ * install-end prompt asks before calling) — this module never prompts.
  *
  * Safety contract: never throws, never exits, never hangs. Every external
  * command has a timeout and a closed stdin (so a sudo prompt fails fast instead
- * of blocking a non-interactive run). The provider is persisted only after the
- * model is verified present.
+ * of blocking a non-interactive run). ensureOllama persists the provider only
+ * after the model is verified present (enableSemanticRecall persists upfront —
+ * see there).
  */
 import { spawn } from "node:child_process";
 import { findExecutable, run } from "./exec.js";
-import { confirm, isInteractive } from "./prompt.js";
-import { getEmbeddingProvider, getOllamaAutostart, setEmbeddingProvider } from "../settings.js";
+import { getOllamaAutostart, setEmbeddingProvider } from "../settings.js";
 
 const OLLAMA_URL = (process.env.BASTRA_OLLAMA_URL ?? "http://localhost:11434").replace(/\/+$/, "");
 const EMBED_MODEL = process.env.BASTRA_EMBEDDING_MODEL ?? "embeddinggemma";
@@ -26,8 +29,6 @@ export interface EnsureResult {
     | "unsupported"
     | "env-override"
     | "already-active"
-    | "detected"
-    | "declined"
     | "would-install"
     | "activated"
     | "error";
@@ -35,13 +36,15 @@ export interface EnsureResult {
   activated: boolean;
 }
 
-export async function ensureOllama(opts: { dryRun: boolean; mode: "auto" | "skip" | null }): Promise<EnsureResult> {
+// mode is deliberately NOT nullable: "auto" acts without asking, so every
+// caller must have collected consent (flag, prompt, or the subcommand itself).
+export async function ensureOllama(opts: { dryRun: boolean; mode: "auto" | "skip" }): Promise<EnsureResult> {
   try {
     if (opts.mode === "skip") {
       return { status: "skipped", activated: false, message: "skipped (--no-ollama) — semantic recall uses BM25 keyword search" };
     }
-    // env wins over the file at runtime — don't burn a 600 MB download on a
-    // choice the daemon will shadow. Checked before the platform gate: the
+    // env wins over the file at runtime — don't burn a 620 MB download on a
+    // choice the daemon will shadow. Checked before everything else: the
     // explicit user override outranks "unsupported here" on every OS.
     const envProvider = (process.env.BASTRA_EMBEDDING_PROVIDER ?? "").toLowerCase();
     if (envProvider && envProvider !== "ollama") {
@@ -52,64 +55,42 @@ export async function ensureOllama(opts: { dryRun: boolean; mode: "auto" | "skip
       };
     }
 
-    if (process.platform !== "darwin") {
-      return {
-        status: "unsupported",
-        activated: false,
-        message:
-          "automatic Ollama setup is macOS-only today (Windows: #84). Manual: install Ollama, then `bastra config set embedding.provider ollama`",
-      };
-    }
-
     const ollamaBin = findExecutable("ollama");
     const serverUp = ollamaBin ? await serverVersion() : null;
     const hasModel = serverUp ? await modelPresent() : false;
     const fullyReady = Boolean(ollamaBin && serverUp && hasModel);
 
-    const settingsProvider = await getEmbeddingProvider();
-    const alreadyOptedIn = settingsProvider === "ollama" || envProvider === "ollama";
-
-    // Everything already present → activation is cheap (no download). But don't
-    // flip the setting as a silent side effect of an unrelated install: require
-    // an explicit opt-in (already chose ollama, --ollama, or an interactive yes).
+    // Everything already present → activation is cheap (no download, works on
+    // every OS — the platform gate below only guards the brew-install path).
     if (fullyReady) {
-      const optIn = alreadyOptedIn || opts.mode === "auto" || (isInteractive() && (await confirm("Ollama + embeddinggemma are ready. Use them for semantic recall?")));
-      if (optIn) {
-        if (!opts.dryRun) await setEmbeddingProvider("ollama");
-        return {
-          status: "already-active",
-          activated: !opts.dryRun,
-          message: `Ollama ready (${serverUp})${opts.dryRun ? "; would enable semantic recall" : "; semantic recall ON"}`,
-        };
-      }
+      if (!opts.dryRun) await setEmbeddingProvider("ollama");
       return {
-        status: "detected",
-        activated: false,
-        message: "Ollama detected but not activated — run `bastra config set embedding.provider ollama` to use it",
+        status: "already-active",
+        activated: !opts.dryRun,
+        message: `Ollama ready (${serverUp})${opts.dryRun ? "; would enable semantic recall" : "; semantic recall ON"}`,
       };
     }
 
-    // Something is missing → may need brew install / serve / pull.
-    const act =
-      opts.mode === "auto" ||
-      (isInteractive() &&
-        (await confirm(
-          "Set up Ollama for semantic recall? Installs Ollama via Homebrew (if missing), downloads the embeddinggemma model (~600 MB), and runs a local Ollama login service (disable later: bastra config set ollama.autostart off).",
-        )));
-    if (!act) {
-      return { status: "declined", activated: false, message: missingHint(ollamaBin, serverUp, hasModel) };
+    // Something is missing → needs brew install / serve / pull (macOS-only today).
+    if (process.platform !== "darwin") {
+      return {
+        status: "unsupported",
+        activated: false,
+        message:
+          "automatic Ollama setup is macOS-only today (Windows: #84). Manual: install + start Ollama (https://ollama.com), pull the embeddinggemma model, then re-run: bastra embeddings on",
+      };
     }
     if (opts.dryRun) {
       return {
         status: "would-install",
         activated: false,
-        message: "would: brew install ollama (if missing) → start service → pull embeddinggemma (~600 MB) → activate",
+        message: "would: brew install ollama (if missing) → start service → pull embeddinggemma (~620 MB) → activate",
       };
     }
 
-    // Cost disclosure on the acting path — also covers --ollama / non-TTY auto,
-    // where confirm() never ran.
-    process.stdout.write("  → setting up Ollama: Homebrew install (if needed) + ~600 MB model + local login service\n");
+    // Cost disclosure on the acting path (the caller's prompt already named
+    // the download; this line marks the moment work actually starts).
+    process.stdout.write("  → setting up Ollama: Homebrew install (if needed) + ~620 MB model + local login service\n");
 
     const autostart = await getOllamaAutostart();
     const brewBin = findExecutable("brew");
@@ -139,7 +120,7 @@ export async function ensureOllama(opts: { dryRun: boolean; mode: "auto" | "skip
     // 3. model
     if (!(await modelPresent())) {
       const r = run(ollamaPath, ["pull", EMBED_MODEL], { timeoutMs: 1_800_000, showProgress: true });
-      if (r.signal) return err(`model download was interrupted — re-run \`bastra install --ollama\` when ready`);
+      if (r.signal) return err(`model download was interrupted — re-run \`bastra embeddings on\` when ready`);
       if (!r.ok) return err(`\`ollama pull ${EMBED_MODEL}\` failed (${r.detail})`);
       // Interrupted pulls can exit 0 with an incomplete model — verify.
       if (!(await modelPresent())) return err(`model not present after pull — re-run \`ollama pull ${EMBED_MODEL}\``);
@@ -161,13 +142,27 @@ function err(message: string): EnsureResult {
   return { status: "error", activated: false, message: `${message} — semantic recall stays OFF (BM25 keyword search still works)` };
 }
 
-function missingHint(bin: string | null, server: string | null, model: boolean): string {
-  const steps: string[] = [];
-  if (!bin) steps.push("brew install ollama");
-  if (!server) steps.push("brew services start ollama  (or: ollama serve)");
-  if (!model) steps.push(`ollama pull ${EMBED_MODEL}`);
-  steps.push("bastra config set embedding.provider ollama");
-  return `semantic recall stays OFF (BM25 keyword search works). To enable: ${steps.join("  &&  ")}`;
+/**
+ * The `bastra embeddings on` core, shared with the install-end prompt (#79):
+ * persist embedding.provider=ollama FIRST (the user's choice must survive a
+ * flaky download — status/doctor then show "configured but model missing"
+ * instead of silent none), then run the provisioning path. `settingsPath` is
+ * injectable for tests only.
+ */
+export async function enableSemanticRecall(
+  opts: { dryRun: boolean },
+  settingsPath?: string,
+): Promise<EnsureResult & { persisted: boolean }> {
+  let persisted = false;
+  if (!opts.dryRun) {
+    // Exception: an env override shadows the file at runtime — still persist
+    // (it's the user's declared intent; doctor explains the override), but
+    // ensureOllama will refuse to download for a shadowed choice.
+    await setEmbeddingProvider("ollama", settingsPath);
+    persisted = true;
+  }
+  const result = await ensureOllama({ dryRun: opts.dryRun, mode: "auto" });
+  return { ...result, persisted };
 }
 
 // ── Ollama HTTP probes ───────────────────────────────────────────────────────

--- a/packages/daemon/src/cli/prompt.ts
+++ b/packages/daemon/src/cli/prompt.ts
@@ -13,15 +13,18 @@ export function isInteractive(): boolean {
 }
 
 /**
- * y/N confirmation, default No. Returns false in any non-interactive context
- * and on EOF / Ctrl-C during the prompt. Never throws.
+ * y/N confirmation, default No — or Y/n (default Yes) with `defaultYes`, where
+ * a plain Enter accepts. Returns false in any non-interactive context and on
+ * EOF / Ctrl-C during the prompt (even with defaultYes: silence is never
+ * consent to a download). Never throws.
  */
-export async function confirm(question: string): Promise<boolean> {
+export async function confirm(question: string, opts: { defaultYes?: boolean } = {}): Promise<boolean> {
   if (!isInteractive()) return false;
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = await rl.question(`${question} [y/N] `);
-    return /^y(es)?$/i.test(answer.trim());
+    const answer = (await rl.question(`${question} ${opts.defaultYes ? "[Y/n]" : "[y/N]"} `)).trim();
+    if (answer === "") return Boolean(opts.defaultYes);
+    return /^y(es)?$/i.test(answer);
   } catch {
     // SIGINT (Ctrl-C) rejects the pending question() — treat as "no".
     return false;

--- a/packages/daemon/src/cli/status.ts
+++ b/packages/daemon/src/cli/status.ts
@@ -110,7 +110,7 @@ async function formatSemanticRecall(configured: EmbeddingProviderName | undefine
     // it directly so "installed but daemon down" vs "model missing" is visible.
     if (configured === "ollama") {
       const o = await probeOllama();
-      const detail = o.ok ? (o.hasModel ? "ollama ready" : "model embeddinggemma MISSING — run: ollama pull embeddinggemma") : o.detail;
+      const detail = o.ok ? (o.hasModel ? "ollama ready" : "model embeddinggemma MISSING — fix: bastra embeddings on") : o.detail;
       return `· daemon not reachable; configured=ollama (${detail})`;
     }
     return `· daemon not reachable; configured=${configured ?? "unset"}`;
@@ -124,7 +124,7 @@ async function formatSemanticRecall(configured: EmbeddingProviderName | undefine
     if ((d.embeddingMode ?? "").startsWith("ollama")) {
       const o = await probeOllama();
       if (o.ok && !o.hasModel) {
-        return `⚠ on (${d.embeddingMode}) but the embeddinggemma model is MISSING — recall falls back to BM25. Fix: ollama pull embeddinggemma`;
+        return `⚠ on (${d.embeddingMode}) but the embeddinggemma model is MISSING — recall falls back to BM25. Fix: bastra embeddings on`;
       }
       if (!o.ok) {
         return `⚠ on (${d.embeddingMode}) but Ollama is unreachable (${o.detail}) — recall falls back to BM25`;
@@ -145,5 +145,5 @@ async function formatSemanticRecall(configured: EmbeddingProviderName | undefine
     }
     return "· off — configured=ollama, daemon hasn't picked it up yet; restart pending (restart your AI client, or auto after idle)";
   }
-  return "· off — BM25 keyword search only. Enable: bastra install --ollama";
+  return "· off — BM25 keyword search only. Enable: bastra embeddings on";
 }

--- a/packages/daemon/src/cli/types.ts
+++ b/packages/daemon/src/cli/types.ts
@@ -53,7 +53,8 @@ export interface ParsedArgs {
   // SessionStart auto-update path so a running session is never disrupted.
   staged: boolean;
   // `install --ollama` → "auto" (provision without asking); `--no-ollama`
-  // → "skip"; null → ask interactively on a TTY, default-skip otherwise.
+  // → "skip"; null → ask ONCE at the end of a successful install (TTY only,
+  // never with --yes/--dry-run; non-TTY prints the `bastra embeddings on` hint).
   ollama: "auto" | "skip" | null;
   // All positional tokens, in order — for sub-commands like
   // `config set update.mode auto` that need more than command+surface.

--- a/packages/daemon/src/cli/update.ts
+++ b/packages/daemon/src/cli/update.ts
@@ -169,9 +169,10 @@ export async function cmdUpdate(args: ParsedArgs): Promise<number> {
     surface: "all",
     yes: args.yes || args.staged,
     // Re-registration is a surface-config refresh — never the place to provision
-    // Ollama (a 600 MB download). Hard-skip on EVERY update path (staged from the
+    // Ollama (a 620 MB download). Hard-skip on EVERY update path (staged from the
     // SessionStart hook, or an interactive `bastra update`); don't lean on the
-    // TTY guard alone for an unattended background re-run.
+    // TTY guard alone for an unattended background re-run. (With a provider
+    // already effective the install step stays silent — no skip noise.)
     ollama: "skip",
   };
   const installRC = await cmdInstall(installArgs);

--- a/packages/daemon/src/embedding-status.ts
+++ b/packages/daemon/src/embedding-status.ts
@@ -25,5 +25,5 @@ export function embeddingStatusLine(s: EmbeddingStatus, prefix = "[bastra-recall
   if (s.on && s.providerId) {
     return `${prefix} semantic recall: ON via ${s.providerId} (source: ${s.source})`;
   }
-  return `${prefix} semantic recall: OFF — BM25 keyword search only. Enable it: bastra install --ollama`;
+  return `${prefix} semantic recall: OFF — BM25 keyword search only. Enable it: bastra embeddings on`;
 }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -37,7 +37,7 @@ import * as path from "node:path";
 import { Telemetry, logDirFor } from "./telemetry.js";
 import { startHttpServer } from "./http.js";
 import { embeddingStatusLine, type EmbeddingStatus, type EmbeddingSource } from "./embedding-status.js";
-import { getEmbeddingProvider, getCommonsEnabled, getSharedRecallEnabled, getSharedRecallLanguage } from "./settings.js";
+import { resolveEmbeddingChoice, getCommonsEnabled, getSharedRecallEnabled, getSharedRecallLanguage } from "./settings.js";
 import { commonsPath, loadVerificationCounts } from "./cli/commons.js";
 import { bridgesPath } from "./cli/bridges.js";
 import { BridgePool } from "./learned-recall/bridges.js";
@@ -642,45 +642,29 @@ interface OllamaInfo {
 }
 
 /**
- * Resolve the embedding provider with explicit precedence:
- *   1. env BASTRA_EMBEDDING_PROVIDER  — wins over the file (none|ollama|openai)
- *   2. cli-settings.json embedding.provider — only when env is unset
- *   3. backwards-compat — OPENAI_API_KEY present, no explicit choice → openai
- *   4. none → BM25 only
- * Returns the provider instance (or null) plus a status used for /health + the
- * single user-facing log line.
+ * Resolve the embedding provider. The PRECEDENCE (env > cli-settings >
+ * API-key > none) lives in ONE shared place — resolveEmbeddingChoice in
+ * settings.ts, also used by bridge.ts and the CLI (#79) — this function only
+ * turns the resolved name into a provider instance + /health status.
  */
 async function resolveEmbedding(): Promise<{
   provider: EmbeddingProvider | null;
   status: EmbeddingStatus;
   ollama?: OllamaInfo;
 }> {
-  const envProvider = (process.env.BASTRA_EMBEDDING_PROVIDER ?? "").toLowerCase();
-  const apiKey = process.env.OPENAI_API_KEY ?? process.env.BASTRA_EMBEDDING_KEY;
-
-  // Tier 1: explicit env wins over the file.
-  if (envProvider === "none") return offEmbedding("env");
-  if (envProvider === "ollama") return ollamaEmbedding("env");
-  if (envProvider === "openai") return apiKey ? openaiEmbedding("env", apiKey) : offEmbedding("env");
-  if (envProvider) {
-    // A typo'd env value must NOT silently disable embeddings and shadow a valid
-    // file choice — warn and fall through (treat as "no opinion"), like the file path.
-    console.error(
-      `[bastra-recall] ignoring invalid BASTRA_EMBEDDING_PROVIDER ${JSON.stringify(process.env.BASTRA_EMBEDDING_PROVIDER)} — falling through to cli-settings / API-key`,
-    );
+  const choice = await resolveEmbeddingChoice({
+    onInvalidEnv: (raw) =>
+      console.error(
+        `[bastra-recall] ignoring invalid BASTRA_EMBEDDING_PROVIDER ${JSON.stringify(raw)} — falling through to cli-settings / API-key`,
+      ),
+  });
+  if (choice.provider === "ollama") return ollamaEmbedding(choice.source);
+  if (choice.provider === "openai") {
+    // provider "openai" implies the resolver saw a key — re-read it for the ctor.
+    const apiKey = process.env.OPENAI_API_KEY ?? process.env.BASTRA_EMBEDDING_KEY;
+    if (apiKey) return openaiEmbedding(choice.source, apiKey);
   }
-
-  // Tier 2: cli-settings.json (env unset or invalid → treat as no opinion).
-  const fileProvider = await getEmbeddingProvider();
-  if (fileProvider === "none") return offEmbedding("cli-settings");
-  if (fileProvider === "ollama") return ollamaEmbedding("cli-settings");
-  if (fileProvider === "openai") return apiKey ? openaiEmbedding("cli-settings", apiKey) : offEmbedding("cli-settings");
-
-  // Tier 3: backwards-compat — key present, no explicit choice anywhere.
-  if (apiKey) return openaiEmbedding("api-key", apiKey);
-
-  // Tier 4: nothing requested.
-  return offEmbedding("none");
+  return offEmbedding(choice.source);
 }
 
 function ollamaEmbedding(source: EmbeddingSource): {

--- a/packages/daemon/src/settings.ts
+++ b/packages/daemon/src/settings.ts
@@ -8,9 +8,10 @@
  * Keys:
  *   - update.mode      : "notify" (default) | "auto" | "off"  (see #39)
  *   - embedding.provider (optional): "ollama" | "openai" | "none"
- *       Written by `bastra install` after the user opts into Ollama, or by
- *       `bastra config set`. Absent = "no opinion" → the daemon falls through to
- *       env / API-key. This is the file half of the #79 fix.
+ *       Written by `bastra embeddings on|off`, by the `bastra install` end
+ *       prompt, or by `bastra config set`. Absent = "no opinion" → the daemon
+ *       falls through to env / API-key. This is the file half of the #79 fix;
+ *       resolveEmbeddingChoice below is the ONE resolution everyone shares.
  *   - ollama.autostart (optional): boolean (default true)
  *       Whether `bastra install` keeps a local `ollama serve` running at login.
  *   - docs.mode (optional): "off" (default) | "suggest" | "auto"
@@ -28,6 +29,7 @@ import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { isSupportedLanguage } from "./learned-recall/language.js";
+import type { EmbeddingSource } from "./embedding-status.js";
 
 export type UpdateMode = "notify" | "auto" | "off";
 export const UPDATE_MODES: readonly UpdateMode[] = ["notify", "auto", "off"];
@@ -206,6 +208,69 @@ export async function setUpdateMode(mode: UpdateMode, path: string = settingsFil
 /** The stored embedding provider, or undefined when unset (no opinion). */
 export async function getEmbeddingProvider(path?: string): Promise<EmbeddingProviderName | undefined> {
   return (await readSettings(path)).embedding?.provider;
+}
+
+/**
+ * The ONE embedding-provider resolution, shared by the OSS daemon (index.ts),
+ * the Pro bridge (bridge.ts) and the CLI (embeddings/doctor/status) so the
+ * precedence can never drift between them (#79):
+ *
+ *   1. env BASTRA_EMBEDDING_PROVIDER — always wins (none | ollama | openai)
+ *   2. cli-settings.json embedding.provider — when env is unset/invalid
+ *   3. backwards-compat — an API key present with no explicit choice → openai
+ *   4. none → BM25 keyword search only
+ *
+ * `provider` is the EFFECTIVE choice (what the daemon will run); `requested`
+ * keeps what env/file asked for when it could not be honoured (today: openai
+ * without an API key → provider "none", requested "openai") so status/doctor
+ * can explain the gap instead of reporting a silent "none".
+ */
+export interface EmbeddingChoice {
+  provider: EmbeddingProviderName;
+  source: EmbeddingSource;
+  requested?: EmbeddingProviderName;
+}
+
+export async function resolveEmbeddingChoice(
+  opts: {
+    path?: string;
+    env?: Record<string, string | undefined>;
+    /** Called with the raw value when BASTRA_EMBEDDING_PROVIDER is set but invalid (typo). */
+    onInvalidEnv?: (raw: string) => void;
+  } = {},
+): Promise<EmbeddingChoice> {
+  const env = opts.env ?? process.env;
+  const envRaw = env.BASTRA_EMBEDDING_PROVIDER ?? "";
+  const envProvider = envRaw.toLowerCase();
+  const hasApiKey = Boolean(env.OPENAI_API_KEY ?? env.BASTRA_EMBEDDING_KEY);
+
+  // Tier 1: explicit env wins over the file.
+  if (envProvider === "none") return { provider: "none", source: "env" };
+  if (envProvider === "ollama") return { provider: "ollama", source: "env" };
+  if (envProvider === "openai") {
+    return hasApiKey
+      ? { provider: "openai", source: "env" }
+      : { provider: "none", source: "env", requested: "openai" };
+  }
+  // A typo'd env value must NOT silently disable embeddings and shadow a valid
+  // file choice — surface it and fall through (treat as "no opinion").
+  if (envProvider) opts.onInvalidEnv?.(envRaw);
+
+  // Tier 2: cli-settings.json (env unset or invalid → no opinion).
+  const fileProvider = await getEmbeddingProvider(opts.path);
+  if (fileProvider === "none") return { provider: "none", source: "cli-settings" };
+  if (fileProvider === "ollama") return { provider: "ollama", source: "cli-settings" };
+  if (fileProvider === "openai") {
+    return hasApiKey
+      ? { provider: "openai", source: "cli-settings" }
+      : { provider: "none", source: "cli-settings", requested: "openai" };
+  }
+
+  // Tier 3: backwards-compat — key present, no explicit choice anywhere.
+  if (hasApiKey) return { provider: "openai", source: "api-key" };
+
+  // Tier 4: nothing requested.
+  return { provider: "none", source: "none" };
 }
 
 /** Persists the embedding provider atomically, merging into existing settings. */


### PR DESCRIPTION
## What

Owner decision (2026-07-02): the embedding layer stays **opt-in with BM25 as default** — but activation becomes discoverable. This changes discoverability only; no default flips.

- **One shared resolver** (`resolveEmbeddingChoice`, settings.ts): env > cli-settings > api-key > none. `requested` explains an unhonorable ask (openai without key) instead of a silent none; a typo'd env value is surfaced and falls through rather than shadowing a valid file setting. index.ts **and** bridge.ts consume it — the bridge now honors cli-settings too (env still wins, per-app spawn env untouched).
- **`bastra embeddings on|off|status`**: `on` persists first, then provisions (Ollama via Homebrew if missing + embeddinggemma, ~620 MB); on provisioning failure the setting survives with an honest re-run hint. `status` shows effective provider + source + model presence.
- **Install prompt** (end of successful `bastra install`, only when effective provider is none): TTY-guarded `[Y/n]`; `--yes`/`--dry-run`/non-TTY never hang — they print the enable one-liner.
- **Doctor**: note on silent BM25-only, warning on configured-but-model-missing, note when env overrides a differing file setting.
- README EN+DE mirrored; docs/architecture.md updated.

## Tests

29 new (resolution order incl. typo-env and requested-tier; command handlers; pure TTY-guard decision fn; doctor strings pinned). Full suite: **398 tests, 397 pass, 0 fail** (1 pre-existing todo). Live-verified read-only: `embeddings status`, doctor note, non-TTY install doesn't hang.

Ready for tonight's clean-VM `npx bastra-recall install all` test — the prompt is exactly what that flow will exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)