### PR TITLE
Trust the tap in Install Bastra.command — new brew security gate (#182)

### DIFF
--- a/distribution/Install Bastra.command
+++ b/distribution/Install Bastra.command
@@ -38,6 +38,11 @@ if ! brew tap | grep -q "^n0mad-ai/tap$"; then
   brew tap n0mad-ai/tap
 fi
 
+# 2b. Trust the tap (#182): current Homebrew refuses formulas from untrusted
+# third-party taps. </dev/null keeps a hypothetical confirmation prompt from
+# hanging the script; || true keeps older brews (no `trust` command) working.
+brew trust n0mad-ai/tap </dev/null 2>/dev/null || true
+
 # 3. Install / upgrade
 if brew list bastra-recall >/dev/null 2>&1; then
   echo "→ bastra-recall already installed — checking for updates…"


### PR DESCRIPTION
Part 1 of #182 (found in the #90 clean-VM run): current Homebrew refuses formulas from untrusted third-party taps, so the double-click installer died right after tapping. It now runs `brew trust n0mad-ai/tap` after the tap step — `</dev/null` so a hypothetical confirmation can never hang the non-interactive script, `|| true` for older brews that don't have the command (the subsequent `brew install` still surfaces the real error there).

Part 2 (tap repo README + formula header) goes directly to the tap repo. The fixed `.command` gets re-attached to the beta.3/beta.4 releases after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)