### PR TITLE
feat(curator): report 0-byte .md files as a vault-health section

### DIFF
--- a/packages/daemon/__tests__/curator-run.test.ts
+++ b/packages/daemon/__tests__/curator-run.test.ts
@@ -7,7 +7,7 @@
  */
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -166,6 +166,26 @@ test("full lifecycle: review-first → observation window matures → acting →
     assert.deepEqual(r4.reactivated, ["tax"]);
     assert.equal(r4.staleTotal, 0);
     assert.deepEqual(demotionCalls.at(-1), [], "index demotion set cleared");
+  });
+});
+
+test("empty-files section: 0-byte .md files are reported, dotfolders ignored (real-vault find 2026-07-04)", async () => {
+  await withFixture(async (root, deps) => {
+    // The Obsidian artifact class: click on an unresolved doc-id wikilink
+    // creates an empty note in the vault root.
+    await writeFile(join(root, "doc-inbox-photo-x-jpg.md"), "", "utf8");
+    await mkdir(join(root, ".obsidian"), { recursive: true });
+    await writeFile(join(root, ".obsidian", "workspace.md"), "", "utf8");
+    await mkdir(join(root, "memories"), { recursive: true });
+    await writeFile(join(root, "memories", "empty-note.md"), "", "utf8");
+
+    const r = await runCuratorPass(deps, { force: true, dryRun: true, nowMs: NOW });
+    assert.equal(r.reportWritten, true);
+    const report = await readFile(join(root, "REPORT.md"), "utf8");
+    assert.ok(report.includes("`doc-inbox-photo-x-jpg.md`"), "root empty file listed");
+    assert.ok(report.includes("`memories/empty-note.md`"), "nested empty file listed");
+    assert.ok(!report.includes("workspace.md"), "dotfolder contents ignored");
+    assert.ok(report.includes("safe to delete"));
   });
 });
 

--- a/packages/daemon/__tests__/vault-report.test.ts
+++ b/packages/daemon/__tests__/vault-report.test.ts
@@ -98,6 +98,14 @@ test("deterministic: identical data renders byte-identical output (stable re-run
   assert.equal(renderVaultHealthReport(FULL), renderVaultHealthReport(FULL));
 });
 
+test("empty-files section: lists paths with delete guidance; empty state is quiet", () => {
+  const withEmpty = renderVaultHealthReport({ ...FULL, emptyFiles: ["doc-inbox-photo-x-jpg.md"] });
+  assert.ok(withEmpty.includes("<!-- bastra-report:empty-files -->"));
+  assert.ok(withEmpty.includes("`doc-inbox-photo-x-jpg.md`"));
+  assert.ok(withEmpty.includes("safe to delete"));
+  assert.ok(renderVaultHealthReport(EMPTY).includes("No 0-byte `.md` files"));
+});
+
 test("writer: REPORT.md lands atomically in the vault root and is overwritten in place", async () => {
   const root = await mkdtemp(join(tmpdir(), "bastra-report-"));
   try {

--- a/packages/daemon/src/curator-run.ts
+++ b/packages/daemon/src/curator-run.ts
@@ -10,6 +10,8 @@
  * only grows by routing lines.
  */
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { readdir, stat } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
 import { listFloors } from "./floors.js";
 import {
   applyDecision,
@@ -189,6 +191,32 @@ function collectConflictsAndDangling(vault: VaultLike): {
   return { conflicts, dangling };
 }
 
+/**
+ * 0-byte .md files anywhere in the vault (dotfolders excluded) — typically
+ * Obsidian's auto-created empty notes from clicking an unresolved wikilink
+ * (e.g. a bastra doc-id link; real-vault find 2026-07-04). Best-effort:
+ * returns [] on any error.
+ */
+async function collectEmptyFiles(vaultRoot: string): Promise<string[]> {
+  try {
+    const entries = await readdir(vaultRoot, { recursive: true, withFileTypes: true });
+    const empty: string[] = [];
+    for (const e of entries) {
+      if (!e.isFile() || !e.name.endsWith(".md")) continue;
+      const rel = relative(vaultRoot, join(e.parentPath, e.name));
+      if (rel.split(sep).some((part) => part.startsWith("."))) continue;
+      try {
+        if ((await stat(join(vaultRoot, rel))).size === 0) empty.push(rel);
+      } catch {
+        /* raced deletion — skip */
+      }
+    }
+    return empty.sort();
+  } catch {
+    return [];
+  }
+}
+
 // ─── the pass ────────────────────────────────────────────────────────────────
 
 /**
@@ -293,6 +321,7 @@ async function runCuratorPassInner(
     })),
     floors: await collectFloorReview(deps.vault, nowMs),
     ...collectConflictsAndDangling(deps.vault),
+    emptyFiles: await collectEmptyFiles(deps.vaultRoot),
     ...(mode !== "acting" ? { pendingReview: true } : {}),
   };
   const reportWritten = await writeVaultHealthReport(deps.vaultRoot, data);

--- a/packages/daemon/src/vault-report.ts
+++ b/packages/daemon/src/vault-report.ts
@@ -63,6 +63,9 @@ export interface VaultHealthData {
   floors: ReportFloorEntry[];
   conflicts: ReportConflictCluster[];
   dangling: ReportDanglingLink[];
+  /** Vault-relative paths of 0-byte .md files — usually Obsidian's
+   *  auto-created empty notes from clicking an unresolved wikilink. */
+  emptyFiles?: string[];
   /** True on review-only passes (dry-run / first-ever run): the stale list
    *  shows what WOULD be demoted — nothing has acted yet. */
   pendingReview?: boolean;
@@ -162,6 +165,19 @@ export function renderVaultHealthReport(data: VaultHealthData): string {
     L.push("");
     for (const d of data.dangling) {
       L.push(`- [[${d.fromId}]] → \`[[${d.target}]]\` (missing)`);
+    }
+  }
+  L.push("");
+  L.push("<!-- bastra-report:empty-files -->");
+  L.push("## Empty files");
+  L.push("");
+  if (!data.emptyFiles || data.emptyFiles.length === 0) {
+    L.push("None. No 0-byte `.md` files in the vault.");
+  } else {
+    L.push("Zero-byte markdown files — typically created by Obsidian when a wikilink that does not resolve to a file (e.g. a bastra doc-id link) gets clicked. They carry nothing and are safe to delete.");
+    L.push("");
+    for (const p of data.emptyFiles) {
+      L.push(`- \`${p}\``);
     }
   }
   L.push("");


### PR DESCRIPTION
Real-vault find from tonight's curator test: an empty `doc-inbox-photo-….md` sat in the vault root since June 23 — created by Obsidian when an unresolved doc-id wikilink (RelatedEnricher cross-links between document sidecars use bastra ids, which Obsidian cannot resolve to filenames) got clicked. Invisible to the index, invisible to the dangling check (the id resolves via the real sidecar), visible only when browsing the root.

New REPORT.md section **Empty files** lists every 0-byte `.md` in the vault (dotfolders excluded) with delete guidance. Deliberately only 0-byte files — flagging content-bearing non-memory notes would drown legit Obsidian content in noise.

Tests: 378/378 daemon green (2 new: collector incl. dotfolder exclusion + renderer section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)