### PR TITLE
feat(cli): guided install wizard — selection lists for vault, clients, semantic recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Three paths, in order of friction. bastra-recall is self-contained: the daemon, 
 2. Double-click it in Finder.
 3. Done. Restart Claude Code / Claude Desktop / Cursor.
 
-The script installs Homebrew if it's missing, adds the bastra tap, installs `bastra-recall`, and runs `bastra install all` — no terminal knowledge required.
+The script installs Homebrew if it's missing, adds the bastra tap, installs `bastra-recall`, and hands over to the guided setup (`bastra install`): selection lists for the memory vault, your AI clients, and semantic recall — no terminal knowledge required.
 
 #### B) One command — for developers
 
@@ -154,13 +154,14 @@ Adapter status:
 
 Every write is **idempotent** (re-runs are no-ops), **atomic** (tmp file + rename), **backed up** (timestamped `.bak-…` next to the original), and **parse-safe** (broken JSON aborts the run instead of corrupting it). Vault path resolves in this order: `--vault <path>` flag → `BASTRA_VAULT_PATH` env → auto-detect from an existing registration in `~/.claude.json` or `claude_desktop_config.json`. If none of those produce a path (a fresh machine), an interactive `bastra install` offers to create `~/BastraVault` for you; non-interactive runs (piped, `--yes`, `--dry-run`) keep the clear deterministic error.
 
-Once installed through Homebrew or npm, this collapses to `bastra install all`. From the first npm release on:
+Once installed through Homebrew or npm, this collapses to a single command. From the first npm release on:
 
 ```bash
-npx bastra-recall install all       # zero-install, one-off
+npx bastra-recall install           # zero-install: guided setup with selection lists
+npx bastra-recall install all       # direct: all clients (script-friendly, add --yes for CI)
 # or install the CLI globally:
 npm install -g bastra-recall
-bastra install all
+bastra install
 ```
 
 #### C) Fully manual — fallback
@@ -412,7 +413,7 @@ Drei Wege, nach Aufwand sortiert. bastra-recall ist eigenständig: Daemon, MCP-S
 2. Doppelklick im Finder.
 3. Fertig. Claude Code / Claude Desktop / Cursor neu starten.
 
-Das Skript installiert bei Bedarf Homebrew, fügt den bastra-Tap hinzu, installiert `bastra-recall` und führt `bastra install all` aus — kein Terminal-Wissen nötig.
+Das Skript installiert bei Bedarf Homebrew, fügt den bastra-Tap hinzu, installiert `bastra-recall` und startet das geführte Setup (`bastra install`): Auswahllisten für Memory-Vault, AI-Clients und Semantic Recall — kein Terminal-Wissen nötig.
 
 > **Status:** Tap `n0mad-ai/tap` ist live; das `.command`-Asset hängt an jedem GitHub-Release.
 
@@ -442,13 +443,14 @@ Adapter-Status:
 
 Jeder Write ist **idempotent** (Re-Runs sind No-Ops), **atomar** (Tmp-File + Rename), **gesichert** (timestamped `.bak-…` neben dem Original) und **parse-safe** (kaputtes JSON bricht den Lauf ab statt es zu zerstören). Vault-Pfad-Auflösung in dieser Reihenfolge: `--vault <pfad>`-Flag → `BASTRA_VAULT_PATH`-ENV → Auto-Detect aus bestehender Registrierung in `~/.claude.json` oder `claude_desktop_config.json`. Greift nichts davon (frische Maschine), bietet ein interaktives `bastra install` an, `~/BastraVault` anzulegen; nicht-interaktive Läufe (gepiped, `--yes`, `--dry-run`) behalten die klare, deterministische Fehlermeldung.
 
-Sobald über Homebrew oder npm installiert, verkürzt sich das zu `bastra install all`. Ab dem ersten npm-Release:
+Sobald über Homebrew oder npm installiert, verkürzt sich das zu einem einzigen Befehl. Ab dem ersten npm-Release:
 
 ```bash
-npx bastra-recall install all       # ohne Installation, einmalig
+npx bastra-recall install           # ohne Installation: geführtes Setup mit Auswahllisten
+npx bastra-recall install all       # direkt: alle Clients (skript-tauglich, --yes für CI)
 # oder die CLI global installieren:
 npm install -g bastra-recall
-bastra install all
+bastra install
 ```
 
 #### C) Komplett manuell — Fallback

