### PR TITLE
fix(curator): keep exception detail out of the /curator/run HTTP response

### DIFF
--- a/packages/daemon/src/curator-run.ts
+++ b/packages/daemon/src/curator-run.ts
@@ -370,6 +370,12 @@ export function handleCuratorRun(req: IncomingMessage, res: ServerResponse, deps
     try { body = raw.trim() ? JSON.parse(raw) : {}; } catch { /* defaults */ }
     runCuratorPass(deps, { force: body.force ?? true, dryRun: body.dryRun ?? true })
       .then((result) => sendJson(res, 200, result))
-      .catch((err) => sendJson(res, 500, { error: (err as Error).message }));
+      .catch((err) => {
+        // Exception detail stays in the server log — never in the HTTP
+        // response (CodeQL js/stack-trace-exposure, alert #23). Loopback-only
+        // today, but the hygiene rule holds regardless of audience.
+        console.error(`[bastra-recall] /curator/run failed: ${(err as Error)?.message ?? err}`);
+        sendJson(res, 500, { error: "curator run failed — see daemon log" });
+      });
   });
 }


### PR DESCRIPTION
Fixes CodeQL alert #23 (js/stack-trace-exposure) in the Wave-C endpoint: exception detail now goes to the daemon log, the HTTP response carries a generic error marker. Loopback-only endpoint, but the hygiene rule holds regardless of audience.

378/378 daemon tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)