### PR TITLE
fix(curator): sanitize the /curator/run result at the HTTP boundary (alert #23, part 2)

### DIFF
--- a/packages/daemon/__tests__/curator-run.test.ts
+++ b/packages/daemon/__tests__/curator-run.test.ts
@@ -11,7 +11,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { runCuratorPass, type CuratorRunDeps } from "../src/curator-run.js";
+import { runCuratorPass, sanitizeRunResultForHttp, type CuratorRunDeps } from "../src/curator-run.js";
 import { recordUsage } from "../src/usage-sidecar.js";
 import { loadCuratorState } from "../src/curator.js";
 
@@ -187,6 +187,26 @@ test("empty-files section: 0-byte .md files are reported, dotfolders ignored (re
     assert.ok(!report.includes("workspace.md"), "dotfolder contents ignored");
     assert.ok(report.includes("safe to delete"));
   });
+});
+
+test("HTTP boundary: exception detail never reaches the response (CodeQL alert #23)", () => {
+  const base = {
+    ran: false as const,
+    mode: "acting" as const,
+    dryRun: false,
+    demoted: [],
+    reactivated: [],
+    pendingObservation: [],
+    staleTotal: 0,
+    reportWritten: false,
+  };
+  const failed = sanitizeRunResultForHttp({ ...base, error: "ENOSPC: no space left on device, write '/Users/x/.bastra/x'" });
+  assert.equal(failed.status, 500);
+  assert.equal(failed.body.error, "curator run failed — see daemon log");
+  assert.ok(!JSON.stringify(failed.body).includes("ENOSPC"), "no exception detail in the payload");
+  const ok = sanitizeRunResultForHttp({ ...base, ran: true });
+  assert.equal(ok.status, 200);
+  assert.equal(ok.body.error, undefined);
 });
 
 test("gate: un-forced run respects the 7d interval (skipped: interval)", async () => {

--- a/packages/daemon/src/curator-run.ts
+++ b/packages/daemon/src/curator-run.ts
@@ -362,6 +362,20 @@ export function handleCuratorState(_req: IncomingMessage, res: ServerResponse, d
  * to dryRun:true: a hand-triggered run is a review request, not consent to
  * demote — the periodic pass is the acting path.
  */
+/**
+ * HTTP boundary sanitizer (CodeQL js/stack-trace-exposure, alert #23):
+ * runCuratorPass is never-throw and carries the exception detail in
+ * `result.error` — useful for the daemon log (index.ts tick), but it must
+ * not reach an HTTP response. Loopback-only today; the hygiene rule holds
+ * regardless of audience. Exported for tests.
+ */
+export function sanitizeRunResultForHttp(
+  result: CuratorRunResult,
+): { status: number; body: CuratorRunResult } {
+  if (!result.error) return { status: 200, body: result };
+  return { status: 500, body: { ...result, error: "curator run failed — see daemon log" } };
+}
+
 export function handleCuratorRun(req: IncomingMessage, res: ServerResponse, deps: CuratorRunDeps): void {
   let raw = "";
   req.on("data", (c) => { raw += c; if (raw.length > 4096) req.destroy(); });
@@ -369,12 +383,14 @@ export function handleCuratorRun(req: IncomingMessage, res: ServerResponse, deps
     let body: { force?: boolean; dryRun?: boolean } = {};
     try { body = raw.trim() ? JSON.parse(raw) : {}; } catch { /* defaults */ }
     runCuratorPass(deps, { force: body.force ?? true, dryRun: body.dryRun ?? true })
-      .then((result) => sendJson(res, 200, result))
-      .catch((err) => {
-        // Exception detail stays in the server log — never in the HTTP
-        // response (CodeQL js/stack-trace-exposure, alert #23). Loopback-only
-        // today, but the hygiene rule holds regardless of audience.
-        console.error(`[bastra-recall] /curator/run failed: ${(err as Error)?.message ?? err}`);
+      .then((result) => {
+        if (result.error) console.error(`[bastra-recall] /curator/run failed: ${result.error}`);
+        const { status, body: payload } = sanitizeRunResultForHttp(result);
+        sendJson(res, status, payload);
+      })
+      .catch(() => {
+        // Unreachable by contract (runCuratorPass never throws) — and
+        // deliberately detail-free if it ever happens anyway.
         sendJson(res, 500, { error: "curator run failed — see daemon log" });
       });
   });


### PR DESCRIPTION
First fix (#189) closed the .catch path, but runCuratorPass is never-throw by contract and carries exception detail in `result.error` — which flowed through the 200 response (the actual CodeQL-tracked path, anchored at the sendJson sink). The handler now logs the detail and sends a generic marker via `sanitizeRunResultForHttp` (exported + unit-tested: payload provably free of exception detail).

379/379 daemon tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)