--- a/distribution/Install Bastra.command
+++ b/distribution/Install Bastra.command
@@ -2,15 +2,18 @@
 # Install Bastra.command — double-click in Finder to set up bastra-recall.
 #
 # Idempotent: safe to run multiple times. Installs Homebrew if missing,
-# adds the bastra tap, installs bastra-recall, and registers it with
-# every supported AI client (Claude Code, Claude Desktop, Cursor).
+# adds the bastra tap, installs bastra-recall, then hands over to the
+# guided setup (`bastra install`): selection lists for the memory vault,
+# your AI clients, and semantic recall — no flags, no typing paths.
 #
 # After this script finishes, restart the AI client(s) you use — the
 # memory tool will be live.
 
 set -euo pipefail
 
-# Make double-click logs readable even when launched from Finder
+# Make double-click logs readable even when launched from Finder.
+# NOTE: this makes stdout a pipe, not a TTY — the guided setup below
+# explicitly redirects to /dev/tty so its selection lists still render.
 mkdir -p "$HOME/Library/Logs"
 exec > >(tee -a "$HOME/Library/Logs/bastra-install.log") 2>&1
 echo
@@ -20,9 +23,9 @@ echo "  log: ~/Library/Logs/bastra-install.log"
 echo "════════════════════════════════════════════════════════════"
 echo
 
-# 1. Homebrew
+# 1/4 Homebrew
 if ! command -v brew >/dev/null 2>&1; then
-  echo "→ Installing Homebrew (one-time, may ask for your password)…"
+  echo "→ [1/4] Installing Homebrew (one-time, may ask for your password)…"
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   # Make brew available in this script's environment
   if [ -x /opt/homebrew/bin/brew ]; then
@@ -30,22 +33,26 @@ if ! command -v brew >/dev/null 2>&1; then
   elif [ -x /usr/local/bin/brew ]; then
     eval "$(/usr/local/bin/brew shellenv)"
   fi
+else
+  echo "→ [1/4] Homebrew present."
 fi
 
-# 2. Tap
+# 2/4 Tap
 if ! brew tap | grep -q "^n0mad-ai/tap$"; then
-  echo "→ Adding bastra tap…"
+  echo "→ [2/4] Adding bastra tap…"
   brew tap n0mad-ai/tap
+else
+  echo "→ [2/4] bastra tap present."
 fi
 
-# 2b. Trust the tap (#182): current Homebrew refuses formulas from untrusted
+# Trust the tap (#182): current Homebrew refuses formulas from untrusted
 # third-party taps. </dev/null keeps a hypothetical confirmation prompt from
 # hanging the script; || true keeps older brews (no `trust` command) working.
 brew trust n0mad-ai/tap </dev/null 2>/dev/null || true
 
-# 3. Install / upgrade
+# 3/4 Install / upgrade
 if brew list bastra-recall >/dev/null 2>&1; then
-  echo "→ bastra-recall already installed — checking for updates…"
+  echo "→ [3/4] bastra-recall already installed — checking for updates…"
   # Non-fatal under `set -e`: a transient upgrade failure (network/tap) must not
   # abort before the friendly error block below — registration can still proceed
   # on the already-installed version.
@@ -55,17 +62,34 @@ if brew list bastra-recall >/dev/null 2>&1; then
     echo "  ⚠ upgrade failed (rc=$upgrade_rc) — continuing with the installed version."
   fi
 else
-  echo "→ Installing bastra-recall…"
+  echo "→ [3/4] Installing bastra-recall…"
   brew install n0mad-ai/tap/bastra-recall
 fi
 
-# 4. Register with every supported AI client
+# 4/4 Guided setup — selection lists need the real terminal: stdout is the
+# log pipe here, and the wizard deliberately refuses to run on a non-TTY.
+# Its output goes to the terminal only (not the log); the doctor block below
+# records the resulting state in the log.
 echo
-echo "→ Registering bastra-recall with Claude Code, Claude Desktop, Cursor…"
 install_rc=0
