### PR TITLE
Guided first-run vault creation in bastra install (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **First-run vault offer (#178)**: on a fresh machine `bastra install` no longer
+  errors with "vault path required" once per surface — when no vault resolves
+  (no `--vault`, no `BASTRA_VAULT_PATH`, nothing to auto-detect) an interactive
+  install asks ONCE, before the per-surface loop: *"No memory vault configured
+  yet. Create one at ~/BastraVault? [Y/n]"*. Yes (default) creates the folder
+  with a short README and installs every surface with it; No keeps the current
+  error text and non-zero exit. Non-TTY and `--yes` keep today's deterministic
+  error (scripts never block on a prompt); `--dry-run` reports the offer as a
+  `~ would prompt to create …` line and writes nothing. The TTY/flag matrix is
+  a pure decision function (`decideFirstRunVaultAction`), unit-tested like the
+  #79 semantic-recall prompt it now leads into.
 - **Survival substrate invariant (#146)**: a memory's id keeps resolving after
   demote (score-only, file byte-identical) and soft-delete (append-only trash +
   audit entry, recoverable via restore) — the one guarantee the pin/floor

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Adapter status:
 | `claude-code` | MCP server in `.claude.json` + Skill in `.claude/skills/` + hooks & powerline statusLine in `.claude/settings.json` | ✅ implemented |
 | `cursor` | MCP server entry in `.cursor/mcp.json` | ✅ implemented (Cursor Rules layer is a separate roadmap item) |
 
-Every write is **idempotent** (re-runs are no-ops), **atomic** (tmp file + rename), **backed up** (timestamped `.bak-…` next to the original), and **parse-safe** (broken JSON aborts the run instead of corrupting it). Vault path resolves in this order: `--vault <path>` flag → `BASTRA_VAULT_PATH` env → auto-detect from an existing registration in `~/.claude.json` or `claude_desktop_config.json`. The CLI bails with a clear message if none of those produce a path.
+Every write is **idempotent** (re-runs are no-ops), **atomic** (tmp file + rename), **backed up** (timestamped `.bak-…` next to the original), and **parse-safe** (broken JSON aborts the run instead of corrupting it). Vault path resolves in this order: `--vault <path>` flag → `BASTRA_VAULT_PATH` env → auto-detect from an existing registration in `~/.claude.json` or `claude_desktop_config.json`. If none of those produce a path (a fresh machine), an interactive `bastra install` offers to create `~/BastraVault` for you; non-interactive runs (piped, `--yes`, `--dry-run`) keep the clear deterministic error.
 
 Once installed through Homebrew or npm, this collapses to `bastra install all`. From the first npm release on:
 
@@ -440,7 +440,7 @@ Adapter-Status:
 | `claude-code` | MCP-Server in `.claude.json` + Skill in `.claude/skills/` + Hooks & Powerline-statusLine in `.claude/settings.json` | ✅ implementiert |
 | `cursor` | MCP-Server-Eintrag in `.cursor/mcp.json` | ✅ implementiert (Cursor-Rules-Layer separater Roadmap-Punkt) |
 
-Jeder Write ist **idempotent** (Re-Runs sind No-Ops), **atomar** (Tmp-File + Rename), **gesichert** (timestamped `.bak-…` neben dem Original) und **parse-safe** (kaputtes JSON bricht den Lauf ab statt es zu zerstören). Vault-Pfad-Auflösung in dieser Reihenfolge: `--vault <pfad>`-Flag → `BASTRA_VAULT_PATH`-ENV → Auto-Detect aus bestehender Registrierung in `~/.claude.json` oder `claude_desktop_config.json`. Wenn nichts greift, bricht die CLI mit klarer Meldung ab.
+Jeder Write ist **idempotent** (Re-Runs sind No-Ops), **atomar** (Tmp-File + Rename), **gesichert** (timestamped `.bak-…` neben dem Original) und **parse-safe** (kaputtes JSON bricht den Lauf ab statt es zu zerstören). Vault-Pfad-Auflösung in dieser Reihenfolge: `--vault <pfad>`-Flag → `BASTRA_VAULT_PATH`-ENV → Auto-Detect aus bestehender Registrierung in `~/.claude.json` oder `claude_desktop_config.json`. Greift nichts davon (frische Maschine), bietet ein interaktives `bastra install` an, `~/BastraVault` anzulegen; nicht-interaktive Läufe (gepiped, `--yes`, `--dry-run`) behalten die klare, deterministische Fehlermeldung.
 
 Sobald über Homebrew oder npm installiert, verkürzt sich das zu `bastra install all`. Ab dem ersten npm-Release:
 

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -42,7 +42,7 @@ For project-level docs (vision, install, REST API, roadmap), see the [top-level 
 See the [top-level README](../../README.md). Three paths, in order of friction:
 
 1. **`Install Bastra.command` doubleclick** — installs Homebrew + tap + binary + runs `bastra install all`.
-2. **`bastra install all`** — single CLI call that registers MCP + Skill + the default quiet Hooks across Claude Code, Claude Desktop, Cursor.
+2. **`bastra install all`** — single CLI call that registers MCP + Skill + the default quiet Hooks across Claude Code, Claude Desktop, Cursor. On a first run with no vault configured, an interactive install offers to create `~/BastraVault` for you (non-interactive/`--yes`/`--dry-run` runs keep the deterministic error).
 3. **Fully manual JSON snippets** — fallback.
 
 All paths end with the daemon reachable on `http://127.0.0.1:6723` and the client configs patched.

--- a/packages/daemon/__tests__/install-vault-firstrun.test.ts
+++ b/packages/daemon/__tests__/install-vault-firstrun.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for the first-run vault step of `bastra install` (#178): the pure
+ * TTY/flag decision matrix, the ~/BastraVault creation helper, and the step's
+ * refusal / failed-creation paths (non-zero exit, today's error text).
+ *
+ * The step is exercised with injected ask/create so no test needs a TTY and
+ * nothing ever touches the real HOME.
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/install-vault-firstrun.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  createVaultAt,
+  decideFirstRunVaultAction,
+  defaultVaultPath,
+  DEFAULT_VAULT_DIRNAME,
+  VAULT_REQUIRED_ERROR,
+} from "../src/cli/helpers.js";
+import { installVaultFirstRunStep, FIRST_RUN_VAULT_QUESTION } from "../src/cli/commands.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-vault-firstrun-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Captures stdout+stderr for the duration of fn. */
+async function withCapture<T>(fn: () => Promise<T>): Promise<{ result: T; out: string; err: string }> {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  let out = "";
+  let err = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    out += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    err += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await fn();
+    return { result, out, err };
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+}
+
+// ─── decision matrix (pure, no TTY needed) ───────────────────────────────────
+
+test("first-run vault: a resolvable vault wins over every flag — never ask", () => {
+  for (const interactive of [true, false]) {
+    for (const yes of [true, false]) {
+      for (const dryRun of [true, false]) {
+        const a = decideFirstRunVaultAction({ vaultConfigured: true, interactive, yes, dryRun });
+        assert.equal(a, "proceed");
+      }
+    }
+  }
+});
+
+test("first-run vault: interactive TTY without flags → ask once", () => {
+  const a = decideFirstRunVaultAction({ vaultConfigured: false, interactive: true, yes: false, dryRun: false });
+  assert.equal(a, "prompt");
+});
+
+test("first-run vault: non-TTY never prompts — today's deterministic error", () => {
+  const a = decideFirstRunVaultAction({ vaultConfigured: false, interactive: false, yes: false, dryRun: false });
+  assert.equal(a, "error");
+});
+
+test("first-run vault: --yes suppresses the prompt — today's deterministic error", () => {
+  const a = decideFirstRunVaultAction({ vaultConfigured: false, interactive: true, yes: true, dryRun: false });
+  assert.equal(a, "error");
+});
+
+test("first-run vault: interactive --dry-run reports the offer, creates nothing", () => {
+  const a = decideFirstRunVaultAction({ vaultConfigured: false, interactive: true, yes: false, dryRun: true });
+  assert.equal(a, "would-create");
+});
+
+test("first-run vault: --yes/non-TTY beat --dry-run (a dry-run reports what the real invocation would do)", () => {
+  assert.equal(
+    decideFirstRunVaultAction({ vaultConfigured: false, interactive: true, yes: true, dryRun: true }),
+    "error",
+  );
+  assert.equal(
+    decideFirstRunVaultAction({ vaultConfigured: false, interactive: false, yes: false, dryRun: true }),
+    "error",
+  );
+});
+
+// ─── vault-creation helper (temp HOME) ───────────────────────────────────────
+
+test("defaultVaultPath: <home>/BastraVault", () => {
+  assert.equal(defaultVaultPath("/tmp/home-x"), resolve("/tmp/home-x", DEFAULT_VAULT_DIRNAME));
+});
+
+test("createVaultAt: creates the folder plus a README that explains what it holds", async () => {
+  await withTempDir(async (home) => {
+    const target = defaultVaultPath(home);
+    const r = await createVaultAt(target);
+    assert.ok(!("error" in r), `expected success, got ${JSON.stringify(r)}`);
+    assert.equal((r as { path: string }).path, target);
+    const readme = await readFile(join(target, "README.md"), "utf8");
+    assert.match(readme, /memory vault/);
+    assert.match(readme, /--vault <path>/);
+  });
+});
+
+test("createVaultAt: idempotent — an existing README is never overwritten", async () => {
+  await withTempDir(async (home) => {
+    const target = defaultVaultPath(home);
+    await createVaultAt(target);
+    await writeFile(join(target, "README.md"), "user-edited\n", "utf8");
+    const r = await createVaultAt(target);
+    assert.ok(!("error" in r));
+    assert.equal(await readFile(join(target, "README.md"), "utf8"), "user-edited\n");
+  });
+});
+
+test("createVaultAt: creation failure returns an error instead of throwing", async () => {
+  await withTempDir(async (home) => {
+    // A FILE occupies the target path → mkdir fails (EEXIST/ENOTDIR).
+    const target = join(home, DEFAULT_VAULT_DIRNAME);
+    await writeFile(target, "in the way\n", "utf8");
+    const r = await createVaultAt(target);
+    assert.ok("error" in r);
+    assert.ok((r as { error: string }).error.length > 0);
+  });
+});
+
+// ─── the step itself (injected ask/create — no TTY, no real HOME) ────────────
+
+test("install step: accepted prompt creates the vault and hands the path to the install opts", async () => {
+  const asked: string[] = [];
+  const { result, out } = await withCapture(() =>
+    installVaultFirstRunStep(
+      { vaultConfigured: false, interactive: true, yes: false, dryRun: false },
+      {
+        ask: async (q) => { asked.push(q); return true; },
+        create: async () => ({ path: "/tmp/home-x/BastraVault" }),
+      },
+    ),
+  );
+  assert.deepEqual(asked, [FIRST_RUN_VAULT_QUESTION]);
+  assert.equal(result.vaultPath, "/tmp/home-x/BastraVault");
+  assert.equal(result.exit, null);
+  assert.match(out, /✓ created \/tmp\/home-x\/BastraVault/);
+});
+
+test("install step: refusal prints today's error text and keeps the non-zero exit", async () => {
+  const { result, err } = await withCapture(() =>
+    installVaultFirstRunStep(
+      { vaultConfigured: false, interactive: true, yes: false, dryRun: false },
+      { ask: async () => false, create: async () => { throw new Error("must not create on refusal"); } },
+    ),
+  );
+  assert.equal(result.vaultPath, null);
+  assert.equal(result.exit, 1);
+  assert.ok(err.includes(`error: ${VAULT_REQUIRED_ERROR}`));
+});
+
+test("install step: failed creation falls back to today's error, non-zero exit", async () => {
+  const { result, err } = await withCapture(() =>
+    installVaultFirstRunStep(
+      { vaultConfigured: false, interactive: true, yes: false, dryRun: false },
+      { ask: async () => true, create: async () => ({ error: "EACCES: permission denied" }) },
+    ),
+  );
+  assert.equal(result.vaultPath, null);
+  assert.equal(result.exit, 1);
+  assert.match(err, /could not create ~\/BastraVault: EACCES/);
+  assert.ok(err.includes(`error: ${VAULT_REQUIRED_ERROR}`));
+});
+
+test("install step: dry-run prints the would-line and never asks or creates", async () => {
+  const { result, out } = await withCapture(() =>
+    installVaultFirstRunStep(
+      { vaultConfigured: false, interactive: true, yes: false, dryRun: true },
+      {
+        ask: async () => { throw new Error("must not ask under --dry-run"); },
+        create: async () => { throw new Error("must not create under --dry-run"); },
+      },
+    ),
+  );
+  assert.equal(result.vaultPath, null);
+  assert.equal(result.exit, null);
+  assert.match(out, /~ would prompt to create ~\/BastraVault \(dry-run\): no vault configured yet/);
+});
+
+test("install step: non-TTY/--yes fall through silently (per-surface error unchanged)", async () => {
+  for (const i of [
+    { vaultConfigured: false, interactive: false, yes: false, dryRun: false },
+    { vaultConfigured: false, interactive: true, yes: true, dryRun: false },
+  ]) {
+    const { result, out, err } = await withCapture(() =>
+      installVaultFirstRunStep(i, {
+        ask: async () => { throw new Error("must not ask"); },
+        create: async () => { throw new Error("must not create"); },
+      }),
+    );
+    assert.equal(result.vaultPath, null);
+    assert.equal(result.exit, null);
+    assert.equal(out, "");
+    assert.equal(err, "");
+  }
+});
+
+test("install step: exact prompt wording (first-run onboarding, #178)", () => {
+  assert.equal(FIRST_RUN_VAULT_QUESTION, "No memory vault configured yet. Create one at ~/BastraVault?");
+});

--- a/packages/daemon/src/cli/commands.ts
+++ b/packages/daemon/src/cli/commands.ts
@@ -1,6 +1,16 @@
 import { ADAPTERS, resolveTargets } from "./registry.js";
-import { VERSION, formatStatus } from "./helpers.js";
+import {
+  VERSION,
+  formatStatus,
+  resolveVault,
+  decideFirstRunVaultAction,
+  defaultVaultPath,
+  createVaultAt,
+  DEFAULT_VAULT_DISPLAY,
+  VAULT_REQUIRED_ERROR,
+} from "./helpers.js";
 import { installSemanticRecallStep, printEmbeddingDoctorNote } from "./embeddings-cmd.js";
+import { confirm, isInteractive } from "./prompt.js";
 import { getEmbeddingProvider } from "../settings.js";
 import type { InstallOpts, ParsedArgs } from "./types.js";
 
@@ -129,6 +139,50 @@ function resolveVaultPath(cliVault: string | null): string | null {
   return cliVault ?? process.env.BASTRA_VAULT_PATH ?? null;
 }
 
+export const FIRST_RUN_VAULT_QUESTION =
+  `No memory vault configured yet. Create one at ${DEFAULT_VAULT_DISPLAY}?`;
+
+/**
+ * First-run vault step (#178): on a fresh machine there is nothing to
+ * auto-detect, so without this the headline onboarding command errors once
+ * per surface. Runs ONCE before the per-surface loop. Returns the created
+ * vault path (the caller feeds it through opts.vaultPath — the same route a
+ * --vault value takes), or an exit code when install must stop (refusal or
+ * failed creation → the unchanged non-zero error semantics). `io` is
+ * injectable for tests only (there is no TTY on CI).
+ */
+export async function installVaultFirstRunStep(
+  i: { vaultConfigured: boolean; interactive: boolean; yes: boolean; dryRun: boolean },
+  io: {
+    ask?: (question: string, opts: { defaultYes?: boolean }) => Promise<boolean>;
+    create?: (path: string) => Promise<{ path: string } | { error: string }>;
+  } = {},
+): Promise<{ vaultPath: string | null; exit: number | null }> {
+  const action = decideFirstRunVaultAction(i);
+  // "error" = non-TTY/--yes without a vault: do nothing here — the per-surface
+  // loop reports today's deterministic error, so scripts see exactly what they
+  // saw before.
+  if (action === "proceed" || action === "error") return { vaultPath: null, exit: null };
+  if (action === "would-create") {
+    process.stdout.write(`~ would prompt to create ${DEFAULT_VAULT_DISPLAY} (dry-run): no vault configured yet\n\n`);
+    return { vaultPath: null, exit: null };
+  }
+  // action === "prompt" — ask once, default Yes.
+  const accepted = await (io.ask ?? confirm)(FIRST_RUN_VAULT_QUESTION, { defaultYes: true });
+  if (!accepted) {
+    process.stderr.write(`error: ${VAULT_REQUIRED_ERROR}\n`);
+    return { vaultPath: null, exit: 1 };
+  }
+  const created = await (io.create ?? createVaultAt)(defaultVaultPath());
+  if ("error" in created) {
+    process.stderr.write(`✗ could not create ${DEFAULT_VAULT_DISPLAY}: ${created.error}\n`);
+    process.stderr.write(`error: ${VAULT_REQUIRED_ERROR}\n`);
+    return { vaultPath: null, exit: 1 };
+  }
+  process.stdout.write(`✓ created ${created.path} — your memories live here as plain markdown files\n\n`);
+  return { vaultPath: created.path, exit: null };
+}
+
 export async function cmdInstall(args: ParsedArgs): Promise<number> {
   const targets = resolveTargets(args.surface);
   if ("error" in targets) {
@@ -143,6 +197,18 @@ export async function cmdInstall(args: ParsedArgs): Promise<number> {
     force: args.yes,
     withStopHook: args.withStopHook,
   };
+
+  // First-run vault guard (#178) — before the loop, so the offer never
+  // repeats per surface.
+  const preResolve = await resolveVault(opts);
+  const firstRun = await installVaultFirstRunStep({
+    vaultConfigured: !("error" in preResolve),
+    interactive: isInteractive(),
+    yes: args.yes,
+    dryRun: args.dryRun,
+  });
+  if (firstRun.exit !== null) return firstRun.exit;
+  if (firstRun.vaultPath) opts.vaultPath = firstRun.vaultPath;
 
   let hadError = false;
   for (const adapter of targets) {

--- a/packages/daemon/src/cli/helpers.ts
+++ b/packages/daemon/src/cli/helpers.ts
@@ -1,5 +1,6 @@
 import { copyFile, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
 import { request as httpRequest } from "node:http";
 import { FORWARDER_SCRIPT_PATH, CLAUDE_DESKTOP_CONFIG, CLAUDE_CODE_CONFIG } from "./paths.js";
 import type { InstallOpts } from "./types.js";
@@ -87,15 +88,80 @@ async function detectExistingVault(): Promise<string | null> {
   return null;
 }
 
+export const VAULT_REQUIRED_ERROR =
+  "vault path required — pass --vault <path>, set BASTRA_VAULT_PATH, or install for another surface first (vault is auto-detected from existing registrations)";
+
 export async function resolveVault(opts: InstallOpts): Promise<{ path: string } | { error: string }> {
   if (opts.vaultPath) return { path: opts.vaultPath };
   const env = process.env.BASTRA_VAULT_PATH;
   if (env && env.length > 0) return { path: env };
   const detected = await detectExistingVault();
   if (detected) return { path: detected };
-  return {
-    error: "vault path required — pass --vault <path>, set BASTRA_VAULT_PATH, or install for another surface first (vault is auto-detected from existing registrations)",
-  };
+  return { error: VAULT_REQUIRED_ERROR };
+}
+
+// ─── first-run vault (#178) ──────────────────────────────────────────────────
+
+/** Default vault offered on first run. Keep DISPLAY and defaultVaultPath in sync. */
+export const DEFAULT_VAULT_DIRNAME = "BastraVault";
+export const DEFAULT_VAULT_DISPLAY = "~/BastraVault";
+
+export function defaultVaultPath(home: string = homedir()): string {
+  return resolve(home, DEFAULT_VAULT_DIRNAME);
+}
+
+const VAULT_README = `# Bastra Vault
+
+This folder is your bastra-recall memory vault. Every memory Claude saves —
+lessons, preferences, decisions, project facts — lives here as a plain
+markdown file you can read, edit, and back up like any other note.
+
+Created by \`bastra install\`. To use a different folder, re-run:
+\`bastra install all --vault <path>\`
+`;
+
+/**
+ * Creates the vault folder (mkdir -p) plus a short README explaining what it
+ * holds. Idempotent: an existing folder is fine and an existing README is
+ * never overwritten. Returns the same shape as resolveVault so the caller
+ * feeds the created path through the exact route a --vault value takes.
+ */
+export async function createVaultAt(path: string): Promise<{ path: string } | { error: string }> {
+  try {
+    await mkdir(path, { recursive: true });
+    try {
+      await writeFile(join(path, "README.md"), VAULT_README, { flag: "wx" });
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    }
+    return { path };
+  } catch (e) {
+    return { error: (e as Error).message };
+  }
+}
+
+export type FirstRunVaultAction = "proceed" | "prompt" | "would-create" | "error";
+
+/**
+ * Pure decision for the first-run vault step (#178) — exported so the
+ * TTY/flag matrix is unit-testable without a terminal:
+ *   vault resolves (flag / env / auto-detect) → proceed, never ask
+ *   non-TTY or --yes → error: keep today's deterministic per-surface error
+ *     (scripts must never block on a prompt). Checked BEFORE dry-run so a
+ *     dry-run reports what the same invocation would really do.
+ *   --dry-run (interactive) → would-create: report the offer, write nothing
+ *   otherwise → ask once, before the per-surface loop
+ */
+export function decideFirstRunVaultAction(i: {
+  vaultConfigured: boolean;
+  interactive: boolean;
+  yes: boolean;
+  dryRun: boolean;
+}): FirstRunVaultAction {
+  if (i.vaultConfigured) return "proceed";
+  if (!i.interactive || i.yes) return "error";
+  if (i.dryRun) return "would-create";
+  return "prompt";
 }
 
 export interface DaemonProbe {


### PR DESCRIPTION
## What

Closes #178 — the first finding from the #90 clean-VM run: on a fresh machine `npx bastra-recall@latest install all` hit a wall ('vault path required' for every surface) because there is nothing to auto-detect on a true first run.

- **One guided question, before the surface loop** (so it never repeats 3×): `No memory vault configured yet. Create one at ~/BastraVault? [Y/n]` — Enter/Y creates the folder (`mkdir -p` + a short README via `wx`, never clobbering an existing one) and routes it through the exact `--vault` code path; **n** keeps today's error text and exit 1.
- **Non-TTY / `--yes`**: exactly today's deterministic error — scripts never guess (pinned by the C3 VM run, which passed on this semantics). `--dry-run` reports a `would prompt to create` line.
- Pure decision function `decideFirstRunVaultAction` mirroring the #79 prompt's testable style; `ask`/`create` injectable for tests only.
- README EN+DE mirrored; CHANGELOG Unreleased entry.

## Verification

16 new tests (decision matrix, vault creation incl. idempotency + failure path, accept/refuse/creation-fail/dry-run at the step level, exact prompt wording). Full suite **431 tests, 430 pass, 0 fail** (1 pre-existing todo). Live pty check: prompt → vault + README created → surfaces registered → #79 semantic-recall step follows — reads as one coherent onboarding sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)