-bastra install all || install_rc=$?
+if [ -t 0 ] && [ -e /dev/tty ]; then
+  echo "→ [4/4] Starting guided setup (pick vault, AI clients, semantic recall)…"
+  bastra install </dev/tty >/dev/tty 2>&1 || install_rc=$?
+  # rc=2 = "missing surface": the installed bastra predates the guided setup
+  # (e.g. `brew upgrade` failed above and we continued on the old version).
+  # Fall back to the classic full registration so nothing is silently skipped.
+  if [ "$install_rc" -eq 2 ]; then
+    echo "  installed bastra has no guided setup yet — registering all AI clients directly…"
+    install_rc=0
+    bastra install all </dev/tty >/dev/tty 2>&1 || install_rc=$?
+  fi
+  echo "  guided setup finished (rc=${install_rc}; interactive output shown in the terminal, not logged)"
+else
+  echo "→ [4/4] No terminal available — registering with all AI clients non-interactively…"
+  bastra install all || install_rc=$?
+fi
 
-# 5. Show status
+# Final status (logged)
 echo
 echo "→ Final status:"
 doctor_rc=0
@@ -74,11 +98,11 @@ bastra doctor || doctor_rc=$?
 if [ "$install_rc" -ne 0 ] || [ "$doctor_rc" -ne 0 ]; then
   echo
   echo "════════════════════════════════════════════════════════════"
-  echo "  Install finished with errors."
+  echo "  Install finished with errors (or the setup was cancelled)."
   echo
   echo "  Log: ~/Library/Logs/bastra-install.log"
-  echo "  Run this after fixing the issue:"
-  echo "    bastra install all"
+  echo "  Run this to try again:"
+  echo "    bastra install"
   echo "    bastra doctor"
   echo "════════════════════════════════════════════════════════════"
   echo
@@ -91,8 +115,8 @@ echo
 echo "════════════════════════════════════════════════════════════"
 echo "  ✓ Done."
 echo
-echo "  Restart Claude Code / Claude Desktop / Cursor"
-echo "  to pick up the new memory tool."
+echo "  Restart the AI clients you selected (Claude Code /"
+echo "  Claude Desktop / Cursor) to pick up the memory tool."
 echo "════════════════════════════════════════════════════════════"
 echo
 echo "(This window will stay open. Press any key to close.)"

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,34 @@
       "resolved": "packages/statusline",
       "link": true
     },
+    "node_modules/@clack/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+      "integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.2",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -1590,6 +1618,21 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -1605,6 +1648,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2517,6 +2569,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2876,6 +2934,7 @@
       "dependencies": {
         "@bastra-recall/core": "0.7.0-beta.4",
         "@bastra-recall/statusline": "0.7.0-beta.4",
+        "@clack/prompts": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "zod": "^4.4.3"
       },

--- a/packages/bastra-recall/README.md
+++ b/packages/bastra-recall/README.md
@@ -5,17 +5,18 @@ Persistent **recall memory** for AI coding agents — Claude Code, Claude Deskto
 ## Install
 
 ```bash
-# zero-install, one-off:
-npx bastra-recall install all
+# zero-install, one-off — guided setup with selection lists:
+npx bastra-recall install
 
 # or install the CLI globally:
 npm install -g bastra-recall
-bastra install all
+bastra install
 ```
 
 Both expose the `bastra` CLI. After installing, restart your AI client.
 
-- `bastra install all` — register the MCP server, Skill, and hooks across Claude Code, Claude Desktop, and Cursor.
+- `bastra install` — guided setup (interactive): pick vault, AI clients, semantic recall.
+- `bastra install all` — register the MCP server, Skill, and hooks across Claude Code, Claude Desktop, and Cursor (script-friendly).
 - `bastra doctor` — check / repair registrations.
 - `bastra uninstall all` — remove everything again.
 

--- a/packages/daemon/__tests__/wizard.test.ts
+++ b/packages/daemon/__tests__/wizard.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the guided-install wizard's pure parts: the gate that decides
+ * wizard vs. classic path, the surface-choice builder (detection →
+ * preselection), and the custom-vault path expansion. The interactive clack
+ * flow itself is exercised by the expect-based smoke, not here (no TTY on CI).
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/wizard.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  shouldRunWizard,
+  buildSurfaceChoices,
+  detectSurfaces,
+  expandUserPath,
+  decideWizardSemantic,
+} from "../src/cli/wizard.js";
+import { cmdInstall } from "../src/cli/commands.js";
+import type { ParsedArgs } from "../src/cli/types.js";
+
+// ─── gate ────────────────────────────────────────────────────────────────────
+
+test("wizard gate: bare install on a TTY → wizard", () => {
+  assert.equal(shouldRunWizard({ surface: null, interactive: true, yes: false, dryRun: false }), true);
+});
+
+test("wizard gate: every scripted invocation stays on the classic path", () => {
+  // named surface / all
+  assert.equal(shouldRunWizard({ surface: "all", interactive: true, yes: false, dryRun: false }), false);
+  assert.equal(shouldRunWizard({ surface: "claude-code", interactive: true, yes: false, dryRun: false }), false);
+  // non-TTY (CI, pipes, hooks) — must keep the deterministic "missing surface" error
+  assert.equal(shouldRunWizard({ surface: null, interactive: false, yes: false, dryRun: false }), false);
+  // automation flags
+  assert.equal(shouldRunWizard({ surface: null, interactive: true, yes: true, dryRun: false }), false);
+  assert.equal(shouldRunWizard({ surface: null, interactive: true, yes: false, dryRun: true }), false);
+});
+
+// ─── surface choices ─────────────────────────────────────────────────────────
+
+test("surface choices: detected clients are preselected and hinted", () => {
+  const { options, initialValues } = buildSurfaceChoices({
+    "claude-code": true,
+    "claude-desktop": false,
+    cursor: true,
+  });
+  assert.deepEqual(options.map((o) => o.value), ["claude-desktop", "claude-code", "cursor"]);
+  assert.deepEqual(new Set(initialValues), new Set(["claude-code", "cursor"]));
+  assert.equal(options.find((o) => o.value === "claude-code")?.hint, "detected");
+  assert.equal(options.find((o) => o.value === "claude-desktop")?.hint, "not detected");
+});
+
+test("surface choices: nothing detected → everything preselected (plain Enter = full install)", () => {
+  const { options, initialValues } = buildSurfaceChoices({});
+  assert.deepEqual(initialValues, options.map((o) => o.value));
+});
+
+test("surface choices: labels drop the parenthetical detail", () => {
+  const { options } = buildSurfaceChoices({});
+  for (const o of options) assert.ok(!o.label.includes("("), `label still has parens: ${o.label}`);
+});
+
+// ─── detection ───────────────────────────────────────────────────────────────
+
+test("detectSurfaces: home-relative traces are found in the given home", async () => {
+  // Only home-relative traces are assertable: absolute ones (/Applications/…)
+  // depend on the machine running the tests.
+  const home = await mkdtemp(join(tmpdir(), "bastra-wizard-home-"));
+  try {
+    assert.equal(detectSurfaces(home)["claude-code"], false);
+    await writeFile(join(home, ".claude.json"), "{}", "utf8");
+    assert.equal(detectSurfaces(home)["claude-code"], true);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+// ─── semantic step decision ──────────────────────────────────────────────────
+
+test("wizard semantic: --ollama = consent, never asks (flag beats everything)", () => {
+  assert.equal(decideWizardSemantic({ ollamaFlag: "auto", effectiveProvider: "none", daemonSemanticOn: false }), "on");
+  assert.equal(decideWizardSemantic({ ollamaFlag: "auto", effectiveProvider: "ollama", daemonSemanticOn: false }), "on");
+});
+
+test("wizard semantic: effective provider or semantic daemon → nothing to ask", () => {
+  assert.equal(decideWizardSemantic({ ollamaFlag: null, effectiveProvider: "ollama", daemonSemanticOn: false }), "already");
+  assert.equal(decideWizardSemantic({ ollamaFlag: null, effectiveProvider: "none", daemonSemanticOn: true }), "already");
+  // --no-ollama with an effective provider: skips provisioning, disables nothing
+  assert.equal(decideWizardSemantic({ ollamaFlag: "skip", effectiveProvider: "openai", daemonSemanticOn: false }), "already");
+});
+
+test("wizard semantic: --no-ollama = opt-out, never asks (review find 2026-07-03)", () => {
+  assert.equal(decideWizardSemantic({ ollamaFlag: "skip", effectiveProvider: "none", daemonSemanticOn: false }), "later");
+});
+
+test("wizard semantic: no flag, nothing effective → ask", () => {
+  assert.equal(decideWizardSemantic({ ollamaFlag: null, effectiveProvider: "none", daemonSemanticOn: false }), "ask");
+});
+
+// ─── install --help gate ─────────────────────────────────────────────────────
+
+test("install --help documents instead of acting (wizard or missing-surface error)", async () => {
+  const args: ParsedArgs = {
+    command: "install", surface: null, dryRun: false, vaultPath: null,
+    showHelp: true, showVersion: false, json: false, quiet: false, yes: false,
+    fix: false, withStopHook: false, staged: false, ollama: null, positional: ["install"],
+  };
+  const origWrite = process.stdout.write.bind(process.stdout);
+  let out = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    out += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const rc = await cmdInstall(args);
+    assert.equal(rc, 0);
+    assert.match(out, /Usage:/);
+  } finally {
+    process.stdout.write = origWrite;
+  }
+});
+
+// ─── path expansion ──────────────────────────────────────────────────────────
+
+test("expandUserPath: tilde, relative, and absolute inputs", () => {
+  assert.equal(expandUserPath("~", "/Users/x"), "/Users/x");
+  assert.equal(expandUserPath("~/Vault", "/Users/x"), "/Users/x/Vault");
+  assert.equal(expandUserPath("  ~/Vault  ", "/Users/x"), "/Users/x/Vault");
+  assert.equal(expandUserPath("/abs/path", "/Users/x"), "/abs/path");
+  assert.equal(expandUserPath("rel/path", "/Users/x"), resolve("rel/path"));
+});

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@bastra-recall/core": "0.7.0-beta.4",
     "@bastra-recall/statusline": "0.7.0-beta.4",
+    "@clack/prompts": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "zod": "^4.4.3"
   },

--- a/packages/daemon/src/cli/commands.ts
+++ b/packages/daemon/src/cli/commands.ts
@@ -10,6 +10,7 @@ import {
   VAULT_REQUIRED_ERROR,
 } from "./helpers.js";
 import { installSemanticRecallStep, printEmbeddingDoctorNote } from "./embeddings-cmd.js";
+import { runInstallWizard, shouldRunWizard } from "./wizard.js";
 import { confirm, isInteractive } from "./prompt.js";
 import { getEmbeddingProvider } from "../settings.js";
 import type { InstallOpts, ParsedArgs } from "./types.js";
@@ -23,6 +24,8 @@ Usage:
   bastra <command> [surface] [options]
 
 Commands:
+  install                    Guided setup (interactive): pick vault, clients,
+                             semantic recall from selection lists
   install <surface|all>      Register bastra-recall with the AI client
   uninstall <surface|all>    Remove the registration (skill is kept; it's shared)
   update                     brew upgrade (if brew-installed) + re-register +
@@ -184,6 +187,21 @@ export async function installVaultFirstRunStep(
 }
 
 export async function cmdInstall(args: ParsedArgs): Promise<number> {
+  // `bastra install --help` must document, never act — without this it would
+  // fall through to the wizard (TTY) or the missing-surface error (script).
+  if (args.showHelp) {
+    showHelp();
+    return 0;
+  }
+
+  // Bare `bastra install` on a terminal → guided setup (selection lists for
+  // vault, clients, semantic recall). Scripted invocations (a named surface,
+  // --yes, --dry-run, non-TTY) never enter the wizard and keep the exact
+  // pre-wizard behavior below.
+  if (shouldRunWizard({ surface: args.surface, interactive: isInteractive(), yes: args.yes, dryRun: args.dryRun })) {
+    return runInstallWizard(args);
+  }
+
   const targets = resolveTargets(args.surface);
   if ("error" in targets) {
     process.stderr.write(`error: ${targets.error}\n`);

--- a/packages/daemon/src/cli/wizard.ts
+++ b/packages/daemon/src/cli/wizard.ts
@@ -1,0 +1,291 @@
+/**
+ * `bastra install` (no surface, on a terminal) — the guided setup wizard.
+ *
+ * Selection lists instead of y/n text prompts: vault location (create the
+ * default or pick a folder), AI clients (multiselect, detected ones
+ * preselected), semantic recall (enable / keyword-only). Built on
+ * @clack/prompts; every prompt is cancellable (Ctrl-C → clean exit, nothing
+ * written).
+ *
+ * The wizard is a front-end only: it collects choices, then drives the exact
+ * same machinery as `bastra install all` (createVaultAt, adapter.install,
+ * enableSemanticRecall) — no second install path. Scripted flows
+ * (`install all`, `--yes`, non-TTY, `--dry-run`) never reach it; see
+ * shouldRunWizard.
+ */
+import * as p from "@clack/prompts";
+import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { ADAPTERS } from "./registry.js";
+import {
+  VERSION,
+  resolveVault,
+  defaultVaultPath,
+  createVaultAt,
+  DEFAULT_VAULT_DISPLAY,
+  probeDaemon,
+} from "./helpers.js";
+import { RECALL_OFF_NOTE } from "./embeddings-cmd.js";
+import { enableSemanticRecall } from "./ollama.js";
+import { resolveEmbeddingChoice } from "../settings.js";
+import type { InstallResult, ParsedArgs } from "./types.js";
+
+/**
+ * Pure gate — exported for tests. The wizard replaces the bare-`install`
+ * "missing surface" error ONLY on an interactive terminal without automation
+ * flags; every scripted invocation keeps today's deterministic behavior.
+ */
+export function shouldRunWizard(i: {
+  surface: string | null;
+  interactive: boolean;
+  yes: boolean;
+  dryRun: boolean;
+}): boolean {
+  return i.surface === null && i.interactive && !i.yes && !i.dryRun;
+}
+
+/** Filesystem traces that mean "this client exists on this machine". */
+const SURFACE_TRACES: Record<string, string[]> = {
+  "claude-code": [".claude.json", ".claude"],
+  "claude-desktop": [
+    "Library/Application Support/Claude",
+    "/Applications/Claude.app",
+  ],
+  cursor: [".cursor", "/Applications/Cursor.app"],
+};
+
+export function detectSurfaces(home: string = homedir()): Record<string, boolean> {
+  const present: Record<string, boolean> = {};
+  for (const [surface, traces] of Object.entries(SURFACE_TRACES)) {
+    present[surface] = traces.some((t) =>
+      existsSync(isAbsolute(t) ? t : resolve(home, t)),
+    );
+  }
+  return present;
+}
+
+export interface SurfaceChoice {
+  value: string;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * Pure options builder — exported for tests. Detected clients are
+ * preselected; when nothing is detected (fresh machine, traces appear only
+ * after first app launch) everything is preselected so plain-Enter still
+ * yields a complete install.
+ */
+export function buildSurfaceChoices(present: Record<string, boolean>): {
+  options: SurfaceChoice[];
+  initialValues: string[];
+} {
+  const options = Object.entries(ADAPTERS).map(([surface, adapter]) => ({
+    value: surface,
+    label: adapter.description.replace(/\s*\(.*\)$/, ""),
+    hint: present[surface] ? "detected" : "not detected",
+  }));
+  const detected = options.filter((o) => present[o.value]).map((o) => o.value);
+  return { options, initialValues: detected.length > 0 ? detected : options.map((o) => o.value) };
+}
+
+/** `~`/relative → absolute, for the custom-vault text input. Exported for tests. */
+export function expandUserPath(input: string, home: string = homedir()): string {
+  const trimmed = input.trim();
+  if (trimmed === "~") return home;
+  if (trimmed.startsWith("~/")) return resolve(home, trimmed.slice(2));
+  return resolve(trimmed);
+}
+
+/**
+ * Pure decision for the wizard's semantic-recall step — the wizard's analogue
+ * of decideInstallRecallAction, same precedence (exported for tests):
+ *   --ollama            → "on" (explicit flag = consent, never ask)
+ *   provider effective or the running daemon is semantic → "already"
+ *   --no-ollama         → "later" (explicit opt-out, never ask)
+ *   otherwise           → "ask"
+ */
+export function decideWizardSemantic(i: {
+  ollamaFlag: "auto" | "skip" | null;
+  effectiveProvider: string;
+  daemonSemanticOn: boolean;
+}): "on" | "later" | "already" | "ask" {
+  if (i.ollamaFlag === "auto") return "on";
+  if (i.effectiveProvider !== "none" || i.daemonSemanticOn) return "already";
+  if (i.ollamaFlag === "skip") return "later";
+  return "ask";
+}
+
+function bailed(value: unknown): value is symbol {
+  return p.isCancel(value);
+}
+
+const CANCEL_MSG = "Setup cancelled — nothing was changed.";
+
+export async function runInstallWizard(args: ParsedArgs): Promise<number> {
+  p.intro(`bastra-recall ${VERSION} — guided setup`);
+
+  // ── 1. vault ──────────────────────────────────────────────────────────────
+  // Same resolution order as every other path: --vault flag > env > detected
+  // from an existing registration. Only a truly unconfigured machine is asked.
+  let vaultPath: string | null = null;
+  let vaultNeedsCreate = false;
+  const preResolved = await resolveVault({ dryRun: false, vaultPath: args.vaultPath });
+  if ("path" in preResolved) {
+    vaultPath = preResolved.path;
+    p.log.info(`Memory vault: ${vaultPath} (already configured)`);
+  } else {
+    const where = await p.select({
+      message: "Where should your memories live? (plain markdown files you can read and back up)",
+      options: [
+        { value: "default", label: `Create ${DEFAULT_VAULT_DISPLAY}`, hint: "recommended" },
+        { value: "custom", label: "Pick a custom folder…" },
+      ],
+      initialValue: "default",
+    });
+    if (bailed(where)) { p.cancel(CANCEL_MSG); return 1; }
+    if (where === "default") {
+      vaultPath = defaultVaultPath();
+    } else {
+      const custom = await p.text({
+        message: "Vault folder (created if missing)",
+        placeholder: DEFAULT_VAULT_DISPLAY,
+        validate: (v) => (v && v.trim().length > 0 ? undefined : "enter a folder path"),
+      });
+      if (bailed(custom)) { p.cancel(CANCEL_MSG); return 1; }
+      vaultPath = expandUserPath(custom);
+      // Echo the expanded absolute path NOW — a typo ('~/Documets/…') or a
+      // CWD-relative surprise must be visible before anything acts on it
+      // (Ctrl-C on the next question still aborts with nothing written).
+      p.log.info(`Vault folder: ${vaultPath}`);
+    }
+    vaultNeedsCreate = true;
+  }
+
+  // ── 2. clients ────────────────────────────────────────────────────────────
+  const { options, initialValues } = buildSurfaceChoices(detectSurfaces());
+  const chosen = await p.multiselect({
+    message: "Which AI clients should get the memory tool? (space to toggle, enter to confirm)",
+    options,
+    initialValues,
+    required: true,
+  });
+  if (bailed(chosen)) { p.cancel(CANCEL_MSG); return 1; }
+
+  // ── 3. semantic recall ────────────────────────────────────────────────────
+  // Same precedence as decideInstallRecallAction: --ollama/--no-ollama are
+  // consent/opt-out and suppress the question; an already-effective provider
+  // or a semantic RUNNING daemon (LaunchAgent env is invisible to this
+  // shell) means there is nothing to ask.
+  const choice = await resolveEmbeddingChoice();
+  let daemonOn = false;
+  if (args.ollama === null && choice.provider === "none") {
+    try {
+      const probe = await probeDaemon();
+      daemonOn = probe.ok && probe.semanticRecall === "on";
+    } catch { /* unreachable daemon = no signal */ }
+  }
+  let semantic = decideWizardSemantic({
+    ollamaFlag: args.ollama,
+    effectiveProvider: choice.provider,
+    daemonSemanticOn: daemonOn,
+  });
+  if (semantic === "already") {
+    p.log.info(
+      choice.provider !== "none"
+        ? `Semantic recall: already configured (${choice.provider}, source: ${choice.source})`
+        : "Semantic recall: already ON in the running daemon",
+    );
+  } else if (semantic === "ask") {
+    const answer = await p.select({
+      message: "Semantic recall? (multilingual vector search on top of keyword search)",
+      options: [
+        {
+          value: "on",
+          label: "Enable — best recall quality",
+          hint: "downloads the embeddinggemma model (~620 MB) via Ollama, installed with Homebrew if missing",
+        },
+        {
+          value: "later",
+          label: "Not now — keyword search only (BM25)",
+          hint: "enable anytime: bastra embeddings on",
+        },
+      ],
+      initialValue: "on",
+    });
+    if (bailed(answer)) { p.cancel(CANCEL_MSG); return 1; }
+    semantic = answer as "on" | "later";
+  }
+
+  // ── execute ───────────────────────────────────────────────────────────────
+  if (vaultNeedsCreate) {
+    const created = await createVaultAt(vaultPath!);
+    if ("error" in created) {
+      p.log.error(`Could not create ${vaultPath}: ${created.error}`);
+      p.outro("Setup failed — nothing else was changed.");
+      return 1;
+    }
+    p.log.success(`Vault created: ${created.path}`);
+  }
+
+  const surfaces = chosen as string[];
+  const results: { surface: string; r: InstallResult }[] = [];
+  const s = p.spinner();
+  s.start("Registering the memory tool…");
+  let hadError = false;
+  for (const surface of surfaces) {
+    const adapter = ADAPTERS[surface];
+    s.message(`Registering ${adapter.description}…`);
+    try {
+      const r = await adapter.install({
+        dryRun: false,
+        vaultPath,
+        force: false,
+        withStopHook: args.withStopHook,
+      });
+      results.push({ surface, r });
+      if (r.status === "error") hadError = true;
+    } catch (err) {
+      results.push({ surface, r: { status: "error", message: (err as Error).message } });
+      hadError = true;
+    }
+  }
+  s.stop(hadError ? "Registration finished with errors" : "Clients registered");
+  for (const { surface, r } of results) {
+    const line = `${surface}: ${r.message}${r.backupPath ? ` (backup: ${r.backupPath})` : ""}`;
+    if (r.status === "error") p.log.error(line);
+    else p.log.success(line);
+  }
+
+  const restart = surfaces.map((sf) => ADAPTERS[sf].description.replace(/\s*\(.*\)$/, "")).join(", ");
+  if (hadError) {
+    // Same contract as the classic path: semantic recall runs only at the end
+    // of a SUCCESSFUL install — never bolt a ~620 MB download onto a failure.
+    if (semantic === "on") {
+      p.log.warn("Skipping semantic recall setup (registration failed) — after fixing, run: bastra embeddings on");
+    }
+    p.outro(`Finished with errors — fix the issue, then re-run: bastra install (log lines above)`);
+    return 1;
+  }
+
+  if (semantic === "on") {
+    // No spinner here on purpose: brew/ollama stream their own progress to
+    // stdout (a ~620 MB download deserves a real progress bar, not a spinner).
+    p.log.step("Setting up semantic recall — Ollama + embeddinggemma model (~620 MB)…");
+    const r = await enableSemanticRecall({ dryRun: false });
+    if (r.status === "error" || r.status === "unsupported") {
+      p.log.warn(`${r.message}\nSetting saved — finish setup, then re-run: bastra embeddings on`);
+    } else if (r.activated) {
+      p.log.success(`Semantic recall: ${r.message}`);
+    } else {
+      // e.g. "env-override": nothing was provisioned — a green success here
+      // would misreport a state where recall stays keyword-only.
+      p.log.warn(`Semantic recall: ${r.message}`);
+    }
+  } else if (semantic === "later") {
+    p.log.info(RECALL_OFF_NOTE);
+  }
+  p.outro(`Done. Restart ${restart} to pick up the memory tool.`);
+  return 0;
+}


### PR DESCRIPTION
## What

Bare `bastra install` on a terminal now runs a **guided setup** built on `@clack/prompts` (the modern installer UI used by Astro/Svelte): intro banner, arrow-key selection lists, spinner, clean outro.

1. **Vault** — select: `Create ~/BastraVault (recommended)` / `Pick a custom folder…` (with `~`-expansion, expanded path echoed before anything acts)
2. **AI clients** — multiselect (space/enter); detected clients hinted and preselected; nothing detected → all preselected so plain Enter still yields a full install
3. **Semantic recall** — select `Enable — best recall quality` / `Not now — keyword only (BM25)`; self-skips when a provider is already effective or the running daemon is semantic

The wizard is a **front-end only**: it drives the exact same machinery as `bastra install all` (`createVaultAt`, `adapter.install`, `enableSemanticRecall`) — no second install path.

## Scripted flows untouched

- named surface / `all`, `--yes`, `--dry-run`, non-TTY, hooks, `bastra update` (calls with `surface:"all"`) never enter the wizard
- bare `install` without a TTY keeps the deterministic missing-surface error (exit 2)
- `--ollama` / `--no-ollama` suppress the semantic question (consent / opt-out)
- `install --help` documents instead of acting

## Contract parity (from adversarial review, 14-agent workflow)

- semantic provisioning only after a **successful** registration ("never on a failed install", same as classic path)
- non-activated results (e.g. `env-override`) render as warning, not success
- 9 findings confirmed → all fixed; 1 refuted

## Install Bastra.command

Hands over to the wizard via `/dev/tty` — **fixes a latent bug**: the `tee` log pipe made stdout non-TTY, silently skipping every interactive prompt in the double-click flow (incl. the #178 vault prompt). Falls back to `bastra install all` when the installed bastra predates the wizard (rc=2, e.g. after a tolerated `brew upgrade` failure).

## Verification

- 343 daemon tests green (7 new: wizard gate matrix, surface choices, detection, path expansion, semantic decision, `--help` gate)
- pty E2E via `expect`: full flow (fresh HOME → vault created, 3 clients registered, rc=0), cancel flow (Ctrl-C → rc=1, **nothing** written), `--no-ollama` flow (no semantic question), tee+`/dev/tty` handover incl. rc propagation both ways

🤖 Generated with [Claude Code](https://claude.com/claude-code)