### PR TITLE
feat: Wave D — breaker, query normalizer, hook backoff, npx stable runtime, uninstall sweep, sidecar aliases

### DIFF
--- a/packages/core/__tests__/doc-sidecar-alias.test.ts
+++ b/packages/core/__tests__/doc-sidecar-alias.test.ts
@@ -17,6 +17,7 @@ import { Vault } from "../src/vault.js";
 import type { EmbeddingIndex } from "../src/embeddings.js";
 import { RelatedEnricher } from "../src/related-enrich.js";
 import { parseMemoryWith } from "../src/schema.js";
+import { saveMemory } from "../src/save.js";
 
 const DOC_ID = "doc-inbox-photo-2026-01-27-jpg";
 const NEIGHBOR_ID = "doc-inbox-other-jpg";
@@ -194,4 +195,78 @@ test("Schema toleriert Obsidians Bare-String-Form und coerct zu Liste", () => {
   const raw = docSidecarMd(DOC_ID, `aliases: ${DOC_ID}\n`);
   const m = parseMemoryWith(matter, raw, "/x.md", 0);
   assert.deepEqual(m.fm.aliases, [DOC_ID]);
+});
+
+// ─── Koerzierungs-Matrix (#188): ein Memory darf NIE über seine aliases
+// aus dem Vault fallen — hand-editierte Frontmatter liefert Zahlen, YAML-
+// Dates, Bare-Scalars, dangling `aliases:` (null) oder leere Listen. ───
+const COERCION_MATRIX: { name: string; fm: string; want: string[] | undefined }[] = [
+  { name: "Zahl in Liste (aliases: [2024])", fm: "aliases: [2024]\n", want: ["2024"] },
+  { name: "YAML-Date in Liste (aliases: [2026-05-01] → JS Date)", fm: "aliases: [2026-05-01]\n", want: ["2026-05-01"] },
+  { name: "Bare-Zahl (aliases: 2024)", fm: "aliases: 2024\n", want: ["2024"] },
+  { name: "Bare-YAML-Date (aliases: 2026-05-01)", fm: "aliases: 2026-05-01\n", want: ["2026-05-01"] },
+  { name: "dangling aliases: (null)", fm: "aliases:\n", want: undefined },
+  { name: "leere Liste (aliases: [])", fm: "aliases: []\n", want: undefined },
+  { name: "gemischte Liste (Zahl + String + null-Member)", fm: 'aliases: [2024, "Foto Mai", null]\n', want: ["2024", "Foto Mai"] },
+];
+
+for (const { name, fm, want } of COERCION_MATRIX) {
+  test(`Schema-Koerzierung statt Reject: ${name}`, () => {
+    const raw = docSidecarMd(DOC_ID, fm);
+    // Darf nicht throwen — sonst fällt das ganze Memory aus dem Vault.
+    const m = parseMemoryWith(matter, raw, "/x.md", 0);
+    assert.deepEqual(m.fm.aliases, want);
+  });
+}
+
+// ─── saveMemory-Serializer (#188): aliases werden geschrieben und ein
+// Overwrite ohne explizite aliases erhält die bestehenden File-Aliases. ───
+function saveInput(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "alias-save-test",
+    title: "Alias Save Test",
+    type: "lesson",
+    summary: "s",
+    body: "body",
+    topic_path: ["t"],
+    tags: ["t"],
+    scope: "t",
+    recall_when: ["w"],
+    ...overrides,
+  } as Parameters<typeof saveMemory>[1];
+}
+
+test("saveMemory schreibt aliases und Overwrite ohne aliases erhält sie", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bastra-doc-alias-"));
+  try {
+    // 1) Erst-Save mit aliases → Serializer schreibt sie ins File.
+    const first = await saveMemory(dir, saveInput({ aliases: ["Foto Mai", DOC_ID] }));
+    const fm1 = matter(await readFile(first.file_path, "utf8")).data as { aliases?: string[] };
+    assert.deepEqual(fm1.aliases, ["Foto Mai", DOC_ID]);
+
+    // 2) Overwrite OHNE aliases → bestehende File-Aliases bleiben erhalten.
+    const second = await saveMemory(dir, saveInput({ overwrite: true, summary: "s2" }));
+    assert.equal(second.file_path, first.file_path);
+    const fm2 = matter(await readFile(second.file_path, "utf8")).data as { aliases?: string[]; summary?: string };
+    assert.deepEqual(fm2.aliases, ["Foto Mai", DOC_ID]);
+    assert.equal(fm2.summary, "s2");
+
+    // 3) Overwrite MIT expliziten aliases → sie ersetzen die alten.
+    await saveMemory(dir, saveInput({ overwrite: true, aliases: ["Neu"] }));
+    const fm3 = matter(await readFile(first.file_path, "utf8")).data as { aliases?: string[] };
+    assert.deepEqual(fm3.aliases, ["Neu"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("saveMemory ohne aliases auf neuem File schreibt kein aliases-Feld", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bastra-doc-alias-"));
+  try {
+    const result = await saveMemory(dir, saveInput());
+    const raw = await readFile(result.file_path, "utf8");
+    assert.doesNotMatch(raw, /aliases:/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/core/__tests__/doc-sidecar-alias.test.ts
+++ b/packages/core/__tests__/doc-sidecar-alias.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Issue #188: Doc-Sidecars tragen ihre eigene doc-id als Obsidian-Alias,
+ * damit die `[[<doc-id>]]`-Cross-Links des RelatedEnrichers in Obsidian aufs
+ * Sidecar-File auflösen (Obsidian löst Wikilinks gegen die `aliases`-
+ * Frontmatter-Liste auf — Standard-Feature) statt beim Klick eine leere
+ * Stray-Note anzulegen.
+ *
+ * Run: npx tsx --test packages/core/__tests__/doc-sidecar-alias.test.ts
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import matter from "gray-matter";
+import { Vault } from "../src/vault.js";
+import type { EmbeddingIndex } from "../src/embeddings.js";
+import { RelatedEnricher } from "../src/related-enrich.js";
+import { parseMemoryWith } from "../src/schema.js";
+
+const DOC_ID = "doc-inbox-photo-2026-01-27-jpg";
+const NEIGHBOR_ID = "doc-inbox-other-jpg";
+
+/** Doc-Sidecar wie vom Inbox-Watcher: Filename ≠ id, kein aliases-Feld. */
+function docSidecarMd(id: string, extraFm = ""): string {
+  return `---
+id: ${id}
+title: Photo
+type: doc
+summary: s
+topic_path: [documents, Inbox]
+tags: [foto]
+scope: documents
+recall_when: ["find photo"]
+created: 2026-05-01
+updated: 2026-05-01
+${extraFm}---
+
+> Sidecar für \`photo.jpg\`.
+`;
+}
+
+function lessonMd(id: string): string {
+  return `---
+id: ${id}
+title: ${id}
+type: lesson
+summary: s
+topic_path: [t]
+tags: [t]
+scope: t
+recall_when: ["w"]
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+body ${id}
+`;
+}
+
+function stubEmbeddings(hits: { id: string; score: number }[]) {
+  const stub = {
+    current: hits,
+    findSimilarById(_id: string, _k: number) {
+      return this.current;
+    },
+    onEmbed(_l: (id: string) => void) {
+      return () => {};
+    },
+  };
+  return { stub, index: stub as unknown as EmbeddingIndex };
+}
+
+/** Vault mit zwei Doc-Sidecars unter documents/Inbox (Filename ≠ id). */
+async function docVault(extraFm = ""): Promise<{ dir: string; vault: Vault; sidecar: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), "bastra-doc-alias-"));
+  const inbox = path.join(dir, "documents", "Inbox");
+  await mkdir(inbox, { recursive: true });
+  const sidecar = path.join(inbox, "PHOTO-2026-01-27.jpg.md");
+  await writeFile(sidecar, docSidecarMd(DOC_ID, extraFm));
+  await writeFile(path.join(inbox, "other.jpg.md"), docSidecarMd(NEIGHBOR_ID));
+  const vault = new Vault(dir);
+  await vault.init();
+  return { dir, vault, sidecar };
+}
+
+test("Enricher ergänzt die eigene id als Alias auf einem Doc-Sidecar ohne aliases", async () => {
+  const { dir, vault, sidecar } = await docVault();
+  try {
+    const { index } = stubEmbeddings([{ id: NEIGHBOR_ID, score: 0.95 }]);
+    const enricher = new RelatedEnricher(vault, index);
+
+    const written = await enricher.enrich(DOC_ID);
+    assert.ok(written);
+
+    const raw = await readFile(sidecar, "utf8");
+    const fm = matter(raw).data as { aliases?: string[] };
+    assert.deepEqual(fm.aliases, [DOC_ID]);
+    assert.match(raw, new RegExp(`\\[\\[${NEIGHBOR_ID}\\]\\]`));
+
+    // Schema-Round-Trip: der Alias überlebt reindex → vault.get().
+    const indexed = vault.get(DOC_ID);
+    assert.ok(indexed);
+    assert.deepEqual(indexed.fm.aliases, [DOC_ID]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Alias-only Write: Links unverändert, aber Alias fehlt → Enricher schreibt trotzdem", async () => {
+  const { dir, vault, sidecar } = await docVault();
+  try {
+    const { index } = stubEmbeddings([{ id: NEIGHBOR_ID, score: 0.95 }]);
+    const enricher = new RelatedEnricher(vault, index);
+    await enricher.enrich(DOC_ID);
+
+    // Alias von Hand entfernen (simuliert Bestands-Sidecar von vor #188).
+    const raw = await readFile(sidecar, "utf8");
+    const parsed = matter(raw);
+    const fm = { ...(parsed.data as Record<string, unknown>) };
+    delete fm.aliases;
+    await writeFile(sidecar, matter.stringify(parsed.content, fm));
+    await vault.reindexFile(sidecar);
+
+    // Similarity-Set identisch → sameVia && sameBody, nur der Alias fehlt.
+    const written = await enricher.enrich(DOC_ID);
+    assert.ok(written, "erwartet Write wegen fehlendem Alias");
+    const after = matter(await readFile(sidecar, "utf8")).data as { aliases?: string[] };
+    assert.deepEqual(after.aliases, [DOC_ID]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Alias vorhanden + Links unverändert → no-op (kein Write-Loop)", async () => {
+  const { dir, vault, sidecar } = await docVault();
+  try {
+    const { index } = stubEmbeddings([{ id: NEIGHBOR_ID, score: 0.95 }]);
+    const enricher = new RelatedEnricher(vault, index);
+    await enricher.enrich(DOC_ID);
+    const before = await readFile(sidecar, "utf8");
+
+    const result = await enricher.enrich(DOC_ID);
+    assert.equal(result, null);
+    assert.equal(await readFile(sidecar, "utf8"), before);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bestehende User-Aliases überleben, die id wird nur angehängt", async () => {
+  const { dir, vault, sidecar } = await docVault('aliases: ["Foto Mai"]\n');
+  try {
+    const { index } = stubEmbeddings([{ id: NEIGHBOR_ID, score: 0.95 }]);
+    const enricher = new RelatedEnricher(vault, index);
+    await enricher.enrich(DOC_ID);
+
+    const fm = matter(await readFile(sidecar, "utf8")).data as { aliases?: string[] };
+    assert.deepEqual(fm.aliases, ["Foto Mai", DOC_ID]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Nicht-Doc-Memories bekommen keinen Alias (Filename == id, Obsidian löst direkt)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bastra-doc-alias-"));
+  try {
+    await writeFile(path.join(dir, "a.md"), lessonMd("a"));
+    await writeFile(path.join(dir, "b.md"), lessonMd("b"));
+    const vault = new Vault(dir);
+    await vault.init();
+    const { index } = stubEmbeddings([{ id: "b", score: 0.95 }]);
+    const enricher = new RelatedEnricher(vault, index);
+    await enricher.enrich("a");
+
+    const raw = await readFile(path.join(dir, "a.md"), "utf8");
+    assert.doesNotMatch(raw, /aliases:/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("Schema-Round-Trip: aliases übersteht parse → stringify → parse", () => {
+  const raw = docSidecarMd(DOC_ID, `aliases: ["${DOC_ID}", "Foto Mai"]\n`);
+  const m = parseMemoryWith(matter, raw, "/x.md", 0);
+  assert.deepEqual(m.fm.aliases, [DOC_ID, "Foto Mai"]);
+
+  const rewritten = matter.stringify(m.body, m.fm as unknown as Record<string, unknown>);
+  const again = parseMemoryWith(matter, rewritten, "/x.md", 0);
+  assert.deepEqual(again.fm.aliases, [DOC_ID, "Foto Mai"]);
+});
+
+test("Schema toleriert Obsidians Bare-String-Form und coerct zu Liste", () => {
+  const raw = docSidecarMd(DOC_ID, `aliases: ${DOC_ID}\n`);
+  const m = parseMemoryWith(matter, raw, "/x.md", 0);
+  assert.deepEqual(m.fm.aliases, [DOC_ID]);
+});

--- a/packages/core/__tests__/query-normalize.test.ts
+++ b/packages/core/__tests__/query-normalize.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for the query normalizer + identifier-preserving tokenizer (#162).
+ *
+ * Code-lesson queries carry dotted/hyphenated/underscored identifiers
+ * (`my-app.config.ts`, `chat-send`, `P2.2`, `--force-push`). The shared
+ * tokenizer dual-emits (joined identifier + split parts) on BOTH the index
+ * and the query side, so precision improves without losing any match the
+ * old split-only tokenization produced. `normalizeQuery` adds hostile-input
+ * hygiene (length cap, whitespace collapse, dangling boolean-ish operators)
+ * at the SearchIndex.recall entry — MCP and hook paths both run through it.
+ *
+ * Runner: node --import tsx --test packages/core/__tests__/query-normalize.test.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "../src/index.js";
+import {
+  normalizeQuery,
+  tokenizeWithIdentifiers,
+  QUERY_MAX_CHARS,
+} from "../src/query-normalize.js";
+
+// ─── tokenizer matrix ────────────────────────────────────────────
+
+test("tokenizer: dual-emits dotted identifier plus its parts", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("my-app.config.ts"), [
+    "my-app.config.ts",
+    "my",
+    "app",
+    "config",
+    "ts",
+  ]);
+});
+
+test("tokenizer: hyphenated command name stays a unit", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("chat-send"), ["chat-send", "chat", "send"]);
+});
+
+test("tokenizer: leading punctuation is trimmed (--force-push)", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("--force-push"), [
+    "force-push",
+    "force",
+    "push",
+  ]);
+});
+
+test("tokenizer: versioned identifier P2.2 survives", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("P2.2 release"), ["P2.2", "P2", "2", "release"]);
+});
+
+test("tokenizer: snake_case survives", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("snake_case_name"), [
+    "snake_case_name",
+    "snake",
+    "case",
+    "name",
+  ]);
+});
+
+test("tokenizer: plain prose is unchanged vs. split-only tokenization", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("plain words here"), ["plain", "words", "here"]);
+});
+
+test("tokenizer: sentence-final period does not create a fake identifier", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("edit the config."), ["edit", "the", "config"]);
+});
+
+test("tokenizer: path separators and colons still split (file segments survive)", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("src/search.ts:42"), [
+    "src",
+    "search.ts",
+    "search",
+    "ts",
+    "42",
+  ]);
+});
+
+test("tokenizer: punctuation-only input yields no tokens", () => {
+  assert.deepEqual(tokenizeWithIdentifiers("... --- ___"), []);
+  assert.deepEqual(tokenizeWithIdentifiers(""), []);
+});
+
+// ─── normalizeQuery matrix ───────────────────────────────────────
+
+test("normalizeQuery: collapses whitespace and trims", () => {
+  assert.equal(normalizeQuery("  foo \n\t bar  "), "foo bar");
+});
+
+test("normalizeQuery: strips dangling boolean-ish operators at both ends", () => {
+  assert.equal(normalizeQuery("foo AND"), "foo");
+  assert.equal(normalizeQuery("AND foo"), "foo");
+  assert.equal(normalizeQuery("NOT and foo bar && ||"), "foo bar");
+});
+
+test("normalizeQuery: operator-only query becomes empty", () => {
+  assert.equal(normalizeQuery("AND OR NOT"), "");
+  assert.equal(normalizeQuery("+ - !"), "");
+});
+
+test("normalizeQuery: inner operators and operator-like identifiers survive", () => {
+  assert.equal(normalizeQuery("foo - bar"), "foo - bar");
+  assert.equal(normalizeQuery("--force-push crashes"), "--force-push crashes");
+  assert.equal(normalizeQuery("git push --force"), "git push --force");
+});
+
+test("normalizeQuery: identifiers stay byte-identical", () => {
+  assert.equal(normalizeQuery("my-app.config.ts chat-send P2.2"), "my-app.config.ts chat-send P2.2");
+});
+
+test("normalizeQuery: caps hostile input at QUERY_MAX_CHARS", () => {
+  const hostile = "x".repeat(50_000);
+  assert.ok(normalizeQuery(hostile).length <= QUERY_MAX_CHARS);
+});
+
+test("normalizeQuery: idempotent", () => {
+  const q = "  foo AND  my-app.config.ts OR ";
+  assert.equal(normalizeQuery(normalizeQuery(q)), normalizeQuery(q));
+});
+
+// ─── retrieval fixtures (index + query symmetry) ─────────────────
+
+/** Identifier-heavy memory fixture — recall_when/title carry the identifiers. */
+function memo(
+  id: string,
+  title: string,
+  recallWhen: string,
+  body: string,
+): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: lesson",
+    `summary: ${title}`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: test-scope",
+    "recall_when:",
+    `  - ${recallWhen}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+async function makeIndex(): Promise<{ idx: SearchIndex; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-qnorm-test-"));
+  // Target: identifier appears verbatim in recall_when + title.
+  await writeFile(
+    join(dir, "cfg.md"),
+    memo(
+      "cfg",
+      "vite aliases in my-app.config.ts",
+      "editing my-app.config.ts build settings",
+      "Alias block in my-app.config.ts must mirror tsconfig paths.",
+    ),
+    "utf8",
+  );
+  // Decoy: carries the generic split parts but NOT the joined identifier.
+  await writeFile(
+    join(dir, "decoy.md"),
+    memo(
+      "decoy",
+      "general app housekeeping",
+      "app config ts cleanup chores",
+      "Misc notes about app config and ts housekeeping.",
+    ),
+    "utf8",
+  );
+  await writeFile(
+    join(dir, "send.md"),
+    memo(
+      "send",
+      "chat-send handler debounce",
+      "touching the chat-send handler",
+      "Debounce lives in the chat-send handler, not the socket layer.",
+    ),
+    "utf8",
+  );
+  await writeFile(
+    join(dir, "phase.md"),
+    memo(
+      "phase",
+      "P2.2 rollout gate",
+      "planning P2.2 rollout",
+      "Gate criteria for P2.2 were fixed in the kickoff.",
+    ),
+    "utf8",
+  );
+  const vault = new Vault(dir);
+  await vault.init();
+  const idx = new SearchIndex(vault);
+  idx.start();
+  return { idx, dir };
+}
+
+test("retrieval: joined identifier query ranks the exact memory above the split-parts decoy", async () => {
+  const { idx, dir } = await makeIndex();
+  try {
+    const hits = idx.recall("my-app.config.ts", { k: 5 });
+    assert.ok(hits.length >= 1, "identifier query returns hits");
+    assert.equal(hits[0].id, "cfg", "exact-identifier memory ranks first");
+    // The joined token itself matched — not just the generic parts.
+    assert.ok(
+      hits[0].matched_terms.includes("my-app.config.ts"),
+      `joined identifier is a matched term (got: ${hits[0].matched_terms.join(", ")})`,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("retrieval: split-parts recall is not reduced (decoy still findable)", async () => {
+  const { idx, dir } = await makeIndex();
+  try {
+    // Old behavior: "my-app.config.ts" degraded to these parts. Both memories
+    // must still match — dual-emission may not lose any previous hit.
+    const hits = idx.recall("app config ts", { k: 5 });
+    const ids = hits.map((h) => h.id);
+    assert.ok(ids.includes("cfg"), "identifier memory matches on its parts");
+    assert.ok(ids.includes("decoy"), "parts-only memory still matches");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("retrieval: hyphenated identifier in recall_when triggers deliberate match", async () => {
+  const { idx, dir } = await makeIndex();
+  try {
+    const hits = idx.recall("chat-send", { k: 5 });
+    assert.equal(hits[0]?.id, "send");
+    assert.equal(hits[0]?.matched_recall_when, true, "recall_when field fired");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("retrieval: versioned identifier P2.2 is retrievable", async () => {
+  const { idx, dir } = await makeIndex();
+  try {
+    const hits = idx.recall("P2.2", { k: 5 });
+    assert.equal(hits[0]?.id, "phase");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("retrieval: normalization applies at the recall entry (dangling operator, hostile length)", async () => {
+  const { idx, dir } = await makeIndex();
+  try {
+    // Dangling operator is stripped before search + cache key.
+    const hits = idx.recall("my-app.config.ts AND", { k: 5 });
+    assert.equal(hits[0]?.id, "cfg");
+    // Operator-only query normalizes to empty → no hits, no throw.
+    assert.deepEqual(idx.recall("AND OR NOT", { k: 5 }), []);
+    // 50k-char hostile query is capped and must not throw.
+    assert.doesNotThrow(() => idx.recall("z".repeat(50_000), { k: 5 }));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/__tests__/query-normalize.test.ts
+++ b/packages/core/__tests__/query-normalize.test.ts
@@ -20,6 +20,7 @@ import { Vault, SearchIndex } from "../src/index.js";
 import {
   normalizeQuery,
   tokenizeWithIdentifiers,
+  capAtWordBoundary,
   QUERY_MAX_CHARS,
 } from "../src/query-normalize.js";
 
@@ -113,6 +114,61 @@ test("normalizeQuery: identifiers stay byte-identical", () => {
 test("normalizeQuery: caps hostile input at QUERY_MAX_CHARS", () => {
   const hostile = "x".repeat(50_000);
   assert.ok(normalizeQuery(hostile).length <= QUERY_MAX_CHARS);
+});
+
+// ─── cap semantics (#162: defense cap, not a relevance knob) ─────
+
+test("cap: QUERY_MAX_CHARS is 8000 — hostile-input defense must not truncate pasted stack traces", () => {
+  // The 1000-char cap silently dropped discriminating identifiers from long
+  // hook prompts on BOTH search arms. 8000 keeps legitimate prompts intact.
+  assert.equal(QUERY_MAX_CHARS, 8000);
+});
+
+test("capAtWordBoundary: text within the cap is returned byte-identical", () => {
+  assert.equal(capAtWordBoundary("aaa bbb ccc", 11), "aaa bbb ccc");
+  assert.equal(capAtWordBoundary("aaa bbb ccc", 500), "aaa bbb ccc");
+});
+
+test("capAtWordBoundary: never cuts mid-token — partial trailing token is dropped", () => {
+  // index 9 is inside "ccc" → the partial token must go, not be halved
+  assert.equal(capAtWordBoundary("aaa bbb ccc", 9), "aaa bbb");
+  assert.equal(capAtWordBoundary("aaa bbb ccc", 5), "aaa");
+});
+
+test("capAtWordBoundary: cut landing exactly on whitespace keeps the full last token", () => {
+  // index 7 is the space after "bbb"
+  assert.equal(capAtWordBoundary("aaa bbb ccc", 7), "aaa bbb");
+});
+
+test("capAtWordBoundary: cut landing right after whitespace drops the next token cleanly", () => {
+  // index 8 is the first char of "ccc" — head ends in a space
+  assert.equal(capAtWordBoundary("aaa bbb ccc", 8), "aaa bbb");
+});
+
+test("capAtWordBoundary: single whitespace-free monster token falls back to a hard cut", () => {
+  assert.equal(capAtWordBoundary("x".repeat(100), 10), "x".repeat(10));
+});
+
+test("normalizeQuery: long hook prompt keeps identifiers past the old 1000-char cap", () => {
+  // Regression for #162: a pasted stack trace pushed the discriminating
+  // identifier past the old slice(0, 1000) and it vanished from the query.
+  const stackNoise = "at Object.handler (webpack-internal:///./src/foo.ts) ".repeat(40); // > 2000 chars
+  const query = `${stackNoise} my-app.config.ts crashes on rebuild`;
+  assert.ok(query.length > 1000 && query.length < QUERY_MAX_CHARS);
+  assert.ok(
+    normalizeQuery(query).includes("my-app.config.ts"),
+    "identifier beyond the old cap must survive normalization",
+  );
+});
+
+test("normalizeQuery: over-cap query is cut at a word boundary, never mid-token", () => {
+  // 1599 × "word " = 7995 chars; the straddler starts at 7995 so index 8000
+  // falls inside it — the partial token must be dropped entirely.
+  const query = "word ".repeat(1599) + "identifier-straddling-the-cap";
+  const normalized = normalizeQuery(query);
+  assert.ok(normalized.length <= QUERY_MAX_CHARS);
+  assert.ok(normalized.endsWith("word"), "cut falls back to the last full token");
+  assert.ok(!normalized.includes("ident"), "no fragment of the straddling token survives");
 });
 
 test("normalizeQuery: idempotent", () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type { RecallHit, RecallOptions } from "./search.js";
 export {
   normalizeQuery,
   tokenizeWithIdentifiers,
+  capAtWordBoundary,
   QUERY_MAX_CHARS,
 } from "./query-normalize.js";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,12 @@ export type { VaultEvent, VaultListener } from "./vault.js";
 export { SearchIndex } from "./search.js";
 export type { RecallHit, RecallOptions } from "./search.js";
 
+export {
+  normalizeQuery,
+  tokenizeWithIdentifiers,
+  QUERY_MAX_CHARS,
+} from "./query-normalize.js";
+
 export type { RecallStage, StageListener } from "./recall-stages.js";
 export { RECALL_STAGE_ORDER, progressIndexFor } from "./recall-stages.js";
 

--- a/packages/core/src/query-normalize.ts
+++ b/packages/core/src/query-normalize.ts
@@ -26,8 +26,31 @@
  * boolean-artige Operatoren an den Rändern strippen.
  */
 
-/** Query-Längen-Cap (hostile-input defense). */
-export const QUERY_MAX_CHARS = 1000;
+/** Query-Längen-Cap — REINE hostile-input defense, kein Relevanz-Knob.
+ *  8000 statt 1000, damit lange, legitime Hook-Prompts (gepastete Stack-
+ *  traces) ihre diskriminierenden Identifier nicht verlieren (#162). */
+export const QUERY_MAX_CHARS = 8000;
+
+/**
+ * Schneidet `text` auf höchstens `maxChars` Zeichen — an einer Whitespace-
+ * Grenze, nie mitten im Token (ein halbierter Identifier matcht nichts und
+ * vergiftet fuzzy/prefix). Fallback: enthält der Kopf gar kein Whitespace
+ * (ein Monster-Token), wird hart geschnitten — Defense bleibt Defense.
+ * Pure, wirft nie; Rückgabe ist rechts getrimmt, wenn geschnitten wurde.
+ */
+export function capAtWordBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const head = text.slice(0, maxChars);
+  // Schnitt fällt genau AUF Whitespace → letztes Token im Kopf ist komplett.
+  if (/\s/.test(text.charAt(maxChars))) return head.trimEnd();
+  // Sonst würde das Token am Schnitt halbiert → auf die letzte
+  // Whitespace-Grenze im Kopf zurückfallen.
+  const partialStart = head.search(/\S+$/);
+  // -1: Kopf endet auf Whitespace (Grenze schon sauber). 0: Monster-Token
+  // ohne jedes Whitespace → harter Schnitt.
+  if (partialStart <= 0) return head.trimEnd();
+  return head.slice(0, partialStart).trimEnd();
+}
 
 // MiniSearch-Default-Splitter ist /[\n\r\p{Z}\p{P}]+/u. Ein Token-Zeichen
 // ist alles, was der Default NICHT splittet — plus `.`, `-`, `_` als
@@ -77,13 +100,14 @@ const DANGLING_OPS = new Set([
 ]);
 
 /**
- * Pure Query-Hygiene für den Recall-Entry: Cap auf QUERY_MAX_CHARS,
- * Whitespace-Kollaps, dangling Operatoren an beiden Enden strippen.
- * Idempotent; wirft nie. Identifier-Tokens bleiben byte-identisch erhalten.
+ * Pure Query-Hygiene für den Recall-Entry: Cap auf QUERY_MAX_CHARS (an
+ * Whitespace-Grenze, nie mitten im Token), Whitespace-Kollaps, dangling
+ * Operatoren an beiden Enden strippen. Idempotent; wirft nie.
+ * Identifier-Tokens bleiben byte-identisch erhalten.
  */
 export function normalizeQuery(query: string): string {
   // Cap zuerst — alles Weitere arbeitet auf gedeckelter Länge.
-  const capped = query.slice(0, QUERY_MAX_CHARS);
+  const capped = capAtWordBoundary(query, QUERY_MAX_CHARS);
   const collapsed = capped.replace(/\s+/g, " ").trim();
   if (!collapsed) return "";
   const words = collapsed.split(" ");

--- a/packages/core/src/query-normalize.ts
+++ b/packages/core/src/query-normalize.ts
@@ -1,0 +1,97 @@
+/**
+ * Query-Normalizer + Identifier-erhaltender Tokenizer (#162).
+ *
+ * Problem: Code-Lesson-Queries tragen gepunktete/gebundene/unterstrichene
+ * Identifier (`my-app.config.ts`, `chat-send`, `P2.2`, `--force-push`).
+ * MiniSearchs Default-Tokenizer splittet auf jeder Punktuation — Index- wie
+ * Query-seitig zerfällt `my-app.config.ts` zu `my app config ts`: lauter
+ * generische Terme, die Präzision genau bei der Query-Klasse kosten, für die
+ * Recall gebaut ist.
+ *
+ * Entscheidung: Der Index splittet Identifier heute selbst (Default-
+ * Tokenizer) — ein rein query-seitiges Bewahren oder Expandieren würde also
+ * nie matchen. Stattdessen wird der Tokenizer auf BEIDEN Seiten getauscht:
+ * MiniSearch nutzt das top-level `tokenize` auch für Queries, solange kein
+ * `searchOptions.tokenize` gesetzt ist — eine Funktion, garantierte
+ * Symmetrie. `tokenizeWithIdentifiers` macht Dual-Emission: der
+ * zusammenhängende Identifier UND seine Teile werden emittiert. Recall
+ * bleibt damit ≥ Status quo (alle bisherigen Sub-Terme sind weiter im Index
+ * und in der Query), Präzision steigt über den exakten, IDF-starken
+ * Identifier-Term. Kein Migrationsproblem: der Index lebt in-memory und
+ * wird bei jedem Daemon-Start aus dem Vault neu gebaut.
+ *
+ * `normalizeQuery` ist davon unabhängige Query-Hygiene am Recall-Entry
+ * (SearchIndex.recall / recallHybrid — MCP- und Hook-Pfad laufen beide da
+ * durch): Längen-Cap gegen hostile Input, Whitespace-Kollaps, dangling
+ * boolean-artige Operatoren an den Rändern strippen.
+ */
+
+/** Query-Längen-Cap (hostile-input defense). */
+export const QUERY_MAX_CHARS = 1000;
+
+// MiniSearch-Default-Splitter ist /[\n\r\p{Z}\p{P}]+/u. Ein Token-Zeichen
+// ist alles, was der Default NICHT splittet — plus `.`, `-`, `_` als
+// Identifier-Kleber. Alles andere (Slash, Doppelpunkt, Quotes, …) trennt
+// weiterhin, damit Pfade wie `src/search.ts:42` in Segmente zerfallen.
+const TOKEN_RE = /(?:[._-]|[^\n\r\p{Z}\p{P}])+/gu;
+const GLUE_TRIM_RE = /^[._-]+|[._-]+$/g;
+const GLUE_SPLIT_RE = /[._-]+/;
+
+/**
+ * Gemeinsamer Tokenizer für Index- UND Query-Seite (Symmetrie-Invariante,
+ * siehe Header). Emittiert pro Roh-Token den von Rand-Punktuation befreiten
+ * Identifier als Ganzes; enthält er inneren Kleber (`.` `-` `_`), zusätzlich
+ * seine Teile. Lowercasing übernimmt MiniSearchs `processTerm` — hier nicht
+ * duplizieren.
+ */
+export function tokenizeWithIdentifiers(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.matchAll(TOKEN_RE)) {
+    const token = raw[0].replace(GLUE_TRIM_RE, "");
+    if (!token) continue;
+    out.push(token);
+    if (GLUE_SPLIT_RE.test(token)) {
+      for (const part of token.split(GLUE_SPLIT_RE)) {
+        if (part) out.push(part);
+      }
+    }
+  }
+  return out;
+}
+
+// Dangling boolean-artige Operatoren an den Query-Rändern. Nur
+// alleinstehende Tokens — Identifier wie `--force-push` bleiben unberührt,
+// ebenso Operatoren mitten in der Query.
+const DANGLING_OPS = new Set([
+  "and",
+  "or",
+  "not",
+  "&&",
+  "||",
+  "&",
+  "|",
+  "+",
+  "!",
+  "-",
+  "--",
+]);
+
+/**
+ * Pure Query-Hygiene für den Recall-Entry: Cap auf QUERY_MAX_CHARS,
+ * Whitespace-Kollaps, dangling Operatoren an beiden Enden strippen.
+ * Idempotent; wirft nie. Identifier-Tokens bleiben byte-identisch erhalten.
+ */
+export function normalizeQuery(query: string): string {
+  // Cap zuerst — alles Weitere arbeitet auf gedeckelter Länge.
+  const capped = query.slice(0, QUERY_MAX_CHARS);
+  const collapsed = capped.replace(/\s+/g, " ").trim();
+  if (!collapsed) return "";
+  const words = collapsed.split(" ");
+  while (words.length > 0 && DANGLING_OPS.has(words[0].toLowerCase())) {
+    words.shift();
+  }
+  while (words.length > 0 && DANGLING_OPS.has(words[words.length - 1].toLowerCase())) {
+    words.pop();
+  }
+  return words.join(" ");
+}

--- a/packages/core/src/query-normalize.ts
+++ b/packages/core/src/query-normalize.ts
@@ -56,9 +56,37 @@ export function capAtWordBoundary(text: string, maxChars: number): string {
 // ist alles, was der Default NICHT splittet — plus `.`, `-`, `_` als
 // Identifier-Kleber. Alles andere (Slash, Doppelpunkt, Quotes, …) trennt
 // weiterhin, damit Pfade wie `src/search.ts:42` in Segmente zerfallen.
-const TOKEN_RE = /(?:[._-]|[^\n\r\p{Z}\p{P}])+/gu;
+// Token-Zeichen = Nicht-Splitter ∪ {._-}. Als Einzelzeichen-Tests statt
+// einer quantifizierten Alternation-Regex: der Scan unten ist damit
+// beweisbar linear (CodeQL js/polynomial-redos flaggte die Alternation-Form,
+// obwohl die Zweige disjunkt waren; die v-Flag-Klassen-Union bräuchte
+// target es2024).
+const GLUE_CHARS = new Set([".", "-", "_"]);
+const SPLIT_CHAR_RE = /[\n\r\p{Z}\p{P}]/u;
 const GLUE_TRIM_RE = /^[._-]+|[._-]+$/g;
 const GLUE_SPLIT_RE = /[._-]+/;
+
+function isTokenChar(ch: string): boolean {
+  return GLUE_CHARS.has(ch) || !SPLIT_CHAR_RE.test(ch);
+}
+
+/** Linearer Roh-Token-Scan (Ersatz für die geflaggte matchAll-Regex). */
+function scanRawTokens(text: string): string[] {
+  const tokens: string[] = [];
+  let start = -1;
+  let i = 0;
+  for (const ch of text) {
+    if (isTokenChar(ch)) {
+      if (start < 0) start = i;
+    } else if (start >= 0) {
+      tokens.push(text.slice(start, i));
+      start = -1;
+    }
+    i += ch.length; // Surrogatpaare zählen 2 UTF-16-Einheiten
+  }
+  if (start >= 0) tokens.push(text.slice(start));
+  return tokens;
+}
 
 /**
  * Gemeinsamer Tokenizer für Index- UND Query-Seite (Symmetrie-Invariante,
@@ -69,8 +97,8 @@ const GLUE_SPLIT_RE = /[._-]+/;
  */
 export function tokenizeWithIdentifiers(text: string): string[] {
   const out: string[] = [];
-  for (const raw of text.matchAll(TOKEN_RE)) {
-    const token = raw[0].replace(GLUE_TRIM_RE, "");
+  for (const raw of scanRawTokens(text)) {
+    const token = raw.replace(GLUE_TRIM_RE, "");
     if (!token) continue;
     out.push(token);
     if (GLUE_SPLIT_RE.test(token)) {

--- a/packages/core/src/query-normalize.ts
+++ b/packages/core/src/query-normalize.ts
@@ -63,8 +63,18 @@ export function capAtWordBoundary(text: string, maxChars: number): string {
 // target es2024).
 const GLUE_CHARS = new Set([".", "-", "_"]);
 const SPLIT_CHAR_RE = /[\n\r\p{Z}\p{P}]/u;
-const GLUE_TRIM_RE = /^[._-]+|[._-]+$/g;
 const GLUE_SPLIT_RE = /[._-]+/;
+
+/** Rand-Kleber (`.` `-` `_`) per Index-Scan trimmen — die naheliegende
+ *  Regex (`/^[._-]+|[._-]+$/`) ist am `$`-Anker auf langen Kleber-Läufen
+ *  quadratisch (CodeQL js/polynomial-redos, PR-#191-Findings). */
+function trimGlue(token: string): string {
+  let start = 0;
+  let end = token.length;
+  while (start < end && GLUE_CHARS.has(token[start])) start++;
+  while (end > start && GLUE_CHARS.has(token[end - 1])) end--;
+  return token.slice(start, end);
+}
 
 function isTokenChar(ch: string): boolean {
   return GLUE_CHARS.has(ch) || !SPLIT_CHAR_RE.test(ch);
@@ -98,7 +108,7 @@ function scanRawTokens(text: string): string[] {
 export function tokenizeWithIdentifiers(text: string): string[] {
   const out: string[] = [];
   for (const raw of scanRawTokens(text)) {
-    const token = raw.replace(GLUE_TRIM_RE, "");
+    const token = trimGlue(raw);
     if (!token) continue;
     out.push(token);
     if (GLUE_SPLIT_RE.test(token)) {

--- a/packages/core/src/related-enrich.ts
+++ b/packages/core/src/related-enrich.ts
@@ -119,11 +119,20 @@ export class RelatedEnricher {
     const expectedBody = rebuildBodyWithAutoSection(memory.body, filtered);
     const sameBody = autoRelatedEquivalent(memory.body, expectedBody);
 
-    if (sameVia && sameBody) return null;
+    // #188: Doc-Sidecars heißen nach dem Original-File (`<file>.jpg.md`),
+    // nicht nach der id — Obsidian löst [[<doc-id>]]-Links nur über die
+    // `aliases`-Frontmatter-Liste auf (Standard-Obsidian-Feature). Der
+    // Enricher stellt die eigene id als Alias auf jedem Doc-Sidecar sicher,
+    // das er anfasst — inkrementeller Backfill statt Big-Bang-Migration.
+    const aliasId = memory.fm.type === "doc" ? id : undefined;
+    const missingAlias =
+      aliasId !== undefined && !(memory.fm.aliases ?? []).includes(aliasId);
+
+    if (sameVia && sameBody && !missingAlias) return null;
 
     if (this.writeGate && !(await this.writeGate())) return null;
 
-    await rewriteFile(memory.filePath, filtered, expectedBody);
+    await rewriteFile(memory.filePath, filtered, expectedBody, aliasId);
     await this.vault.reindexFile(memory.filePath);
     return filtered;
   }
@@ -204,11 +213,27 @@ async function rewriteFile(
   filePath: string,
   related_via: RelatedViaEntry[],
   newBody: string,
+  ensureAlias?: string,
 ): Promise<void> {
   const raw = await readFile(filePath, "utf8");
   const parsed = matter(raw);
-  const fm = parsed.data as Record<string, unknown>;
+  // Copy statt in-place: gray-matter cached matter(content) per Input-String —
+  // Mutation von parsed.data würde den Cache-Eintrag vergiften (siehe
+  // trigger-expand.ts).
+  const fm = { ...(parsed.data as Record<string, unknown>) };
   fm.related_via = related_via;
+  if (ensureAlias !== undefined) {
+    // Bestehende (User-)Aliases bleiben erhalten, die id wird nur ergänzt —
+    // Obsidian erlaubt auch die Bare-String-Form, deshalb normalisieren.
+    const existing = Array.isArray(fm.aliases)
+      ? fm.aliases.map(String)
+      : typeof fm.aliases === "string"
+        ? [fm.aliases]
+        : [];
+    if (!existing.includes(ensureAlias)) {
+      fm.aliases = [...existing, ensureAlias];
+    }
+  }
   const next = matter.stringify(
     newBody.startsWith("\n") ? newBody : `\n${newBody}`,
     fm,

--- a/packages/core/src/save.ts
+++ b/packages/core/src/save.ts
@@ -1,8 +1,8 @@
-import { writeFile, access, mkdir, unlink } from "node:fs/promises";
+import { writeFile, readFile, access, mkdir, unlink } from "node:fs/promises";
 import { join, dirname, resolve, sep } from "node:path";
 import { z } from "zod";
 import matter from "gray-matter";
-import { MemoryTypeEnum, isPathSafeComponent } from "./schema.js";
+import { MemoryTypeEnum, isPathSafeComponent, coerceAliases } from "./schema.js";
 import { clampSummary, SUMMARY_MAX } from "./summary.js";
 
 /**
@@ -28,6 +28,13 @@ export const SaveMemoryInput = z.object({
   }),
   recall_when: z.array(z.string().min(1)).min(1),
   related: z.array(z.string()).optional(),
+  /**
+   * Obsidian-Aliases (#188): Substrat-Plumbing, kein Agent-Knob — der Daemon
+   * exponiert das Feld NICHT im MCP-Tool-Schema. Wird vom RelatedEnricher /
+   * Documents-Flow gesetzt. Beim Overwrite ohne explizite aliases bleiben
+   * die bestehenden File-Aliases erhalten (siehe saveMemory).
+   */
+  aliases: z.array(z.string()).optional(),
   /**
    * Memory-Graph (#30 / #49): LLM-detektierte Beziehungen. Optional —
    * normalerweise nicht beim manuellen save_memory gesetzt, sondern vom
@@ -273,6 +280,22 @@ export async function saveMemory(
     );
   }
 
+  // #188: Ein Overwrite ohne explizite aliases darf die bestehenden
+  // Obsidian-Aliases des Files nicht verlieren — Doc-Sidecars tragen ihre
+  // doc-id als Alias, damit [[<doc-id>]]-Links in Obsidian auflösen.
+  // Best-effort: ein unlesbares File blockt den Save nicht.
+  let aliases = input.aliases;
+  if (aliases === undefined && exists) {
+    try {
+      const existingRaw = await readFile(filePath, "utf8");
+      aliases = coerceAliases(
+        (matter(existingRaw).data as Record<string, unknown> | undefined)?.aliases,
+      );
+    } catch {
+      // korrupt/parallel gelöscht → nichts zu erhalten
+    }
+  }
+
   const today = todayISO();
   // Wikilinks aus dem Body in `related[]` spiegeln. Im OSS-Stack existiert
   // sonst keine Stelle, die `[[id]]`-Referenzen in Strukturdaten überführt
@@ -297,6 +320,7 @@ export async function saveMemory(
     scope: input.scope,
     recall_when: input.recall_when,
     related: mergedRelated,
+    ...(aliases && aliases.length > 0 ? { aliases } : {}),
     related_via: input.related_via ?? [],
     sensitivity: input.sensitivity ?? "team",
     ...(input.valid_until ? { valid_until: input.valid_until } : {}),

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -148,6 +148,19 @@ export const FrontmatterSchema = z.object({
   linked_file: z.boolean().optional(),
   document_category: z.string().optional(),
   folder_path: z.string().optional(),
+  /**
+   * Obsidian löst `[[wikilinks]]` gegen die `aliases`-Frontmatter-Liste auf
+   * (Standard-Obsidian-Feature). Doc-Sidecars heißen nach dem Original-File
+   * (`<file>.jpg.md`), nicht nach der id — sie tragen deshalb ihre eigene
+   * doc-id als Alias, damit die `[[<doc-id>]]`-Cross-Links des
+   * RelatedEnrichers in Obsidian aufs Sidecar auflösen statt beim Klick eine
+   * leere Stray-Note anzulegen (#188). Preprocess: Obsidian akzeptiert auch
+   * die Bare-String-Form — coercen statt rejecten, damit hand-editierte
+   * Sidecars weiter laden.
+   */
+  aliases: z
+    .preprocess((v) => (typeof v === "string" ? [v] : v), z.array(z.string()))
+    .optional(),
   // Auto-Inbox: Files vom Inbox-Watcher werden ohne User-Sheet eingelesen
   // und als "ungeprüft" markiert. Mac-App rendert Pill + Tint, bietet
   // Bulk-Review-Sheet bei ≥2 needs_review im aktuellen Folder.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -58,6 +58,24 @@ export function isPathSafeComponent(value: string): boolean {
 const pathSafeMessage =
   "must not contain path separators, '..', or a leading dot";
 
+/**
+ * Tolerante aliases-Koerzierung (#188): Frontmatter ist in Obsidian hand-
+ * editierbar, also kommen aliases auch als Bare-Scalar (`aliases: foo`),
+ * Zahl (`aliases: [2024]`), YAML-Datum (`aliases: [2026-05-01]` → JS Date,
+ * siehe dateString oben) oder dangling `aliases:` (null) an. Ein Memory darf
+ * NIE über seine aliases aus dem Vault fallen — deshalb coercen statt
+ * rejecten: null/leer → undefined, Scalar → [String], Date → YYYY-MM-DD.
+ * Auch von save.ts genutzt, damit ein Overwrite bestehende Aliases erhält.
+ */
+export function coerceAliases(v: unknown): string[] | undefined {
+  if (v == null) return undefined;
+  const arr = Array.isArray(v) ? v : [v];
+  const out = arr
+    .filter((a) => a != null)
+    .map((a) => (a instanceof Date ? a.toISOString().slice(0, 10) : String(a)));
+  return out.length > 0 ? out : undefined;
+}
+
 export const FrontmatterSchema = z.object({
   id: z.string().min(1).refine(isPathSafeComponent, { message: pathSafeMessage }),
   title: z.string().min(1),
@@ -154,13 +172,11 @@ export const FrontmatterSchema = z.object({
    * (`<file>.jpg.md`), nicht nach der id — sie tragen deshalb ihre eigene
    * doc-id als Alias, damit die `[[<doc-id>]]`-Cross-Links des
    * RelatedEnrichers in Obsidian aufs Sidecar auflösen statt beim Klick eine
-   * leere Stray-Note anzulegen (#188). Preprocess: Obsidian akzeptiert auch
-   * die Bare-String-Form — coercen statt rejecten, damit hand-editierte
-   * Sidecars weiter laden.
+   * leere Stray-Note anzulegen (#188). Preprocess: coerceAliases() — Obsidian
+   * akzeptiert Bare-Scalars, YAML macht aus 2024/2026-05-01 Number/Date;
+   * coercen statt rejecten, damit hand-editierte Sidecars weiter laden.
    */
-  aliases: z
-    .preprocess((v) => (typeof v === "string" ? [v] : v), z.array(z.string()))
-    .optional(),
+  aliases: z.preprocess(coerceAliases, z.array(z.string()).optional()),
   // Auto-Inbox: Files vom Inbox-Watcher werden ohne User-Sheet eingelesen
   // und als "ungeprüft" markiert. Mac-App rendert Pill + Tint, bietet
   // Bulk-Review-Sheet bei ≥2 needs_review im aktuellen Folder.

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -4,6 +4,7 @@ import type { Vault, VaultEvent } from "./vault.js";
 import type { EmbeddingIndex } from "./embeddings.js";
 import { fuseRRF } from "./embeddings.js";
 import type { RecallStage, StageListener } from "./recall-stages.js";
+import { normalizeQuery, tokenizeWithIdentifiers } from "./query-normalize.js";
 
 export interface RecallHit {
   id: string;
@@ -136,6 +137,11 @@ export class SearchIndex {
 
   constructor(private readonly vault: Vault) {
     this.mini = new MiniSearch<IndexDoc>({
+      // #162: Identifier-erhaltender Tokenizer (Dual-Emission: `my-app.config.ts`
+      // + `my app config ts`). Gilt für Index- UND Query-Seite — MiniSearch fällt
+      // ohne `searchOptions.tokenize` auf diese Funktion zurück; KEIN separates
+      // searchOptions.tokenize setzen, sonst bricht die Symmetrie (query-normalize.ts).
+      tokenize: tokenizeWithIdentifiers,
       fields: [
         "title",
         "summary",
@@ -199,6 +205,10 @@ export class SearchIndex {
   }
 
   recall(query: string, opts: RecallOptions = {}): RecallHit[] {
+    // #162: Query-Hygiene für ALLE Caller (MCP-Recall, Hooks, Bridge, Dedup) —
+    // Längen-Cap, Whitespace-Kollaps, dangling Operatoren. Vor dem Cache-Key,
+    // damit äquivalente Queries denselben Eintrag teilen.
+    query = normalizeQuery(query);
     const k = opts.k ?? 5;
     const stage = new StageEmitter(opts.onStage);
     const recallStart = Date.now();
@@ -287,6 +297,10 @@ export class SearchIndex {
    *  Hook-Score-Threshold (≥100 = REQUIRED) sinnvoll greift. */
   async recallHybrid(query: string, opts: RecallOptions = {}): Promise<RecallHit[]> {
     if (!this.embeddings) return this.recall(query, opts);
+    // #162: gleiche Query-Hygiene wie in recall() — auch der Vector-Arm
+    // profitiert vom Längen-Cap (idempotent, deshalb kein Doppel-Schaden
+    // beim BM25-Fallback oben).
+    query = normalizeQuery(query);
     const k = opts.k ?? 5;
     const stage = new StageEmitter(opts.onStage);
     const recallStart = Date.now();

--- a/packages/daemon/__tests__/bash-pre-hook.test.ts
+++ b/packages/daemon/__tests__/bash-pre-hook.test.ts
@@ -1,6 +1,15 @@
 import { describe, it } from "node:test";
 import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { matchPattern, formatHintBlock } from "../src/bash-pre-hook.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = resolve(__dirname, "..", "src", "bash-pre-hook.ts");
 
 describe("bash-pre-hook: matchPattern", () => {
   it("matches rm -rf as destructive", () => {
@@ -147,5 +156,116 @@ describe("bash-pre-hook: formatHintBlock", () => {
     assert.equal(out.match(/<\/recall-hints>/g)!.length, 1);
     assert.ok(out.endsWith("</recall-hints>"));
     assert.ok(!out.includes("<system-reminder>"));
+  });
+});
+
+// ─── #161: the tripwire is EXEMPT from backoff — the STOP warning always emits ──
+
+function startMockDaemon(handler: (req: IncomingMessage, res: ServerResponse) => void) {
+  const server = createServer(handler);
+  return new Promise<{ port: number; close: () => Promise<void> }>((ok) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      ok({
+        port,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+function runHook(
+  payload: object,
+  env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((ok, ko) => {
+    const child = spawn("npx", ["tsx", HOOK_PATH], {
+      env: { ...process.env, ...env, BASTRA_TELEMETRY: "off" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", ko);
+    child.on("close", (code) => ok({ stdout, stderr, code: code ?? -1 }));
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+describe("bash-pre-hook: backoff exemption (#161)", () => {
+  it("destructive STOP warning + enrichment emit despite a hot suppression window", async () => {
+    // Pre-seed a session state that WOULD suppress any backoff-consulting
+    // emitter (streak far above BACKOFF_MIN_STREAK, window wide open).
+    const stateDir = await mkdtemp(join(tmpdir(), "bastra-bashpre-backoff-"));
+    const sessionId = "bashpre-backoff-exempt";
+    await writeFile(
+      join(stateDir, `${sessionId}.json`),
+      JSON.stringify({
+        shown: {},
+        sources: {
+          "bash-tripwire": { streak: 6, at: Date.now() - 1000, ids: ["safety-1"], skipped: 0 },
+        },
+      }),
+      "utf8",
+    );
+
+    const daemon = await startMockDaemon((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (req.url === "/hook/recall") {
+        // Sub-REQUIRED score (80 < 100): the emission must still not be
+        // suppressible — the tripwire is exempt, not merely REQUIRED-bypassed.
+        res.end(
+          JSON.stringify({
+            hits: [
+              {
+                id: "safety-1",
+                title: "no rm -rf",
+                type: "user-preference",
+                scope: "all-projects",
+                summary: "Never rm -rf without explicit ok.",
+                score: 80,
+              },
+            ],
+            vault_size: 10,
+            latency_ms: 1,
+            recall_id: "t",
+          }),
+        );
+      } else {
+        res.end("{}");
+      }
+    });
+
+    try {
+      const { stdout } = await runHook(
+        {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          session_id: sessionId,
+          tool_input: { command: "rm -rf /tmp/whatever" },
+        },
+        {
+          BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}`,
+          BASTRA_HOOK_STATE_DIR: stateDir,
+        },
+      );
+      const parsed = JSON.parse(stdout) as {
+        hookSpecificOutput?: { additionalContext?: string };
+      };
+      assert.ok(parsed.hookSpecificOutput, "STOP warning must emit — never suppressed");
+      const ctx = parsed.hookSpecificOutput?.additionalContext ?? "";
+      assert.match(ctx, /STOP — destructive/);
+      // Enrichment always rides along with the warning (no trimming either).
+      assert.match(ctx, /safety-1/);
+    } finally {
+      await daemon.close();
+      await rm(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/daemon/__tests__/documents-alias.test.ts
+++ b/packages/daemon/__tests__/documents-alias.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Issue #188: neue Doc-Sidecars tragen ab Write-Time ihre eigene doc-id als
+ * Obsidian-Alias (`aliases: [<id>]`), damit `[[<doc-id>]]`-Wikilinks in
+ * Obsidian aufs Sidecar auflösen statt eine leere Stray-Note anzulegen.
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/documents-alias.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import matter from "gray-matter";
+import { Vault } from "@bastra-recall/core";
+
+import { saveDocument, buildFrontmatter } from "../src/documents-write-handler.js";
+
+test("saveDocument schreibt aliases: [<doc-id>] ins Sidecar-Frontmatter", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-doc-save-"));
+  try {
+    const source = join(dir, "PHOTO-2026-01-27.jpg");
+    await writeFile(source, "fake-jpg-bytes");
+    const vaultDir = join(dir, "vault");
+    const vault = new Vault(vaultDir);
+    await vault.init();
+
+    const result = await saveDocument(vault, {
+      original_path: source,
+      folder_path: "Inbox",
+      title: "Photo",
+      tags: ["foto"],
+      category: "bild",
+      linked_file: false,
+      overwrite: false,
+    });
+
+    const fm = matter(await readFile(result.sidecar_path, "utf8")).data as {
+      id: string;
+      aliases?: string[];
+    };
+    assert.equal(fm.id, result.id);
+    assert.deepEqual(fm.aliases, [result.id]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildFrontmatter übernimmt bestehende Aliases und hängt die id nur einmal an", () => {
+  const base = {
+    id: "doc-inbox-photo-jpg",
+    title: "Photo",
+    summary: "s",
+    tags: ["foto"],
+    category: "bild",
+    recallWhen: ["find photo"],
+    originalPath: "/v/documents/Inbox/photo.jpg",
+    linkedFile: false,
+    folderPath: "Inbox",
+    created: "2026-05-01",
+    updated: "2026-05-01",
+  };
+
+  // User-Alias aus Obsidian überlebt recategorize/move.
+  const withUser = buildFrontmatter({ ...base, aliases: ["Foto Mai"] });
+  assert.deepEqual(withUser.aliases, ["Foto Mai", "doc-inbox-photo-jpg"]);
+
+  // Bereits vorhandene id wird nicht dupliziert.
+  const withId = buildFrontmatter({ ...base, aliases: ["doc-inbox-photo-jpg"] });
+  assert.deepEqual(withId.aliases, ["doc-inbox-photo-jpg"]);
+
+  // Ohne Bestand: genau die eigene id.
+  const fresh = buildFrontmatter(base);
+  assert.deepEqual(fresh.aliases, ["doc-inbox-photo-jpg"]);
+});

--- a/packages/daemon/__tests__/embedding-breaker.test.ts
+++ b/packages/daemon/__tests__/embedding-breaker.test.ts
@@ -9,6 +9,11 @@
  * - BreakerGuardedProvider: offener Breaker skipt den inneren Provider
  *   komplett (kein Call, kein Timeout), Probe geht nach Cooldown durch,
  *   leerer Input umgeht den Breaker in beide Richtungen.
+ * - Hardening (#165 Review): reset() re-closed hart (Autostart-Fenster),
+ *   der data-shaped Batch-Mismatch ("expected N embeddings, got M") zählt
+ *   nie Richtung OPEN, BreakerOpenError trägt die Root-Cause des letzten
+ *   Fehlers (für /health), und der embedding_degraded-Flag wird VOR dem
+ *   Recall ausgewertet.
  * - Wiring ohne Netzwerk: recallHybrid über echtes Vault + SearchIndex +
  *   EmbeddingIndex degradiert bei offenem Breaker auf BM25-only und liefert
  *   weiter Hits; der Probe-Erfolg re-aktiviert das Vector-Leg.
@@ -25,9 +30,12 @@ import {
   EmbeddingBreaker,
   BreakerGuardedProvider,
   BreakerOpenError,
+  isBatchShapeMismatch,
   BREAKER_FAILURE_THRESHOLD,
   BREAKER_COOLDOWN_MS,
 } from "../src/embedding-breaker.js";
+import { recallHandler, type ToolDeps } from "../src/tool-handlers.js";
+import { Telemetry } from "../src/telemetry.js";
 
 const T0 = 1_000_000;
 
@@ -123,6 +131,27 @@ test("snapshot surfaces state, failures and remaining cooldown", () => {
   assert.equal(b.snapshot(T0 + BREAKER_COOLDOWN_MS).cooldown_remaining_ms, 0);
 });
 
+test("reset() re-closes an open breaker hard — autostart window (#165)", () => {
+  const b = new EmbeddingBreaker();
+  for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
+    b.recordFailure(T0 + i, "connect ECONNREFUSED 127.0.0.1:11434");
+  }
+  assert.equal(b.state(T0 + 10), "open");
+  // Daemon-Boot: ensureOllamaServerForDaemon meldet started / "already
+  // running" → index.ts resettet. Ohne den Reset würden frühe Boot-Fehler
+  // die ersten Recalls der Session 60s auf BM25 pinnen, obwohl der Server
+  // Sekunden später steht.
+  b.reset();
+  assert.deepEqual(b.snapshot(T0 + 10), {
+    state: "closed",
+    consecutive_failures: 0,
+    opened_at_ms: null,
+    cooldown_remaining_ms: null,
+  });
+  assert.equal(b.shouldAttempt(T0 + 10), true);
+  assert.equal(b.lastFailureMessage(), null);
+});
+
 // ─── Guarded provider (fake inner, fake clock) ───────────────────
 
 /** Deterministischer Provider: dim 4, Fehler schaltbar, Call-Zähler. */
@@ -131,10 +160,13 @@ class FakeProvider implements EmbeddingProvider {
   readonly dim = 4;
   calls = 0;
   failing = false;
+  /** Überschreibt die Fehlermeldung (z.B. Batch-Mismatch-Shape). */
+  failWith: string | null = null;
   async embed(texts: string[]): Promise<Float32Array[]> {
     // Contract der echten Provider: leerer Input → [] ohne Roundtrip.
     if (texts.length === 0) return [];
     this.calls++;
+    if (this.failWith !== null) throw new Error(this.failWith);
     if (this.failing) throw new Error("fake provider down");
     return texts.map((t) => {
       // Grobe, aber stabile Text-Abbildung — genug für Cosine-Ranking.
@@ -183,6 +215,70 @@ test("guarded provider: empty input bypasses the breaker in both directions", as
   assert.deepEqual(await guarded.embed([]), []);
   // … und zählt nicht als Erfolg: der Breaker bleibt offen.
   assert.equal(breaker.state(now), "open");
+});
+
+test("isBatchShapeMismatch matches exactly the core mismatch shape", () => {
+  assert.equal(isBatchShapeMismatch(new Error("Ollama embed: expected 4 embeddings, got 2")), true);
+  assert.equal(isBatchShapeMismatch(new Error("Ollama embed: expected 1 embeddings, got none")), true);
+  assert.equal(isBatchShapeMismatch("expected 50 embeddings, got 49"), true);
+  // Availability-Fehler zählen weiter Richtung OPEN.
+  assert.equal(isBatchShapeMismatch(new Error("Ollama embed HTTP 500 (http://127.0.0.1:11434/api/embed): boom")), false);
+  assert.equal(isBatchShapeMismatch(new Error("fetch failed")), false);
+  assert.equal(isBatchShapeMismatch(new Error("connect ECONNREFUSED 127.0.0.1:11434")), false);
+});
+
+test("guarded provider: poisoned-batch mismatch is data-shaped — never trips the breaker", async () => {
+  const now = T0;
+  const inner = new FakeProvider();
+  const breaker = new EmbeddingBreaker();
+  const guarded = new BreakerGuardedProvider(inner, breaker, () => now);
+
+  // Deterministischer Pro-Batch-Fehler (z.B. ein vergiftetes Dokument im
+  // Backfill): egal wie oft er auftritt, der Breaker bleibt closed — der
+  // Provider ist verfügbar, nur die Daten sind kaputt. Der Fehler selbst
+  // propagiert unverändert (Requeue-Verhalten des EmbeddingIndex bleibt).
+  inner.failWith = "Ollama embed: expected 2 embeddings, got 1";
+  for (let i = 0; i < BREAKER_FAILURE_THRESHOLD + 2; i++) {
+    await assert.rejects(guarded.embed(["a", "b"]), /expected 2 embeddings, got 1/);
+  }
+  assert.equal(breaker.state(now), "closed");
+  assert.equal(breaker.snapshot(now).consecutive_failures, 0);
+
+  // Echte Availability-Fehler zählen weiterhin — auch mit Mismatch dazwischen.
+  inner.failWith = "fake provider down";
+  await assert.rejects(guarded.embed(["q"]));
+  inner.failWith = "Ollama embed: expected 1 embeddings, got none";
+  await assert.rejects(guarded.embed(["q"]));
+  inner.failWith = "fake provider down";
+  await assert.rejects(guarded.embed(["q"]));
+  await assert.rejects(guarded.embed(["q"]));
+  assert.equal(breaker.state(now), "open");
+});
+
+test("BreakerOpenError carries the last root cause — /health keeps showing WHY", async () => {
+  let now = T0;
+  const inner = new FakeProvider();
+  const breaker = new EmbeddingBreaker();
+  const guarded = new BreakerGuardedProvider(inner, breaker, () => now);
+  inner.failing = true;
+  for (let i = 0; i < 3; i++) await assert.rejects(guarded.embed(["q"]), /fake provider down/);
+  assert.equal(breaker.lastFailureMessage(), "fake provider down");
+
+  // EmbeddingIndex speichert err.message als runtime lastError (/health →
+  // embedding_error) — die Root-Cause muss im BreakerOpenError mitreisen,
+  // sonst überschreibt der generische Circuit-Text das actionable WARUM.
+  await assert.rejects(guarded.embed(["q"]), (err: unknown) => {
+    assert.ok(err instanceof BreakerOpenError);
+    assert.match((err as Error).message, /embedding breaker open/);
+    assert.match((err as Error).message, /last error: fake provider down/);
+    return true;
+  });
+
+  // Nach Erholung (Probe-Erfolg) ist die Root-Cause gecleart.
+  now = T0 + BREAKER_COOLDOWN_MS;
+  inner.failing = false;
+  await guarded.embed(["q"]);
+  assert.equal(breaker.lastFailureMessage(), null);
 });
 
 // ─── Wiring: recallHybrid degradiert bei offenem Breaker (kein Netzwerk) ──
@@ -258,6 +354,9 @@ test("hybrid recall serves BM25-only while open, probe re-enables the vector leg
     assert.equal(inner.calls, callsBefore + 3, "no provider call while open");
     // So verdrahtet index.ts den Telemetrie-Flag-Getter (embedding_degraded).
     assert.equal(search.hasEmbeddings() && breaker.state(now) === "open", true);
+    // /health-Pfad: der BreakerOpenError landet als runtime lastError — und
+    // trägt die Root-Cause statt sie mit dem Circuit-Text zu überschreiben.
+    assert.match(embIdx.runtimeHealth().lastError ?? "", /last error: fake provider down/);
 
     // Cooldown vorbei + Provider gesund → genau ein Probe-Call, re-closed.
     now = T0 + BREAKER_COOLDOWN_MS;
@@ -268,6 +367,58 @@ test("hybrid recall serves BM25-only while open, probe re-enables the vector leg
     assert.equal(breaker.state(now), "closed");
   } finally {
     embIdx?.stop();
+    search.stop();
+    await vault.stop?.();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── embedding_degraded wird VOR dem Recall ausgewertet (#165 Race) ──
+
+test("recall telemetry: embedding_degraded describes the served recall, not the post-recall breaker state", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-breaker-order-"));
+  const vault = new Vault(dir);
+  const search = new SearchIndex(vault);
+  try {
+    await writeFile(join(dir, "alpha.md"), memoryFile("alpha", "alpha bravo"), "utf8");
+    await vault.init();
+    search.start();
+
+    // Der Breaker öffnet erst WÄHREND des Recalls (z.B. paralleler Backfill-
+    // Batch-Fehler). Der servierte Recall lief noch gesund hybrid — würde der
+    // Flag nach dem Recall ausgewertet, wäre er fälschlich degraded.
+    let breakerOpen = false;
+    const searchStub = {
+      hasEmbeddings: () => true,
+      recallHybrid: async (q: string, opts: unknown) => {
+        const hits = search.recall(q, opts as never);
+        breakerOpen = true;
+        return hits;
+      },
+    } as unknown as SearchIndex;
+
+    const telemetry = new Telemetry();
+    let logged: { embedding_degraded?: boolean } | null = null;
+    (telemetry as unknown as { logRecall: (p: unknown) => Promise<void> }).logRecall = async (p) => {
+      logged = p as { embedding_degraded?: boolean };
+    };
+
+    const deps = {
+      vault,
+      search: searchStub,
+      telemetry,
+      vaultPath: dir,
+      embeddingDegraded: () => breakerOpen,
+    } as ToolDeps;
+
+    await recallHandler(deps, { query: "alpha bravo" });
+    assert.ok(logged, "logRecall must have been called");
+    assert.equal(
+      (logged as { embedding_degraded?: boolean }).embedding_degraded,
+      undefined,
+      "flag must be captured BEFORE the recall runs",
+    );
+  } finally {
     search.stop();
     await vault.stop?.();
     await rm(dir, { recursive: true, force: true });

--- a/packages/daemon/__tests__/embedding-breaker.test.ts
+++ b/packages/daemon/__tests__/embedding-breaker.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests für den Embedding-Circuit-Breaker (#165).
+ *
+ * Verifiziert:
+ * - State-Machine-Matrix (hermetisch, injizierte nowMs): closed → open nach
+ *   K konsekutiven Fehlern, Cooldown-Gating, half-open mit genau EINEM Probe,
+ *   re-close bei Probe-Erfolg, re-open (frischer Cooldown) bei Probe-Fehler,
+ *   Erfolg resettet den Counter, stale Probe-Claims verfallen.
+ * - BreakerGuardedProvider: offener Breaker skipt den inneren Provider
+ *   komplett (kein Call, kein Timeout), Probe geht nach Cooldown durch,
+ *   leerer Input umgeht den Breaker in beide Richtungen.
+ * - Wiring ohne Netzwerk: recallHybrid über echtes Vault + SearchIndex +
+ *   EmbeddingIndex degradiert bei offenem Breaker auf BM25-only und liefert
+ *   weiter Hits; der Probe-Erfolg re-aktiviert das Vector-Leg.
+ *
+ * Runner: `tsx --test __tests__/embedding-breaker.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex, EmbeddingIndex, type EmbeddingProvider } from "@bastra-recall/core";
+import {
+  EmbeddingBreaker,
+  BreakerGuardedProvider,
+  BreakerOpenError,
+  BREAKER_FAILURE_THRESHOLD,
+  BREAKER_COOLDOWN_MS,
+} from "../src/embedding-breaker.js";
+
+const T0 = 1_000_000;
+
+// ─── State-Machine-Matrix ────────────────────────────────────────
+
+test("closed: attempts allowed, failures below K stay closed", () => {
+  const b = new EmbeddingBreaker();
+  assert.equal(b.shouldAttempt(T0), true);
+  b.recordFailure(T0);
+  b.recordFailure(T0 + 1);
+  assert.equal(b.state(T0 + 2), "closed");
+  assert.equal(b.shouldAttempt(T0 + 2), true);
+});
+
+test("success anywhere resets the consecutive-failure counter", () => {
+  const b = new EmbeddingBreaker();
+  b.recordFailure(T0);
+  b.recordFailure(T0 + 1);
+  b.recordSuccess();
+  // Zwei weitere Fehler nach dem Reset: 2 < K=3 → bleibt closed.
+  b.recordFailure(T0 + 2);
+  b.recordFailure(T0 + 3);
+  assert.equal(b.state(T0 + 4), "closed");
+  assert.equal(b.snapshot(T0 + 4).consecutive_failures, 2);
+});
+
+test("opens after K consecutive failures — attempts denied without provider cost", () => {
+  const b = new EmbeddingBreaker();
+  for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) b.recordFailure(T0 + i);
+  assert.equal(b.state(T0 + 10), "open");
+  assert.equal(b.shouldAttempt(T0 + 10), false);
+});
+
+test("cooldown gates: denied one ms before, single probe allowed at cooldown", () => {
+  const b = new EmbeddingBreaker();
+  for (let i = 0; i < 3; i++) b.recordFailure(T0);
+  assert.equal(b.shouldAttempt(T0 + BREAKER_COOLDOWN_MS - 1), false);
+  assert.equal(b.shouldAttempt(T0 + BREAKER_COOLDOWN_MS), true, "probe after cooldown");
+  // Probe in flight: kein zweiter Versuch.
+  assert.equal(b.shouldAttempt(T0 + BREAKER_COOLDOWN_MS + 1), false, "exactly one probe");
+  assert.equal(b.state(T0 + BREAKER_COOLDOWN_MS + 1), "half-open");
+});
+
+test("half-open probe success re-closes and resets the counter", () => {
+  const b = new EmbeddingBreaker();
+  for (let i = 0; i < 3; i++) b.recordFailure(T0);
+  assert.equal(b.shouldAttempt(T0 + BREAKER_COOLDOWN_MS), true);
+  b.recordSuccess();
+  assert.equal(b.state(T0 + BREAKER_COOLDOWN_MS + 1), "closed");
+  // Counter ist zurückgesetzt: ein einzelner Folge-Fehler öffnet nicht.
+  b.recordFailure(T0 + BREAKER_COOLDOWN_MS + 2);
+  assert.equal(b.state(T0 + BREAKER_COOLDOWN_MS + 3), "closed");
+});
+
+test("half-open probe failure re-opens with a fresh cooldown", () => {
+  const b = new EmbeddingBreaker();
+  for (let i = 0; i < 3; i++) b.recordFailure(T0);
+  const tProbe = T0 + BREAKER_COOLDOWN_MS;
+  assert.equal(b.shouldAttempt(tProbe), true);
+  b.recordFailure(tProbe + 500);
+  assert.equal(b.state(tProbe + 501), "open");
+  // Frisches Fenster ab dem Probe-Fehler, nicht ab dem ersten openedAt.
+  assert.equal(b.shouldAttempt(tProbe + 500 + BREAKER_COOLDOWN_MS - 1), false);
+  assert.equal(b.shouldAttempt(tProbe + 500 + BREAKER_COOLDOWN_MS), true);
+});
+
+test("stale probe claim expires after a full cooldown (crashed prober)", () => {
+  const b = new EmbeddingBreaker();
+  for (let i = 0; i < 3; i++) b.recordFailure(T0);
+  const tProbe = T0 + BREAKER_COOLDOWN_MS;
+  assert.equal(b.shouldAttempt(tProbe), true);
+  // Der Prober meldet sich nie zurück — nach einem weiteren Cooldown darf
+  // ein neuer Probe ran, sonst bliebe der Breaker für immer zu.
+  assert.equal(b.shouldAttempt(tProbe + BREAKER_COOLDOWN_MS - 1), false);
+  assert.equal(b.shouldAttempt(tProbe + BREAKER_COOLDOWN_MS), true);
+});
+
+test("snapshot surfaces state, failures and remaining cooldown", () => {
+  const b = new EmbeddingBreaker();
+  assert.deepEqual(b.snapshot(T0), {
+    state: "closed",
+    consecutive_failures: 0,
+    opened_at_ms: null,
+    cooldown_remaining_ms: null,
+  });
+  for (let i = 0; i < 3; i++) b.recordFailure(T0);
+  const snap = b.snapshot(T0 + 10_000);
+  assert.equal(snap.state, "open");
+  assert.equal(snap.consecutive_failures, 3);
+  assert.equal(snap.opened_at_ms, T0);
+  assert.equal(snap.cooldown_remaining_ms, BREAKER_COOLDOWN_MS - 10_000);
+  assert.equal(b.snapshot(T0 + BREAKER_COOLDOWN_MS).state, "half-open");
+  assert.equal(b.snapshot(T0 + BREAKER_COOLDOWN_MS).cooldown_remaining_ms, 0);
+});
+
+// ─── Guarded provider (fake inner, fake clock) ───────────────────
+
+/** Deterministischer Provider: dim 4, Fehler schaltbar, Call-Zähler. */
+class FakeProvider implements EmbeddingProvider {
+  readonly id = "fake-test";
+  readonly dim = 4;
+  calls = 0;
+  failing = false;
+  async embed(texts: string[]): Promise<Float32Array[]> {
+    // Contract der echten Provider: leerer Input → [] ohne Roundtrip.
+    if (texts.length === 0) return [];
+    this.calls++;
+    if (this.failing) throw new Error("fake provider down");
+    return texts.map((t) => {
+      // Grobe, aber stabile Text-Abbildung — genug für Cosine-Ranking.
+      const v = new Float32Array(4);
+      for (let i = 0; i < t.length; i++) v[i % 4] += t.charCodeAt(i) / 1000;
+      return v;
+    });
+  }
+}
+
+test("guarded provider: opens after 3 failures, skips inner entirely, probe re-closes", async () => {
+  let now = T0;
+  const inner = new FakeProvider();
+  const breaker = new EmbeddingBreaker();
+  const guarded = new BreakerGuardedProvider(inner, breaker, () => now);
+  assert.equal(guarded.id, inner.id, "id must mirror inner (persistence header)");
+  assert.equal(guarded.dim, inner.dim);
+
+  inner.failing = true;
+  for (let i = 0; i < 3; i++) {
+    await assert.rejects(guarded.embed(["q"]), /fake provider down/);
+  }
+  assert.equal(inner.calls, 3);
+  // Offen: kein inner-Call mehr, sofortiger BreakerOpenError.
+  await assert.rejects(guarded.embed(["q"]), BreakerOpenError);
+  assert.equal(inner.calls, 3, "open breaker must not touch the provider");
+
+  // Cooldown vorbei, Provider wieder gesund → Probe geht durch, re-closed.
+  now = T0 + BREAKER_COOLDOWN_MS;
+  inner.failing = false;
+  const out = await guarded.embed(["q"]);
+  assert.equal(out.length, 1);
+  assert.equal(inner.calls, 4);
+  assert.equal(breaker.state(now), "closed");
+});
+
+test("guarded provider: empty input bypasses the breaker in both directions", async () => {
+  let now = T0;
+  const inner = new FakeProvider();
+  const breaker = new EmbeddingBreaker();
+  const guarded = new BreakerGuardedProvider(inner, breaker, () => now);
+  inner.failing = true;
+  for (let i = 0; i < 3; i++) await assert.rejects(guarded.embed(["q"]));
+  now = T0 + 1;
+  // Leerer Input wirft nicht (Provider-Contract: [] ohne Roundtrip) …
+  assert.deepEqual(await guarded.embed([]), []);
+  // … und zählt nicht als Erfolg: der Breaker bleibt offen.
+  assert.equal(breaker.state(now), "open");
+});
+
+// ─── Wiring: recallHybrid degradiert bei offenem Breaker (kein Netzwerk) ──
+
+function memoryFile(id: string, title: string): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    "type: lesson",
+    `summary: ${title} summary text`,
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: breaker-test",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const t0 = Date.now();
+  while (!cond()) {
+    if (Date.now() - t0 > timeoutMs) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+test("hybrid recall serves BM25-only while open, probe re-enables the vector leg", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-breaker-test-"));
+  const vault = new Vault(dir);
+  const search = new SearchIndex(vault);
+  let embIdx: EmbeddingIndex | null = null;
+  try {
+    await writeFile(join(dir, "alpha.md"), memoryFile("alpha", "alpha bravo"), "utf8");
+    await writeFile(join(dir, "charlie.md"), memoryFile("charlie", "charlie delta"), "utf8");
+    await vault.init();
+    search.start();
+
+    let now = T0;
+    const inner = new FakeProvider();
+    const breaker = new EmbeddingBreaker();
+    const guarded = new BreakerGuardedProvider(inner, breaker, () => now);
+    embIdx = new EmbeddingIndex(vault, guarded, join(dir, ".bastra", "embeddings.json"));
+    await embIdx.start();
+    // Backfill läuft fire-and-forget — auf die Vektoren warten, damit der
+    // Query-Pfad überhaupt einen Provider-Call macht (leerer Index skipt ihn).
+    await waitFor(() => embIdx!.size() === 2);
+    search.useEmbeddings(embIdx);
+
+    // 3 konsekutive Query-Fehler öffnen den Breaker. Distinkte Queries
+    // umgehen den SearchIndex-Query-Cache.
+    inner.failing = true;
+    const callsBefore = inner.calls;
+    for (let i = 1; i <= 3; i++) {
+      const hits = await search.recallHybrid(`alpha probefail${i}`, { k: 3 });
+      assert.ok(hits.some((h) => h.id === "alpha"), "BM25 leg must still deliver");
+    }
+    assert.equal(inner.calls, callsBefore + 3);
+    assert.equal(breaker.state(now), "open");
+
+    // Offen: Recall degradiert silent auf BM25-only OHNE Embed-Versuch.
+    const degraded = await search.recallHybrid("alpha degraded", { k: 3 });
+    assert.ok(degraded.some((h) => h.id === "alpha"));
+    assert.equal(inner.calls, callsBefore + 3, "no provider call while open");
+    // So verdrahtet index.ts den Telemetrie-Flag-Getter (embedding_degraded).
+    assert.equal(search.hasEmbeddings() && breaker.state(now) === "open", true);
+
+    // Cooldown vorbei + Provider gesund → genau ein Probe-Call, re-closed.
+    now = T0 + BREAKER_COOLDOWN_MS;
+    inner.failing = false;
+    const recovered = await search.recallHybrid("alpha recovered", { k: 3 });
+    assert.ok(recovered.some((h) => h.id === "alpha"));
+    assert.equal(inner.calls, callsBefore + 4, "probe reached the provider");
+    assert.equal(breaker.state(now), "closed");
+  } finally {
+    embIdx?.stop();
+    search.stop();
+    await vault.stop?.();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/__tests__/hook-backoff.test.ts
+++ b/packages/daemon/__tests__/hook-backoff.test.ts
@@ -3,7 +3,8 @@
  *
  * Covers:
  *   - decideBackoff matrix: no entry, min-streak threshold, skipped window,
- *     cap at BACKOFF_STREAK_CAP, consumption reset, malformed entries
+ *     cap at BACKOFF_STREAK_CAP, consumption reset, malformed entries,
+ *     REQUIRED-band bypass (hasRequired)
  *   - recordSourceEmit: streak growth, reset on consumption, ids cap
  *   - recordSourceSuppressed: skipped counter, defensive no-op
  *   - suppression cadence over a simulated event stream (E E E S S E …)
@@ -38,42 +39,68 @@ function entry(streak: number, skipped: number, at = 1_000_000): ss.SourceBackof
 // ── decideBackoff matrix ────────────────────────────────────────────────────
 
 test("decideBackoff: no entry → never suppress", () => {
-  assert.deepEqual(ss.decideBackoff(undefined, false), { suppress: false, streak: 0 });
+  assert.deepEqual(ss.decideBackoff(undefined, false, false), { suppress: false, streak: 0 });
 });
 
 test("decideBackoff: streak below MIN_STREAK → emit", () => {
-  assert.equal(ss.decideBackoff(entry(0, 0), false).suppress, false);
-  assert.equal(ss.decideBackoff(entry(ss.BACKOFF_MIN_STREAK - 1, 0), false).suppress, false);
+  assert.equal(ss.decideBackoff(entry(0, 0), false, false).suppress, false);
+  assert.equal(ss.decideBackoff(entry(ss.BACKOFF_MIN_STREAK - 1, 0), false, false).suppress, false);
 });
 
 test("decideBackoff: streak at MIN_STREAK, window open → suppress", () => {
-  const d = ss.decideBackoff(entry(ss.BACKOFF_MIN_STREAK, 0), false);
+  const d = ss.decideBackoff(entry(ss.BACKOFF_MIN_STREAK, 0), false, false);
   assert.equal(d.suppress, true);
   assert.equal(d.streak, ss.BACKOFF_MIN_STREAK);
 });
 
 test("decideBackoff: skipped < streak keeps suppressing, then probes", () => {
-  assert.equal(ss.decideBackoff(entry(3, 0), false).suppress, true);
-  assert.equal(ss.decideBackoff(entry(3, 2), false).suppress, true);
+  assert.equal(ss.decideBackoff(entry(3, 0), false, false).suppress, true);
+  assert.equal(ss.decideBackoff(entry(3, 2), false, false).suppress, true);
   // window exhausted → probe emit
-  assert.equal(ss.decideBackoff(entry(3, 3), false).suppress, false);
+  assert.equal(ss.decideBackoff(entry(3, 3), false, false).suppress, false);
 });
 
 test("decideBackoff: cap — streak beyond CAP needs only CAP skips", () => {
-  assert.equal(ss.decideBackoff(entry(12, ss.BACKOFF_STREAK_CAP - 1), false).suppress, true);
-  assert.equal(ss.decideBackoff(entry(12, ss.BACKOFF_STREAK_CAP), false).suppress, false);
+  assert.equal(ss.decideBackoff(entry(12, ss.BACKOFF_STREAK_CAP - 1), false, false).suppress, true);
+  assert.equal(ss.decideBackoff(entry(12, ss.BACKOFF_STREAK_CAP), false, false).suppress, false);
 });
 
 test("decideBackoff: consumption resets streak to 0 → emit", () => {
-  const d = ss.decideBackoff(entry(7, 1), true);
+  const d = ss.decideBackoff(entry(7, 1), true, false);
   assert.deepEqual(d, { suppress: false, streak: 0 });
 });
 
 test("decideBackoff: malformed entry fails open", () => {
   const broken = { streak: "x", at: 1, skipped: 0 } as unknown as ss.SourceBackoff;
-  assert.deepEqual(ss.decideBackoff(broken, false), { suppress: false, streak: 0 });
+  assert.deepEqual(ss.decideBackoff(broken, false, false), { suppress: false, streak: 0 });
   const noEmit = entry(5, 0, 0); // at <= 0 → never emitted
-  assert.deepEqual(ss.decideBackoff(noEmit, false), { suppress: false, streak: 0 });
+  assert.deepEqual(ss.decideBackoff(noEmit, false, false), { suppress: false, streak: 0 });
+});
+
+// ── REQUIRED-band bypass (hasRequired) ──────────────────────────────────────
+
+test("decideBackoff: hasRequired bypasses suppression at every streak level", () => {
+  // Every state that would suppress without a REQUIRED hit must emit with one.
+  const wouldSuppress = [
+    entry(ss.BACKOFF_MIN_STREAK, 0),
+    entry(3, 2),
+    entry(12, ss.BACKOFF_STREAK_CAP - 1),
+    entry(50, 0),
+  ];
+  for (const e of wouldSuppress) {
+    assert.equal(ss.decideBackoff(e, false, false).suppress, true, "precondition: suppresses");
+    const d = ss.decideBackoff(e, false, true);
+    assert.equal(d.suppress, false, `hasRequired must bypass (streak ${e.streak})`);
+    // Streak resolution is unchanged — bypass is not a consumption signal.
+    assert.equal(d.streak, e.streak);
+  }
+});
+
+test("decideBackoff: hasRequired matrix — no entry / consumed / malformed stay identical", () => {
+  assert.deepEqual(ss.decideBackoff(undefined, false, true), { suppress: false, streak: 0 });
+  assert.deepEqual(ss.decideBackoff(entry(7, 1), true, true), { suppress: false, streak: 0 });
+  const broken = { streak: "x", at: 1, skipped: 0 } as unknown as ss.SourceBackoff;
+  assert.deepEqual(ss.decideBackoff(broken, false, true), { suppress: false, streak: 0 });
 });
 
 // ── recordSourceEmit / recordSourceSuppressed ───────────────────────────────
@@ -127,8 +154,14 @@ test("recordSourceSuppressed: increments skipped; no-op without entry", () => {
 // ── suppression cadence over a simulated event stream ──────────────────────
 
 /** Mimics one injection-worthy hook event: decide, then commit the outcome. */
-function driveEvent(state: ss.SessionState, source: string, consumed: boolean, now: number): boolean {
-  const d = ss.decideBackoff(state.sources?.[source], consumed);
+function driveEvent(
+  state: ss.SessionState,
+  source: string,
+  consumed: boolean,
+  now: number,
+  hasRequired = false,
+): boolean {
+  const d = ss.decideBackoff(state.sources?.[source], consumed, hasRequired);
   if (d.suppress) {
     ss.recordSourceSuppressed(state, source);
     return false; // suppressed
@@ -153,6 +186,21 @@ test("cadence: skip requirement never exceeds the cap", () => {
   let skips = 0;
   while (!driveEvent(state, "s", false, 2000)) skips++;
   assert.equal(skips, ss.BACKOFF_STREAK_CAP);
+});
+
+test("cadence: REQUIRED emission mid-window emits as a REGULAR emission — streak grows, only consumption resets", () => {
+  const state: ss.SessionState = { shown: {}, sources: { s: entry(3, 0) } };
+  // Suppression window is open (streak 3, skipped 0) — a REQUIRED hit still emits…
+  assert.equal(driveEvent(state, "s", false, 4000, true), true);
+  // …and is booked as a regular unconsumed emit: streak 3 → 4, not reset.
+  assert.equal(state.sources?.s.streak, 4);
+  assert.equal(state.sources?.s.skipped, 0);
+  // The next optional-only event goes back to suppression (window re-opened).
+  assert.equal(driveEvent(state, "s", false, 4001, false), false);
+  assert.equal(state.sources?.s.skipped, 1);
+  // Only consumption resets the streak — even alongside a REQUIRED hit.
+  assert.equal(driveEvent(state, "s", true, 4002, true), true);
+  assert.equal(state.sources?.s.streak, 0);
 });
 
 test("cadence: consumption mid-window re-opens immediately and resets streak", () => {

--- a/packages/daemon/__tests__/hook-backoff.test.ts
+++ b/packages/daemon/__tests__/hook-backoff.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Unit tests for the #161 empty-streak backoff (session-state.ts).
+ *
+ * Covers:
+ *   - decideBackoff matrix: no entry, min-streak threshold, skipped window,
+ *     cap at BACKOFF_STREAK_CAP, consumption reset, malformed entries
+ *   - recordSourceEmit: streak growth, reset on consumption, ids cap
+ *   - recordSourceSuppressed: skipped counter, defensive no-op
+ *   - suppression cadence over a simulated event stream (E E E S S E …)
+ *   - wasEmitConsumed against real load-markers
+ *   - session-state round-trip preserves the `sources` section
+ */
+import { test, before, after } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let testDir = "";
+
+before(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "bastra-backoff-test-"));
+  process.env.BASTRA_HOOK_STATE_DIR = testDir;
+});
+
+after(async () => {
+  if (testDir) await rm(testDir, { recursive: true, force: true });
+  delete process.env.BASTRA_HOOK_STATE_DIR;
+});
+
+// Import AFTER env override so sessionStateDir() picks up the test dir.
+const ss = await import("../src/session-state.js");
+
+function entry(streak: number, skipped: number, at = 1_000_000): ss.SourceBackoff {
+  return { streak, at, ids: ["mem-a"], skipped };
+}
+
+// ── decideBackoff matrix ────────────────────────────────────────────────────
+
+test("decideBackoff: no entry → never suppress", () => {
+  assert.deepEqual(ss.decideBackoff(undefined, false), { suppress: false, streak: 0 });
+});
+
+test("decideBackoff: streak below MIN_STREAK → emit", () => {
+  assert.equal(ss.decideBackoff(entry(0, 0), false).suppress, false);
+  assert.equal(ss.decideBackoff(entry(ss.BACKOFF_MIN_STREAK - 1, 0), false).suppress, false);
+});
+
+test("decideBackoff: streak at MIN_STREAK, window open → suppress", () => {
+  const d = ss.decideBackoff(entry(ss.BACKOFF_MIN_STREAK, 0), false);
+  assert.equal(d.suppress, true);
+  assert.equal(d.streak, ss.BACKOFF_MIN_STREAK);
+});
+
+test("decideBackoff: skipped < streak keeps suppressing, then probes", () => {
+  assert.equal(ss.decideBackoff(entry(3, 0), false).suppress, true);
+  assert.equal(ss.decideBackoff(entry(3, 2), false).suppress, true);
+  // window exhausted → probe emit
+  assert.equal(ss.decideBackoff(entry(3, 3), false).suppress, false);
+});
+
+test("decideBackoff: cap — streak beyond CAP needs only CAP skips", () => {
+  assert.equal(ss.decideBackoff(entry(12, ss.BACKOFF_STREAK_CAP - 1), false).suppress, true);
+  assert.equal(ss.decideBackoff(entry(12, ss.BACKOFF_STREAK_CAP), false).suppress, false);
+});
+
+test("decideBackoff: consumption resets streak to 0 → emit", () => {
+  const d = ss.decideBackoff(entry(7, 1), true);
+  assert.deepEqual(d, { suppress: false, streak: 0 });
+});
+
+test("decideBackoff: malformed entry fails open", () => {
+  const broken = { streak: "x", at: 1, skipped: 0 } as unknown as ss.SourceBackoff;
+  assert.deepEqual(ss.decideBackoff(broken, false), { suppress: false, streak: 0 });
+  const noEmit = entry(5, 0, 0); // at <= 0 → never emitted
+  assert.deepEqual(ss.decideBackoff(noEmit, false), { suppress: false, streak: 0 });
+});
+
+// ── recordSourceEmit / recordSourceSuppressed ───────────────────────────────
+
+test("recordSourceEmit: first emit starts at streak 0", () => {
+  const state: ss.SessionState = { shown: {} };
+  ss.recordSourceEmit(state, "write-edit", ["m1", "m2"], false, 5000);
+  assert.deepEqual(state.sources?.["write-edit"], {
+    streak: 0,
+    at: 5000,
+    ids: ["m1", "m2"],
+    skipped: 0,
+  });
+});
+
+test("recordSourceEmit: unconsumed previous emit increments streak, resets skipped", () => {
+  const state: ss.SessionState = { shown: {}, sources: { s: entry(2, 2) } };
+  ss.recordSourceEmit(state, "s", ["m3"], false, 6000);
+  assert.deepEqual(state.sources?.s, { streak: 3, at: 6000, ids: ["m3"], skipped: 0 });
+});
+
+test("recordSourceEmit: consumed previous emit resets streak to 0", () => {
+  const state: ss.SessionState = { shown: {}, sources: { s: entry(7, 4) } };
+  ss.recordSourceEmit(state, "s", ["m3"], true, 6000);
+  assert.equal(state.sources?.s.streak, 0);
+});
+
+test("recordSourceEmit: ids are capped to bound state size", () => {
+  const state: ss.SessionState = { shown: {} };
+  const many = Array.from({ length: 30 }, (_, i) => `m${i}`);
+  ss.recordSourceEmit(state, "s", many, false, 1);
+  assert.equal(state.sources?.s.ids.length, 10);
+});
+
+test("recordSourceEmit: sources back off independently", () => {
+  const state: ss.SessionState = { shown: {}, sources: { a: entry(4, 0) } };
+  ss.recordSourceEmit(state, "b", ["m1"], false, 1);
+  assert.equal(state.sources?.a.streak, 4); // untouched
+  assert.equal(state.sources?.b.streak, 0);
+});
+
+test("recordSourceSuppressed: increments skipped; no-op without entry", () => {
+  const state: ss.SessionState = { shown: {}, sources: { s: entry(2, 0) } };
+  ss.recordSourceSuppressed(state, "s");
+  ss.recordSourceSuppressed(state, "s");
+  assert.equal(state.sources?.s.skipped, 2);
+  ss.recordSourceSuppressed(state, "missing"); // must not throw
+  assert.equal(state.sources?.missing, undefined);
+});
+
+// ── suppression cadence over a simulated event stream ──────────────────────
+
+/** Mimics one injection-worthy hook event: decide, then commit the outcome. */
+function driveEvent(state: ss.SessionState, source: string, consumed: boolean, now: number): boolean {
+  const d = ss.decideBackoff(state.sources?.[source], consumed);
+  if (d.suppress) {
+    ss.recordSourceSuppressed(state, source);
+    return false; // suppressed
+  }
+  ss.recordSourceEmit(state, source, ["mem-a"], consumed, now);
+  return true; // emitted
+}
+
+test("cadence: never-consumed source widens deterministically (E E E S S E S S S E)", () => {
+  const state: ss.SessionState = { shown: {} };
+  const pattern: string[] = [];
+  for (let i = 0; i < 10; i++) {
+    pattern.push(driveEvent(state, "s", false, 1000 + i) ? "E" : "S");
+  }
+  assert.equal(pattern.join(" "), "E E E S S E S S S E");
+  // streak after the 5th emit: 4 unconsumed emits counted
+  assert.equal(state.sources?.s.streak, 4);
+});
+
+test("cadence: skip requirement never exceeds the cap", () => {
+  const state: ss.SessionState = { shown: {}, sources: { s: entry(50, 0) } };
+  let skips = 0;
+  while (!driveEvent(state, "s", false, 2000)) skips++;
+  assert.equal(skips, ss.BACKOFF_STREAK_CAP);
+});
+
+test("cadence: consumption mid-window re-opens immediately and resets streak", () => {
+  const state: ss.SessionState = { shown: {}, sources: { s: entry(5, 1) } };
+  // Suppression would continue (skipped 1 < 5), but a load-marker arrived:
+  assert.equal(driveEvent(state, "s", true, 3000), true);
+  assert.equal(state.sources?.s.streak, 0);
+  // Next unconsumed event emits normally again (streak 0 → 1).
+  assert.equal(driveEvent(state, "s", false, 3001), true);
+  assert.equal(state.sources?.s.streak, 1);
+});
+
+// ── wasEmitConsumed against real load-markers ───────────────────────────────
+
+test("wasEmitConsumed: marker newer than emit → consumed", async () => {
+  const e: ss.SourceBackoff = { streak: 1, at: Date.now() - 5000, ids: ["backoff-mem-1"], skipped: 0 };
+  assert.equal(await ss.wasEmitConsumed(e), false, "no marker yet");
+  await ss.touchLoadedMarker("backoff-mem-1");
+  assert.equal(await ss.wasEmitConsumed(e), true);
+});
+
+test("wasEmitConsumed: marker older than emit → not consumed", async () => {
+  await ss.touchLoadedMarker("backoff-mem-2");
+  const e: ss.SourceBackoff = { streak: 1, at: Date.now() + 60_000, ids: ["backoff-mem-2"], skipped: 0 };
+  assert.equal(await ss.wasEmitConsumed(e), false);
+});
+
+test("wasEmitConsumed: undefined entry / empty ids / malformed → false", async () => {
+  assert.equal(await ss.wasEmitConsumed(undefined), false);
+  assert.equal(await ss.wasEmitConsumed({ streak: 1, at: 1, ids: [], skipped: 0 }), false);
+  const broken = { streak: 1, at: 1, ids: "nope", skipped: 0 } as unknown as ss.SourceBackoff;
+  assert.equal(await ss.wasEmitConsumed(broken), false);
+});
+
+// ── session-state round-trip ────────────────────────────────────────────────
+
+test("round-trip: sources section survives save → load", async () => {
+  const sessionId = "session-backoff-roundtrip";
+  const state: ss.SessionState = {
+    shown: { "mem-a": { count: 1, at: 123 } },
+    sources: {
+      "write-edit": { streak: 3, at: 456, ids: ["m1", "m2"], skipped: 2 },
+      "bash-tripwire": { streak: 0, at: 789, ids: ["m3"], skipped: 0 },
+    },
+  };
+  await ss.saveSessionState(sessionId, state);
+  const loaded = await ss.loadSessionState(sessionId);
+  assert.deepEqual(loaded, state);
+});
+
+test("round-trip: legacy state without sources loads cleanly", async () => {
+  const sessionId = "session-backoff-legacy";
+  await ss.saveSessionState(sessionId, { shown: { m: { count: 1, at: 1 } } });
+  const loaded = await ss.loadSessionState(sessionId);
+  assert.equal(loaded.sources, undefined);
+  assert.deepEqual(loaded.shown, { m: { count: 1, at: 1 } });
+});

--- a/packages/daemon/__tests__/learned-recall-bridges.test.ts
+++ b/packages/daemon/__tests__/learned-recall-bridges.test.ts
@@ -172,6 +172,45 @@ test("expandQuery is a no-op for a null pool or abstained language", async () =>
   });
 });
 
+test("expandQuery caps the base at a word boundary BEFORE appending expansions (#162)", async () => {
+  const deB = bridge({ lang: "de", trigger_terms: ["panel"], expansion_terms: ["resignkey", "observer"] });
+  await withPool([deB], async (pool) => {
+    // Trigger up front, then enough filler to blow past the 4000-char base cap.
+    const query = "panel " + "füllwort ".repeat(500); // ~4500 chars
+    const r = expandQuery(query, pool, { configuredLang: "de" });
+    assert.deepEqual(r.added, ["resignkey", "observer"], "expansion fired");
+    // Structural guarantee: the appended terms sit INSIDE the capped string,
+    // so core's downstream QUERY_MAX_CHARS defense can never cut them —
+    // telemetry never claims an expansion that was dropped.
+    assert.ok(r.query.endsWith(" resignkey observer"), "expansions survive at the tail");
+    const base = r.query.slice(0, -" resignkey observer".length);
+    assert.ok(base.length <= 4000, `base capped to 4000 (got ${base.length})`);
+    assert.ok(
+      base.trim().split(/\s+/).every((w) => w === "panel" || w === "füllwort"),
+      "base cap falls on a word boundary — no half token",
+    );
+  });
+});
+
+test("expandQuery trigger matching sees the FULL query, not the capped base", async () => {
+  const deB = bridge({ lang: "de", trigger_terms: ["resignkey"], expansion_terms: ["observer", "modal"] });
+  await withPool([deB], async (pool) => {
+    // The only trigger term sits beyond the 4000-char base cap.
+    const query = "füllwort ".repeat(500) + "resignkey";
+    const r = expandQuery(query, pool, { configuredLang: "de" });
+    assert.deepEqual(r.added, ["observer", "modal"], "trigger beyond the cap still fires");
+    assert.ok(r.query.endsWith(" observer modal"));
+  });
+});
+
+test("expandQuery leaves a short base untouched when appending", async () => {
+  const deB = bridge({ lang: "de", trigger_terms: ["panel"], expansion_terms: ["resignkey"] });
+  await withPool([deB], async (pool) => {
+    const r = expandQuery("warum schließt das Panel", pool, { configuredLang: "de" });
+    assert.equal(r.query, "warum schließt das Panel resignkey", "no cap side effects below 4000 chars");
+  });
+});
+
 test("configuredLang override forces a pool regardless of detection", async () => {
   const deB = bridge({ lang: "de", trigger_terms: ["panel"], expansion_terms: ["resignkey"] });
   await withPool([deB], async (pool) => {

--- a/packages/daemon/__tests__/prompt-hook.test.ts
+++ b/packages/daemon/__tests__/prompt-hook.test.ts
@@ -13,11 +13,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   detectRetrieval,
+  effectiveScoreFloor,
   extractPrompt,
   formatHintBlock,
   isTrivialPrompt,
+  MUST_LOAD_SCORE,
   type RecallHit,
 } from "../src/prompt-hook.ts";
+import { decideBackoff, type SourceBackoff } from "../src/session-state.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const HOOK_PATH = resolve(__dirname, "..", "src", "prompt-hook.ts");
@@ -296,4 +299,94 @@ test("gate wins over retrieval regex on expanded command payloads", () => {
   // scaffolding, not user intent.
   const payload = "<command-name>/deep-research</command-name>\nfind all sources about X";
   assert.equal(isTrivialPrompt(payload), true);
+});
+
+// ─── #161: backoff safety — retrieval exemption + generic-mode invariant ──
+
+test("#161 — generic mode floors at MUST_LOAD_SCORE: suppression impossible by construction", () => {
+  // Every hit surviving the generic floor sits in the REQUIRED band …
+  assert.ok(
+    effectiveScoreFloor("generic") >= MUST_LOAD_SCORE,
+    "generic floor must be >= MUST_LOAD_SCORE — this is what makes the invariant hold",
+  );
+  // … so hasRequired is true for any non-empty generic emission, and the
+  // shared decideBackoff can never suppress it — whatever the streak says.
+  const hotEntries: SourceBackoff[] = [
+    { streak: 2, at: Date.now() - 1000, ids: ["x"], skipped: 0 },
+    { streak: 50, at: Date.now() - 1000, ids: ["x"], skipped: 0 },
+  ];
+  for (const e of hotEntries) {
+    assert.equal(decideBackoff(e, false, false).suppress, true, "precondition: would suppress");
+    assert.equal(decideBackoff(e, false, true).suppress, false, "REQUIRED band bypasses");
+  }
+});
+
+test("integration — #161: retrieval lookup is NEVER suppressed, even in a hot suppression window", async () => {
+  // Pre-seed a prompt-lookup backoff state that would suppress a generic
+  // emission (streak far above BACKOFF_MIN_STREAK, window wide open).
+  const { mkdtemp, rm, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const stateDir = await mkdtemp(join(tmpdir(), "bastra-prompt-backoff-"));
+  const sessionId = "prompt-backoff-retrieval-exempt";
+  await writeFile(
+    join(stateDir, `${sessionId}.json`),
+    JSON.stringify({
+      shown: {},
+      sources: {
+        "prompt-lookup": { streak: 6, at: Date.now() - 1000, ids: ["old-hit"], skipped: 0 },
+      },
+    }),
+    "utf8",
+  );
+
+  const daemon = await startMockDaemon((req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    if (req.url === "/hook/recall") {
+      // Sub-REQUIRED score (70 < MUST_LOAD_SCORE): the emission must survive
+      // via the retrieval exemption itself, not via the hasRequired bypass.
+      res.end(
+        JSON.stringify({
+          hits: [
+            {
+              id: "lease-2024",
+              title: "Mietvertrag 2024",
+              type: "project-fact",
+              scope: "personal",
+              summary: "Mietvertrag Hauptstr. 5, unterschrieben 2024-01-15.",
+              score: 70,
+            },
+          ],
+          vault_size: 50,
+          latency_ms: 5,
+          recall_id: "t",
+        }),
+      );
+    } else {
+      res.end("{}");
+    }
+  });
+
+  try {
+    const { stdout } = await runHook(
+      {
+        hook_event_name: "UserPromptSubmit",
+        prompt: "such mal meinen Mietvertrag",
+        session_id: sessionId,
+        cwd: process.cwd(),
+      },
+      {
+        BASTRA_HTTP_URL: `http://127.0.0.1:${daemon.port}`,
+        BASTRA_HOOK_STATE_DIR: stateDir,
+      },
+    );
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: { additionalContext?: string };
+    };
+    assert.ok(parsed.hookSpecificOutput, "retrieval lookup must emit — never suppressed");
+    assert.match(parsed.hookSpecificOutput?.additionalContext ?? "", /lease-2024/);
+  } finally {
+    await daemon.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
 });

--- a/packages/daemon/__tests__/stable-runtime.test.ts
+++ b/packages/daemon/__tests__/stable-runtime.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for the stable runtime of npx-based installs (#180): the pure
+ * ephemeral-path decision, the node_modules-root resolution, the
+ * copy-into-~/.bastra/runtime round-trip (fixture dirs, no real npm), and
+ * doctor's forwarder-path check formatting.
+ *
+ * ensureStableForwarder is exercised with injected forwarderPath/version/home
+ * so no test touches the real HOME or a real npx cache.
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/stable-runtime.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  checkForwarderRegistration,
+  ensureStableForwarder,
+  isEphemeralInstallPath,
+  resolveNodeModulesRoot,
+  stableRuntimeTarget,
+} from "../src/cli/stable-runtime.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-stable-runtime-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function exists(p: string): Promise<boolean> {
+  try { await stat(p); return true; } catch { return false; }
+}
+
+/**
+ * Builds a fake npx cache: a flat node_modules with the daemon package and
+ * two "production deps" — the shape `npx @bastra-recall/daemon` materializes.
+ * Returns the node_modules root and the forwarder path inside it.
+ */
+async function makeFakeNpxCache(dir: string): Promise<{ nmRoot: string; forwarderPath: string }> {
+  const nmRoot = join(dir, ".npm", "_npx", "0123abcd4567ef89", "node_modules");
+  const daemonPkg = join(nmRoot, "@bastra-recall", "daemon");
+  await mkdir(join(daemonPkg, "dist"), { recursive: true });
+  await writeFile(join(daemonPkg, "package.json"), '{"name":"@bastra-recall/daemon","type":"module"}\n', "utf8");
+  await writeFile(join(daemonPkg, "dist", "mcp-forwarder.js"), "// fake forwarder\n", "utf8");
+  await writeFile(join(daemonPkg, "dist", "index.js"), "// fake daemon\n", "utf8");
+  const corePkg = join(nmRoot, "@bastra-recall", "core");
+  await mkdir(join(corePkg, "dist"), { recursive: true });
+  await writeFile(join(corePkg, "package.json"), '{"name":"@bastra-recall/core","type":"module"}\n', "utf8");
+  await writeFile(join(corePkg, "dist", "index.js"), "// fake core\n", "utf8");
+  await mkdir(join(nmRoot, "zod"), { recursive: true });
+  await writeFile(join(nmRoot, "zod", "package.json"), '{"name":"zod"}\n', "utf8");
+  return { nmRoot, forwarderPath: join(daemonPkg, "dist", "mcp-forwarder.js") };
+}
+
+// ─── isEphemeralInstallPath (pure matrix) ────────────────────────────────────
+
+test("isEphemeralInstallPath: npx cache paths are ephemeral", () => {
+  assert.equal(isEphemeralInstallPath("/Users/x/.npm/_npx/0123abcd/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js"), true);
+  assert.equal(isEphemeralInstallPath("/home/x/.npm/_npx/ff00/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js"), true);
+  // Windows separators — npx caches exist there too.
+  assert.equal(isEphemeralInstallPath("C:\\Users\\x\\AppData\\Local\\npm-cache\\_npx\\ab12\\node_modules\\@bastra-recall\\daemon\\dist\\mcp-forwarder.js"), true);
+  // segment at the very start
+  assert.equal(isEphemeralInstallPath("_npx/abc/dist/mcp-forwarder.js"), true);
+});
+
+test("isEphemeralInstallPath: permanent installs are not", () => {
+  // global npm
+  assert.equal(isEphemeralInstallPath("/usr/local/lib/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js"), false);
+  // Homebrew
+  assert.equal(isEphemeralInstallPath("/opt/homebrew/lib/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js"), false);
+  // source checkout
+  assert.equal(isEphemeralInstallPath("/Users/x/Projekte/bastra-recall/packages/daemon/dist/mcp-forwarder.js"), false);
+  assert.equal(isEphemeralInstallPath(""), false);
+});
+
+test("isEphemeralInstallPath: '_npx' must be a path segment, never a substring", () => {
+  assert.equal(isEphemeralInstallPath("/home/x/my_npx_tools/daemon/dist/mcp-forwarder.js"), false);
+  assert.equal(isEphemeralInstallPath("/home/x/_npx_backup/dist/mcp-forwarder.js"), false);
+});
+
+// ─── resolveNodeModulesRoot ──────────────────────────────────────────────────
+
+test("resolveNodeModulesRoot: scoped package under node_modules → the node_modules dir", () => {
+  assert.equal(
+    resolveNodeModulesRoot("/x/.npm/_npx/ab/node_modules/@bastra-recall/daemon"),
+    "/x/.npm/_npx/ab/node_modules",
+  );
+});
+
+test("resolveNodeModulesRoot: source checkout is not a node_modules install", () => {
+  assert.equal(resolveNodeModulesRoot("/repo/packages/daemon"), null);
+});
+
+// ─── stableRuntimeTarget layout ──────────────────────────────────────────────
+
+test("stableRuntimeTarget: versioned dir under <home>/.bastra/runtime", () => {
+  const t = stableRuntimeTarget("1.2.3", "/tmp/home-x");
+  assert.equal(t.rootDir, join("/tmp/home-x", ".bastra", "runtime", "1.2.3"));
+  assert.equal(t.forwarderPath, join(t.rootDir, "node_modules", "@bastra-recall", "daemon", "dist", "mcp-forwarder.js"));
+  assert.equal(t.markerPath, join(t.rootDir, "runtime-source.json"));
+});
+
+// ─── ensureStableForwarder (fixture dirs, no real npm) ───────────────────────
+
+test("ensureStableForwarder: permanent install passes through untouched", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const fwd = "/opt/homebrew/lib/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js";
+    const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath: fwd, version: "9.9.9", home });
+    assert.equal(r.action, "native");
+    assert.equal(r.path, fwd);
+    assert.equal(r.note, undefined);
+    assert.equal(await exists(join(home, ".bastra")), false);
+  });
+});
+
+test("ensureStableForwarder: npx cache → copies the tree and returns the stable path", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { nmRoot, forwarderPath } = await makeFakeNpxCache(dir);
+    const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "9.9.9-test", home });
+
+    assert.equal(r.action, "copied");
+    const target = stableRuntimeTarget("9.9.9-test", home);
+    assert.equal(r.path, target.forwarderPath);
+    assert.ok(r.note?.includes(target.rootDir), `note names the runtime dir: ${r.note}`);
+
+    // Full tree survives: forwarder + daemon package.json + production deps.
+    assert.equal(await readFile(target.forwarderPath, "utf8"), "// fake forwarder\n");
+    assert.ok(await exists(join(target.rootDir, "node_modules", "@bastra-recall", "daemon", "package.json")));
+    assert.ok(await exists(join(target.rootDir, "node_modules", "@bastra-recall", "core", "dist", "index.js")));
+    assert.ok(await exists(join(target.rootDir, "node_modules", "zod", "package.json")));
+
+    // Marker records the source.
+    const marker = JSON.parse(await readFile(target.markerPath, "utf8"));
+    assert.equal(marker.version, "9.9.9-test");
+    assert.equal(marker.source, nmRoot);
+    assert.ok(typeof marker.copied_at === "string" && marker.copied_at.length > 0);
+  });
+});
+
+test("ensureStableForwarder: same version reuses the copy — survives cache eviction", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { forwarderPath } = await makeFakeNpxCache(dir);
+    const first = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "9.9.9-test", home });
+    assert.equal(first.action, "copied");
+
+    // A sentinel in the runtime dir proves the second run does not re-copy.
+    const target = stableRuntimeTarget("9.9.9-test", home);
+    await writeFile(join(target.rootDir, "sentinel.txt"), "untouched\n", "utf8");
+
+    // Evict the npx cache — the whole point of #180.
+    await rm(join(dir, ".npm"), { recursive: true, force: true });
+
+    const second = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "9.9.9-test", home });
+    assert.equal(second.action, "reused");
+    assert.equal(second.path, target.forwarderPath);
+    assert.equal(await readFile(join(target.rootDir, "sentinel.txt"), "utf8"), "untouched\n");
+  });
+});
+
+test("ensureStableForwarder: new version copies again alongside the old one", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { forwarderPath } = await makeFakeNpxCache(dir);
+    await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "1.0.0", home });
+    const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "2.0.0", home });
+    assert.equal(r.action, "copied");
+    assert.ok(await exists(stableRuntimeTarget("1.0.0", home).forwarderPath));
+    assert.ok(await exists(stableRuntimeTarget("2.0.0", home).forwarderPath));
+  });
+});
+
+test("ensureStableForwarder: dry-run reports the target path, writes nothing", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { forwarderPath } = await makeFakeNpxCache(dir);
+    const r = await ensureStableForwarder({ dryRun: true }, { forwarderPath, version: "9.9.9-test", home });
+    assert.equal(r.action, "would-copy");
+    assert.equal(r.path, stableRuntimeTarget("9.9.9-test", home).forwarderPath);
+    assert.match(r.note ?? "", /would copy/);
+    assert.equal(await exists(join(home, ".bastra")), false);
+  });
+});
+
+test("ensureStableForwarder: unexpected layout falls back to the cache path, never throws", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    // _npx in the path but the package does NOT live under node_modules.
+    const fwd = join(dir, "_npx", "weird", "daemon", "dist", "mcp-forwarder.js");
+    const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath: fwd, version: "9.9.9", home });
+    assert.equal(r.action, "fallback");
+    assert.equal(r.path, fwd);
+    assert.match(r.note ?? "", /layout unexpected/);
+  });
+});
+
+test("ensureStableForwarder: failed copy falls back to the cache path, never throws", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    // Plausible npx layout as a string, but nothing exists on disk → cp fails.
+    const fwd = join(dir, "_npx", "ab", "node_modules", "@bastra-recall", "daemon", "dist", "mcp-forwarder.js");
+    const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath: fwd, version: "9.9.9", home });
+    assert.equal(r.action, "fallback");
+    assert.equal(r.path, fwd);
+    assert.match(r.note ?? "", /copy failed/);
+  });
+});
+
+// ─── doctor forwarder-path check (pure formatting) ───────────────────────────
+
+test("checkForwarderRegistration: healthy permanent path", () => {
+  const c = checkForwarderRegistration("/opt/homebrew/lib/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js", true, "claude-code");
+  assert.equal(c.broken, false);
+  assert.match(c.detail, /\(exists\)$/);
+});
+
+test("checkForwarderRegistration: missing path → broken with re-install hint", () => {
+  const c = checkForwarderRegistration("/gone/dist/mcp-forwarder.js", false, "cursor");
+  assert.equal(c.broken, true);
+  assert.match(c.detail, /MISSING/);
+  assert.match(c.detail, /re-run 'bastra install cursor'/);
+});
+
+test("checkForwarderRegistration: existing npx-cache path → broken with re-install hint (#180)", () => {
+  const c = checkForwarderRegistration("/Users/x/.npm/_npx/ab12/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js", true, "claude-desktop");
+  assert.equal(c.broken, true);
+  assert.match(c.detail, /EPHEMERAL npx cache/);
+  assert.match(c.detail, /re-run 'bastra install claude-desktop'/);
+  assert.match(c.detail, /\.bastra\/runtime/);
+});
+
+test("checkForwarderRegistration: missing beats ephemeral in the wording", () => {
+  const c = checkForwarderRegistration("/Users/x/.npm/_npx/ab12/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js", false, "claude-code");
+  assert.equal(c.broken, true);
+  assert.match(c.detail, /MISSING/);
+});

--- a/packages/daemon/__tests__/stable-runtime.test.ts
+++ b/packages/daemon/__tests__/stable-runtime.test.ts
@@ -19,6 +19,8 @@ import {
   checkForwarderRegistration,
   ensureStableForwarder,
   isEphemeralInstallPath,
+  mapBinToStableRuntime,
+  removeRuntimeBase,
   resolveNodeModulesRoot,
   stableRuntimeTarget,
 } from "../src/cli/stable-runtime.js";
@@ -165,15 +167,33 @@ test("ensureStableForwarder: same version reuses the copy — survives cache evi
   });
 });
 
-test("ensureStableForwarder: new version copies again alongside the old one", async () => {
+test("ensureStableForwarder: new version copies again and prunes the old dir — runtime never grows unbounded", async () => {
   await withTempDir(async (dir) => {
     const home = join(dir, "home");
     const { forwarderPath } = await makeFakeNpxCache(dir);
     await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "1.0.0", home });
+    // Stale staging leftovers (killed install) go too.
+    const staleStaging = `${stableRuntimeTarget("1.0.0", home).rootDir}.tmp-99999`;
+    await mkdir(staleStaging, { recursive: true });
     const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "2.0.0", home });
     assert.equal(r.action, "copied");
-    assert.ok(await exists(stableRuntimeTarget("1.0.0", home).forwarderPath));
+    assert.equal(await exists(stableRuntimeTarget("1.0.0", home).rootDir), false);
+    assert.equal(await exists(staleStaging), false);
     assert.ok(await exists(stableRuntimeTarget("2.0.0", home).forwarderPath));
+  });
+});
+
+test("ensureStableForwarder: reuse never prunes — a second surface install keeps sibling dirs", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { forwarderPath } = await makeFakeNpxCache(dir);
+    await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "3.0.0", home });
+    // A sibling dir that appears after the copy (e.g. concurrent tooling).
+    const sibling = stableRuntimeTarget("other", home).rootDir;
+    await mkdir(sibling, { recursive: true });
+    const r = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "3.0.0", home });
+    assert.equal(r.action, "reused");
+    assert.ok(await exists(sibling));
   });
 });
 
@@ -210,6 +230,95 @@ test("ensureStableForwarder: failed copy falls back to the cache path, never thr
     assert.equal(r.action, "fallback");
     assert.equal(r.path, fwd);
     assert.match(r.note ?? "", /copy failed/);
+  });
+});
+
+// ─── mapBinToStableRuntime (#180: hooks + statusline follow the forwarder) ───
+
+test("mapBinToStableRuntime: bin under the source node_modules maps into the copy", () => {
+  const res = {
+    rootDir: "/home/x/.bastra/runtime/1.0.0",
+    sourceNodeModules: "/home/x/.npm/_npx/ab/node_modules",
+  };
+  assert.equal(
+    mapBinToStableRuntime("/home/x/.npm/_npx/ab/node_modules/@bastra-recall/daemon/dist/hook.js", res),
+    join("/home/x/.bastra/runtime/1.0.0", "node_modules", "@bastra-recall", "daemon", "dist", "hook.js"),
+  );
+  // Statusline resolves within the copied node_modules too.
+  assert.equal(
+    mapBinToStableRuntime("/home/x/.npm/_npx/ab/node_modules/@bastra-recall/statusline/dist/index.mjs", res),
+    join("/home/x/.bastra/runtime/1.0.0", "node_modules", "@bastra-recall", "statusline", "dist", "index.mjs"),
+  );
+});
+
+test("mapBinToStableRuntime: non-stable resolution or bin outside the tree passes through", () => {
+  // Native install: no stable runtime → identity, byte-identical no-op.
+  assert.equal(
+    mapBinToStableRuntime("/repo/packages/daemon/dist/hook.js", {}),
+    "/repo/packages/daemon/dist/hook.js",
+  );
+  // Stable runtime active, but the bin lives outside the copied tree
+  // (source-checkout sibling) → identity.
+  const res = { rootDir: "/h/.bastra/runtime/1.0.0", sourceNodeModules: "/h/.npm/_npx/ab/node_modules" };
+  assert.equal(
+    mapBinToStableRuntime("/repo/packages/statusline/dist/index.mjs", res),
+    "/repo/packages/statusline/dist/index.mjs",
+  );
+});
+
+test("ensureStableForwarder: stable resolutions carry rootDir + sourceNodeModules; native/fallback don't", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { nmRoot, forwarderPath } = await makeFakeNpxCache(dir);
+    const target = stableRuntimeTarget("9.9.9-test", home);
+
+    const dry = await ensureStableForwarder({ dryRun: true }, { forwarderPath, version: "9.9.9-test", home });
+    assert.equal(dry.rootDir, target.rootDir);
+    assert.equal(dry.sourceNodeModules, nmRoot);
+
+    const copied = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "9.9.9-test", home });
+    assert.equal(copied.action, "copied");
+    assert.equal(copied.rootDir, target.rootDir);
+    assert.equal(copied.sourceNodeModules, nmRoot);
+
+    const reused = await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "9.9.9-test", home });
+    assert.equal(reused.action, "reused");
+    assert.equal(reused.rootDir, target.rootDir);
+    assert.equal(reused.sourceNodeModules, nmRoot);
+
+    const native = await ensureStableForwarder(
+      { dryRun: false },
+      { forwarderPath: "/opt/homebrew/lib/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js", version: "9.9.9-test", home },
+    );
+    assert.equal(native.rootDir, undefined);
+    assert.equal(native.sourceNodeModules, undefined);
+
+    const fallback = await ensureStableForwarder(
+      { dryRun: false },
+      { forwarderPath: join(dir, "_npx", "weird", "daemon", "dist", "mcp-forwarder.js"), version: "0.0.1", home },
+    );
+    assert.equal(fallback.action, "fallback");
+    assert.equal(fallback.rootDir, undefined);
+  });
+});
+
+// ─── removeRuntimeBase (uninstall all, #180) ─────────────────────────────────
+
+test("removeRuntimeBase: removes ~/.bastra/runtime entirely and reports it", async () => {
+  await withTempDir(async (dir) => {
+    const home = join(dir, "home");
+    const { forwarderPath } = await makeFakeNpxCache(dir);
+    await ensureStableForwarder({ dryRun: false }, { forwarderPath, version: "1.0.0", home });
+    assert.equal(await removeRuntimeBase(home), true);
+    assert.equal(await exists(join(home, ".bastra", "runtime")), false);
+    // Sibling ~/.bastra content survives.
+    assert.ok(await exists(join(home, ".bastra")));
+  });
+});
+
+test("removeRuntimeBase: absent dir → false, never throws", async () => {
+  await withTempDir(async (dir) => {
+    assert.equal(await removeRuntimeBase(join(dir, "no-such-home")), false);
   });
 });
 

--- a/packages/daemon/__tests__/uninstall-skill-sweep.test.ts
+++ b/packages/daemon/__tests__/uninstall-skill-sweep.test.ts
@@ -74,6 +74,40 @@ test("sweep guard: runs that never touch ~/.claude/skills don't sweep", () => {
   assert.equal(shouldSweepSkill({ surface: null, remainingRegistrations: [] }), false);
 });
 
+test("sweep guard: a covered surface whose uninstall FAILED counts as still registered", () => {
+  // 'all' needs every skill-sharing surface to have succeeded …
+  assert.equal(
+    shouldSweepSkill({ surface: "all", remainingRegistrations: [], succeededSurfaces: ["claude-desktop"] }),
+    false,
+  );
+  assert.equal(
+    shouldSweepSkill({
+      surface: "all",
+      remainingRegistrations: [],
+      succeededSurfaces: ["claude-desktop", "claude-code"],
+    }),
+    true,
+  );
+  // … but a failed cursor never blocks — it doesn't share the skill.
+  assert.equal(
+    shouldSweepSkill({
+      surface: "all",
+      remainingRegistrations: [],
+      succeededSurfaces: ["claude-desktop", "claude-code"], // cursor errored
+    }),
+    true,
+  );
+  // Single-surface run: that surface itself must have succeeded.
+  assert.equal(
+    shouldSweepSkill({ surface: "claude-code", remainingRegistrations: [], succeededSurfaces: [] }),
+    false,
+  );
+  assert.equal(
+    shouldSweepSkill({ surface: "claude-code", remainingRegistrations: [], succeededSurfaces: ["claude-code"] }),
+    true,
+  );
+});
+
 // ─── fs step (temp dir, injected paths) ──────────────────────────────────────
 
 test("sweep step: 'all' with no registrations left removes the skill dir", async () => {
@@ -137,6 +171,46 @@ test("sweep step: dry-run single surface only subtracts itself — the other reg
     const io = await setupHome(dir, { skill: true, registered: ["claude-desktop", "claude-code"] });
     const r = await sweepSharedSkill({ surface: "claude-code", dryRun: true }, io);
     assert.equal(r.status, "kept");
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: dry-run 'all' with a FAILED surface never over-promises — its registration is not subtracted", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: ["claude-desktop", "claude-code"] });
+    // claude-code's uninstall reported an error (e.g. invalid settings JSON).
+    const r = await sweepSharedSkill(
+      { surface: "all", dryRun: true, succeededSurfaces: ["claude-desktop", "cursor"] },
+      io,
+    );
+    assert.equal(r.status, "kept");
+    assert.match(r.detail, /claude-code/);
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: dry-run 'all' with every surface succeeded still reports would-remove", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: ["claude-desktop", "claude-code"] });
+    const r = await sweepSharedSkill(
+      { surface: "all", dryRun: true, succeededSurfaces: ["claude-desktop", "claude-code", "cursor"] },
+      io,
+    );
+    assert.equal(r.status, "would-remove");
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: a FAILED surface blocks the wet sweep even when its registration is already gone", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: [] });
+    // claude-code errored mid-uninstall after its MCP entry was dropped.
+    const r = await sweepSharedSkill(
+      { surface: "all", dryRun: false, succeededSurfaces: ["claude-desktop"] },
+      io,
+    );
+    assert.equal(r.status, "kept");
+    assert.match(r.detail, /uninstall failed: claude-code/);
     assert.equal(existsSync(io.skillDir), true);
   });
 });

--- a/packages/daemon/__tests__/uninstall-skill-sweep.test.ts
+++ b/packages/daemon/__tests__/uninstall-skill-sweep.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the post-uninstall shared-skill sweep (#181): the pure decision
+ * guard (shouldSweepSkill) and the fs step (sweepSharedSkill) that removes
+ * ~/.claude/skills/bastra-recall once no surface registration references it.
+ *
+ * The step is exercised with an injected skill dir + config paths under a
+ * temp dir, so nothing ever touches the real HOME.
+ *
+ * Run: npx tsx --test packages/daemon/__tests__/uninstall-skill-sweep.test.ts
+ */
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { shouldSweepSkill, sweepSharedSkill, SKILL_SHARING_SURFACES } from "../src/cli/skill.js";
+import { SERVER_KEY } from "../src/cli/helpers.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-skill-sweep-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Lays out a fake HOME slice: skill dir (optional) + per-surface configs. */
+async function setupHome(
+  dir: string,
+  opts: { skill: boolean; registered: string[] },
+): Promise<{ skillDir: string; configPaths: Record<string, string> }> {
+  const skillDir = join(dir, "skills", "bastra-recall");
+  if (opts.skill) {
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# skill\n", "utf8");
+  }
+  const configPaths: Record<string, string> = {};
+  for (const surface of SKILL_SHARING_SURFACES) {
+    const path = join(dir, `${surface}.json`);
+    configPaths[surface] = path;
+    const servers = opts.registered.includes(surface) ? { [SERVER_KEY]: { command: "node" } } : {};
+    await writeFile(path, JSON.stringify({ mcpServers: servers }), "utf8");
+  }
+  return { skillDir, configPaths };
+}
+
+// ─── decision matrix (pure) ──────────────────────────────────────────────────
+
+test("sweep guard: 'all' with no remaining registration → sweep", () => {
+  assert.equal(shouldSweepSkill({ surface: "all", remainingRegistrations: [] }), true);
+});
+
+test("sweep guard: any remaining registration always wins", () => {
+  for (const surface of ["all", "claude-code", "claude-desktop"]) {
+    assert.equal(
+      shouldSweepSkill({ surface, remainingRegistrations: ["claude-desktop"] }),
+      false,
+      `surface=${surface}`,
+    );
+  }
+});
+
+test("sweep guard: single skill-sharing surface with nothing else registered → sweep", () => {
+  for (const surface of SKILL_SHARING_SURFACES) {
+    assert.equal(shouldSweepSkill({ surface, remainingRegistrations: [] }), true, `surface=${surface}`);
+  }
+});
+
+test("sweep guard: runs that never touch ~/.claude/skills don't sweep", () => {
+  assert.equal(shouldSweepSkill({ surface: "cursor", remainingRegistrations: [] }), false);
+  assert.equal(shouldSweepSkill({ surface: null, remainingRegistrations: [] }), false);
+});
+
+// ─── fs step (temp dir, injected paths) ──────────────────────────────────────
+
+test("sweep step: 'all' with no registrations left removes the skill dir", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: [] });
+    const r = await sweepSharedSkill({ surface: "all", dryRun: false }, io);
+    assert.equal(r.status, "removed");
+    assert.match(r.detail, /no surface registration references it anymore/);
+    assert.equal(existsSync(io.skillDir), false);
+  });
+});
+
+test("sweep step: missing skill dir → not-present, nothing to do", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: false, registered: [] });
+    const r = await sweepSharedSkill({ surface: "all", dryRun: false }, io);
+    assert.equal(r.status, "not-present");
+  });
+});
+
+test("sweep step: a surviving registration (e.g. errored surface uninstall) blocks the sweep", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: ["claude-desktop"] });
+    const r = await sweepSharedSkill({ surface: "all", dryRun: false }, io);
+    assert.equal(r.status, "kept");
+    assert.match(r.detail, /claude-desktop/);
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: single-surface uninstall keeps the skill while the other surface is registered", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: ["claude-desktop"] });
+    const r = await sweepSharedSkill({ surface: "claude-code", dryRun: false }, io);
+    assert.equal(r.status, "kept");
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: single-surface uninstall sweeps when no other registration remains", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: [] });
+    const r = await sweepSharedSkill({ surface: "claude-code", dryRun: false }, io);
+    assert.equal(r.status, "removed");
+    assert.equal(existsSync(io.skillDir), false);
+  });
+});
+
+test("sweep step: dry-run 'all' reports would-remove (covered registrations still on disk) and deletes nothing", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: ["claude-desktop", "claude-code"] });
+    const r = await sweepSharedSkill({ surface: "all", dryRun: true }, io);
+    assert.equal(r.status, "would-remove");
+    assert.match(r.detail, /no surface registration would remain/);
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: dry-run single surface only subtracts itself — the other registration keeps the skill", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: ["claude-desktop", "claude-code"] });
+    const r = await sweepSharedSkill({ surface: "claude-code", dryRun: true }, io);
+    assert.equal(r.status, "kept");
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: an unreadable config counts as registered — never delete on uncertainty", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: [] });
+    await writeFile(io.configPaths["claude-desktop"], "{ not json", "utf8");
+    const r = await sweepSharedSkill({ surface: "all", dryRun: false }, io);
+    assert.equal(r.status, "kept");
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});
+
+test("sweep step: cursor-only uninstall never touches the skill dir", async () => {
+  await withTempDir(async (dir) => {
+    const io = await setupHome(dir, { skill: true, registered: [] });
+    const r = await sweepSharedSkill({ surface: "cursor", dryRun: false }, io);
+    assert.equal(r.status, "kept");
+    assert.equal(existsSync(io.skillDir), true);
+  });
+});

--- a/packages/daemon/scripts/stats.ts
+++ b/packages/daemon/scripts/stats.ts
@@ -346,8 +346,29 @@ function summarizeContextROI(events: AnyEvent[]): void {
     typeof e.surfaced === "boolean" ? Boolean(e.surfaced) : e.surfaced_score != null;
   const actedSurfaced = episodes.filter((e) => isSurfaced(e) && e.acted_on === true);
 
+  // #161: Backoff-Ersparnis — Events, deren Injektion der Empty-Streak-
+  // Backoff unterdrückt hat, tragen suppressed_tokens_est als Sparseite.
+  const allHookKinds = new Set([
+    ...hookKinds,
+    "bash_fail_hook_call",
+    "prompt_hook_call",
+    "todo_hook_call",
+  ]);
+  const suppressedEvents = events.filter(
+    (e) => allHookKinds.has(String(e.kind)) && e.suppressed === true,
+  );
+  const savedTokens = suppressedEvents.reduce(
+    (sum, e) => sum + (typeof e.suppressed_tokens_est === "number" ? Number(e.suppressed_tokens_est) : 0),
+    0,
+  );
+
   console.log(`\n## Net-context-ROI  (hint tokens spent vs. acted-on loads they caused)`);
   console.log(`  injected hint tokens (est.):  ${totalTokens}  across ${withTokens.length} hook emissions`);
+  if (suppressedEvents.length > 0) {
+    console.log(
+      `  backoff-suppressed (#161):    ${suppressedEvents.length} emissions skipped, ~${savedTokens} hint tokens saved`,
+    );
+  }
   console.log(`  acted-on surfaced loads:      ${actedSurfaced.length}`);
   console.log(
     actedSurfaced.length > 0

--- a/packages/daemon/src/bash-fail-hook.ts
+++ b/packages/daemon/src/bash-fail-hook.ts
@@ -42,6 +42,9 @@ const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 500, "NEXUS_HOOK_TIMEOU
 const DEFAULT_PORT = 6723;
 const HOOK_VERSION = "0.1.0";
 const SCORE_FLOOR = 50;
+// #161: hits at/above this are REQUIRED-band — they bypass backoff suppression
+// (see decideBackoff). Mirrors the MUST_LOAD_SCORE default in the other hooks.
+const MUST_LOAD_SCORE = 100;
 const THROTTLE_WINDOW_MS = 30_000;
 const THROTTLE_DIR = join(tmpdir(), "bastra-hook");
 // #161: backoff source key — fail-hints back off independently.
@@ -173,10 +176,12 @@ async function main(): Promise<void> {
   } else {
     // #161 empty-streak backoff (see session-state.ts): unconsumed injection
     // streaks widen the cadence; any load of an emitted candidate resets.
+    // REQUIRED-band hits (score >= MUST_LOAD_SCORE) bypass suppression.
     const state = await loadSessionState(sessionId);
     const entry = state.sources?.[BACKOFF_SOURCE];
     const consumed = await wasEmitConsumed(entry);
-    const decision = decideBackoff(entry, consumed);
+    const hasRequired = hits.some((h) => h.score >= MUST_LOAD_SCORE);
+    const decision = decideBackoff(entry, consumed, hasRequired);
     backoffStreak = decision.streak;
     suppressed = decision.suppress;
     const block = formatHintBlock(hits);

--- a/packages/daemon/src/bash-fail-hook.ts
+++ b/packages/daemon/src/bash-fail-hook.ts
@@ -29,6 +29,14 @@ import { HINT_FRAME_NOTE, stripFenceMarkers } from "@bastra-recall/core/scrub";
 import { envFirst, envInt } from "./env.js";
 import { defaultLogDir } from "./telemetry.js";
 import { reportHinted } from "./hook-hinted.js";
+import {
+  decideBackoff,
+  loadSessionState,
+  recordSourceEmit,
+  recordSourceSuppressed,
+  saveSessionState,
+  wasEmitConsumed,
+} from "./session-state.js";
 
 const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 500, "NEXUS_HOOK_TIMEOUT_MS");
 const DEFAULT_PORT = 6723;
@@ -36,6 +44,8 @@ const HOOK_VERSION = "0.1.0";
 const SCORE_FLOOR = 50;
 const THROTTLE_WINDOW_MS = 30_000;
 const THROTTLE_DIR = join(tmpdir(), "bastra-hook");
+// #161: backoff source key — fail-hints back off independently.
+const BACKOFF_SOURCE = "bash-fail";
 
 interface ClaudeHookPayload {
   session_id?: string;
@@ -155,23 +165,45 @@ async function main(): Promise<void> {
   if (resp && hits.length === 0) status = "no-hits";
 
   // No hits above floor → no value in interrupting Claude.
+  let backoffStreak = 0;
+  let suppressed = false;
+  let suppressedTokensEst = 0;
   if (hits.length === 0) {
     emitEmpty();
   } else {
-    // Mark throttle only when we actually emit — otherwise quiet calls
-    // would burn the budget.
-    await markThrottle(sessionId);
-    // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
-    await reportHinted(url, hits.map((h) => h.id));
+    // #161 empty-streak backoff (see session-state.ts): unconsumed injection
+    // streaks widen the cadence; any load of an emitted candidate resets.
+    const state = await loadSessionState(sessionId);
+    const entry = state.sources?.[BACKOFF_SOURCE];
+    const consumed = await wasEmitConsumed(entry);
+    const decision = decideBackoff(entry, consumed);
+    backoffStreak = decision.streak;
+    suppressed = decision.suppress;
     const block = formatHintBlock(hits);
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PostToolUse",
-          additionalContext: block,
-        },
-      }),
-    );
+    if (suppressed) {
+      // Suppressed emits {} like the no-hits path; the throttle stays
+      // unmarked (nothing was emitted), the saved tokens go to telemetry.
+      suppressedTokensEst = Math.ceil(block.length / 4);
+      recordSourceSuppressed(state, BACKOFF_SOURCE);
+      await saveSessionState(sessionId, state);
+      emitEmpty();
+    } else {
+      // Mark throttle only when we actually emit — otherwise quiet calls
+      // would burn the budget.
+      await markThrottle(sessionId);
+      // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
+      await reportHinted(url, hits.map((h) => h.id));
+      recordSourceEmit(state, BACKOFF_SOURCE, hits.map((h) => h.id), consumed);
+      await saveSessionState(sessionId, state);
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PostToolUse",
+            additionalContext: block,
+          },
+        }),
+      );
+    }
   }
 
   const totalMs = Date.now() - startedAt;
@@ -180,10 +212,13 @@ async function main(): Promise<void> {
     command_head: commandHead,
     daemon_url: url,
     daemon_reachable: resp !== null,
-    hit_count: hits.length,
+    hit_count: suppressed ? 0 : hits.length,
     top_score: resp?.hits?.[0]?.score ?? null,
     latency_ms_total: totalMs,
-    status,
+    backoff_streak: backoffStreak,
+    suppressed,
+    suppressed_tokens_est: suppressedTokensEst,
+    status: suppressed ? "suppressed" : status,
     error: errMsg,
   });
 }
@@ -415,7 +450,13 @@ interface BashFailHookTelemetry {
   hit_count: number;
   top_score: number | null;
   latency_ms_total: number;
-  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
+  /** #161: aufgelöster Streak der Backoff-Entscheidung dieses Events. */
+  backoff_streak: number;
+  /** #161: true, wenn der Backoff die Injektion unterdrückt hat. */
+  suppressed: boolean;
+  /** #161: Tokens des NICHT injizierten Blocks — die Sparseite der ROI. */
+  suppressed_tokens_est: number;
+  status: "ok" | "no-hits" | "suppressed" | "daemon-unreachable" | "timeout" | "error";
   error: string | null;
 }
 

--- a/packages/daemon/src/bash-pre-hook.ts
+++ b/packages/daemon/src/bash-pre-hook.ts
@@ -27,11 +27,23 @@ import { HINT_FRAME_NOTE, stripFenceMarkers } from "@bastra-recall/core/scrub";
 import { envFirst, envInt } from "./env.js";
 import { defaultLogDir } from "./telemetry.js";
 import { reportHinted } from "./hook-hinted.js";
+import {
+  decideBackoff,
+  loadSessionState,
+  recordSourceEmit,
+  recordSourceSuppressed,
+  saveSessionState,
+  wasEmitConsumed,
+  type SessionState,
+} from "./session-state.js";
 
 const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 500, "NEXUS_HOOK_TIMEOUT_MS");
 const DEFAULT_PORT = 6723;
 const HOOK_VERSION = "0.1.0";
 const SCORE_FLOOR = 50;
+// #161: backoff source key — one key for both severities; they share the
+// noise pattern (162 surfaced / 0 loaded in early v0.7 numbers).
+const BACKOFF_SOURCE = "bash-tripwire";
 
 interface ClaudeHookPayload {
   session_id?: string;
@@ -180,14 +192,42 @@ async function main(): Promise<void> {
 
   // Emit hint even if no memories match — the warning itself is the point.
   const block = formatHintBlock(match.label, match.severity, hits);
-  process.stdout.write(
-    JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        additionalContext: block,
-      },
-    }),
-  );
+
+  // #161 empty-streak backoff: only candidate-carrying blocks participate —
+  // a plain warning (no hits) has no consumption signal and always emits.
+  const sessionId = payload.session_id ?? "";
+  let backoffStreak = 0;
+  let suppressed = false;
+  let consumed = false;
+  let state: SessionState | null = null;
+  if (hits.length > 0) {
+    state = await loadSessionState(sessionId);
+    const entry = state.sources?.[BACKOFF_SOURCE];
+    consumed = await wasEmitConsumed(entry);
+    const decision = decideBackoff(entry, consumed);
+    backoffStreak = decision.streak;
+    suppressed = decision.suppress;
+  }
+
+  if (suppressed && state) {
+    // Suppressed emits {} exactly like the empty path (#161).
+    emitEmpty();
+    recordSourceSuppressed(state, BACKOFF_SOURCE);
+    await saveSessionState(sessionId, state);
+  } else {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext: block,
+        },
+      }),
+    );
+    if (state) {
+      recordSourceEmit(state, BACKOFF_SOURCE, hits.map((h) => h.id), consumed);
+      await saveSessionState(sessionId, state);
+    }
+  }
 
   const totalMs = Date.now() - startedAt;
   await writeTelemetry({
@@ -195,16 +235,19 @@ async function main(): Promise<void> {
     severity: match.severity,
     daemon_url: url,
     daemon_reachable: resp !== null,
-    hint_count: hits.length,
+    hint_count: suppressed ? 0 : hits.length,
     top_score: resp?.hits?.[0]?.score ?? null,
     latency_ms_total: totalMs,
-    hint_tokens_est: Math.ceil(block.length / 4),
-    hinted_ids: hits.map((h) => h.id),
-    status,
+    hint_tokens_est: suppressed ? 0 : Math.ceil(block.length / 4),
+    hinted_ids: suppressed ? [] : hits.map((h) => h.id),
+    backoff_streak: backoffStreak,
+    suppressed,
+    suppressed_tokens_est: suppressed ? Math.ceil(block.length / 4) : 0,
+    status: suppressed ? "suppressed" : status,
     error: errMsg,
   });
   // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
-  await reportHinted(url, hits.map((h) => h.id));
+  if (!suppressed) await reportHinted(url, hits.map((h) => h.id));
 }
 
 function emitEmpty(): void {
@@ -333,7 +376,13 @@ interface BashHookCallTelemetry {
   /** Geschätzte Tokens des injizierten Tripwire-Blocks (#72). */
   hint_tokens_est: number;
   hinted_ids: string[];
-  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
+  /** #161: aufgelöster Streak der Backoff-Entscheidung dieses Events. */
+  backoff_streak: number;
+  /** #161: true, wenn der Backoff die Injektion unterdrückt hat. */
+  suppressed: boolean;
+  /** #161: Tokens des NICHT injizierten Blocks — die Sparseite der ROI. */
+  suppressed_tokens_est: number;
+  status: "ok" | "no-hits" | "suppressed" | "daemon-unreachable" | "timeout" | "error";
   error: string | null;
 }
 

--- a/packages/daemon/src/bash-pre-hook.ts
+++ b/packages/daemon/src/bash-pre-hook.ts
@@ -27,23 +27,16 @@ import { HINT_FRAME_NOTE, stripFenceMarkers } from "@bastra-recall/core/scrub";
 import { envFirst, envInt } from "./env.js";
 import { defaultLogDir } from "./telemetry.js";
 import { reportHinted } from "./hook-hinted.js";
-import {
-  decideBackoff,
-  loadSessionState,
-  recordSourceEmit,
-  recordSourceSuppressed,
-  saveSessionState,
-  wasEmitConsumed,
-  type SessionState,
-} from "./session-state.js";
 
 const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 500, "NEXUS_HOOK_TIMEOUT_MS");
 const DEFAULT_PORT = 6723;
 const HOOK_VERSION = "0.1.0";
 const SCORE_FLOOR = 50;
-// #161: backoff source key — one key for both severities; they share the
-// noise pattern (162 surfaced / 0 loaded in early v0.7 numbers).
-const BACKOFF_SOURCE = "bash-tripwire";
+// #161 CONSTRAINT: this hook is fully EXEMPT from the empty-streak backoff.
+// The STOP/CAUTION tripwire is a safety warning — the warning itself is the
+// point, and it must emit unconditionally (including its lesson enrichment).
+// Safety beats context tax: trimming the attached hint list could return
+// later as an optimization; suppressing the warning may not.
 
 interface ClaudeHookPayload {
   session_id?: string;
@@ -191,43 +184,17 @@ async function main(): Promise<void> {
   if (resp && hits.length === 0) status = "no-hits";
 
   // Emit hint even if no memories match — the warning itself is the point.
+  // #161 CONSTRAINT (see top of file): the tripwire is exempt from backoff.
+  // Warning + enrichment always emit — never suppressed, never trimmed here.
   const block = formatHintBlock(match.label, match.severity, hits);
-
-  // #161 empty-streak backoff: only candidate-carrying blocks participate —
-  // a plain warning (no hits) has no consumption signal and always emits.
-  const sessionId = payload.session_id ?? "";
-  let backoffStreak = 0;
-  let suppressed = false;
-  let consumed = false;
-  let state: SessionState | null = null;
-  if (hits.length > 0) {
-    state = await loadSessionState(sessionId);
-    const entry = state.sources?.[BACKOFF_SOURCE];
-    consumed = await wasEmitConsumed(entry);
-    const decision = decideBackoff(entry, consumed);
-    backoffStreak = decision.streak;
-    suppressed = decision.suppress;
-  }
-
-  if (suppressed && state) {
-    // Suppressed emits {} exactly like the empty path (#161).
-    emitEmpty();
-    recordSourceSuppressed(state, BACKOFF_SOURCE);
-    await saveSessionState(sessionId, state);
-  } else {
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          additionalContext: block,
-        },
-      }),
-    );
-    if (state) {
-      recordSourceEmit(state, BACKOFF_SOURCE, hits.map((h) => h.id), consumed);
-      await saveSessionState(sessionId, state);
-    }
-  }
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: block,
+      },
+    }),
+  );
 
   const totalMs = Date.now() - startedAt;
   await writeTelemetry({
@@ -235,19 +202,19 @@ async function main(): Promise<void> {
     severity: match.severity,
     daemon_url: url,
     daemon_reachable: resp !== null,
-    hint_count: suppressed ? 0 : hits.length,
+    hint_count: hits.length,
     top_score: resp?.hits?.[0]?.score ?? null,
     latency_ms_total: totalMs,
-    hint_tokens_est: suppressed ? 0 : Math.ceil(block.length / 4),
-    hinted_ids: suppressed ? [] : hits.map((h) => h.id),
-    backoff_streak: backoffStreak,
-    suppressed,
-    suppressed_tokens_est: suppressed ? Math.ceil(block.length / 4) : 0,
-    status: suppressed ? "suppressed" : status,
+    hint_tokens_est: Math.ceil(block.length / 4),
+    hinted_ids: hits.map((h) => h.id),
+    backoff_streak: 0,
+    suppressed: false,
+    suppressed_tokens_est: 0,
+    status,
     error: errMsg,
   });
   // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
-  if (!suppressed) await reportHinted(url, hits.map((h) => h.id));
+  await reportHinted(url, hits.map((h) => h.id));
 }
 
 function emitEmpty(): void {
@@ -376,13 +343,12 @@ interface BashHookCallTelemetry {
   /** Geschätzte Tokens des injizierten Tripwire-Blocks (#72). */
   hint_tokens_est: number;
   hinted_ids: string[];
-  /** #161: aufgelöster Streak der Backoff-Entscheidung dieses Events. */
-  backoff_streak: number;
-  /** #161: true, wenn der Backoff die Injektion unterdrückt hat. */
-  suppressed: boolean;
-  /** #161: Tokens des NICHT injizierten Blocks — die Sparseite der ROI. */
-  suppressed_tokens_est: number;
-  status: "ok" | "no-hits" | "suppressed" | "daemon-unreachable" | "timeout" | "error";
+  /** #161: Tripwire ist backoff-EXEMPT — Felder bleiben fürs Stats-Schema,
+   *  sind aber konstant „nie unterdrückt“ (streak 0, suppressed false, 0). */
+  backoff_streak: 0;
+  suppressed: false;
+  suppressed_tokens_est: 0;
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error";
   error: string | null;
 }
 

--- a/packages/daemon/src/cli/adapters/claude-code.ts
+++ b/packages/daemon/src/cli/adapters/claude-code.ts
@@ -24,7 +24,7 @@ import {
   resolveVault,
 } from "../helpers.js";
 import { copySkill } from "../skill.js";
-import { checkForwarderRegistration, ensureStableForwarder } from "../stable-runtime.js";
+import { checkForwarderRegistration, ensureStableForwarder, mapBinToStableRuntime } from "../stable-runtime.js";
 import type { Adapter, DoctorResult, InstallOpts, InstallResult, UninstallResult } from "../types.js";
 
 // ─── Hook helpers (claude-code-only surface) ─────────────────────
@@ -126,18 +126,25 @@ type HookStepStatus = "installed" | "already-installed" | "would-install" | "rem
 
 async function patchClaudeCodeHooks(
   action: "install" | "uninstall",
-  opts: { dryRun: boolean; includeStop?: boolean },
+  opts: { dryRun: boolean; includeStop?: boolean; mapBin?: (bin: string) => string },
 ): Promise<{ status: HookStepStatus; detail: string; backupPath?: string }> {
-  const defs = hookDefinitions({ includeStop: opts.includeStop });
+  const sourceDefs = hookDefinitions({ includeStop: opts.includeStop });
   const includeStop = opts.includeStop === true;
 
   if (action === "install") {
-    for (const def of defs) {
+    // Existence is checked against the SOURCE bins — under an active stable
+    // runtime the copy may not exist yet (dry-run), but it mirrors these.
+    for (const def of sourceDefs) {
       if (!(await fileExists(def.bin))) {
         return { status: "error", detail: `hook binary missing: ${def.bin} — run 'npm run build'` };
       }
     }
   }
+
+  // Register the stable-runtime copy of each bin when active (#180) — hooks
+  // pointing into the npx cache break on eviction just like the forwarder.
+  const mapBin = opts.mapBin;
+  const defs = mapBin ? sourceDefs.map((def) => ({ ...def, bin: mapBin(def.bin) })) : sourceDefs;
 
   const read = await readJsonConfig(CLAUDE_CODE_SETTINGS);
   if ("error" in read) return { status: "error", detail: read.error };
@@ -211,12 +218,16 @@ async function patchClaudeCodeHooks(
 
 // Matches Daniel's hand-configured block + the One-command default:
 //   node <statusline>/dist/index.mjs --style=powerline
-const STATUSLINE_COMMAND = `node ${STATUSLINE_BIN} --style=powerline`;
+// The bin is a parameter (#180): under an active stable runtime it points into
+// the ~/.bastra/runtime copy instead of the npx cache.
+function statuslineCommand(bin: string): string {
+  return `node ${bin} --style=powerline`;
+}
 
-function buildStatuslineBlock(): Record<string, unknown> {
+function buildStatuslineBlock(command: string): Record<string, unknown> {
   return {
     type: "command",
-    command: STATUSLINE_COMMAND,
+    command,
     refreshInterval: 1,
     __bastraRecall: true,
   };
@@ -237,11 +248,11 @@ function isOurStatusline(sl: unknown): boolean {
   );
 }
 
-function statuslineMatches(sl: unknown): boolean {
+function statuslineMatches(sl: unknown, command: string): boolean {
   if (typeof sl !== "object" || sl === null) return false;
   const s = sl as Record<string, unknown>;
   return (
-    s.command === STATUSLINE_COMMAND &&
+    s.command === command &&
     s.type === "command" &&
     s.refreshInterval === 1
   );
@@ -253,8 +264,12 @@ type StatuslineStepStatus =
 
 async function patchClaudeCodeStatusline(
   action: "install" | "uninstall",
-  opts: { dryRun: boolean; force: boolean },
+  opts: { dryRun: boolean; force: boolean; bin?: string },
 ): Promise<{ status: StatuslineStepStatus; detail: string; backupPath?: string }> {
+  // opts.bin: the path to REGISTER (stable-runtime copy when active, #180).
+  // Build/existence is still checked against the source STATUSLINE_BIN — the
+  // copy mirrors it and may not exist yet under dry-run.
+  const command = statuslineCommand(opts.bin ?? STATUSLINE_BIN);
   if (action === "install" && !(await fileExists(STATUSLINE_BIN))) {
     return { status: "error", detail: `statusline not built: ${STATUSLINE_BIN} — run 'npm run build'` };
   }
@@ -271,17 +286,17 @@ async function patchClaudeCodeStatusline(
       if (!opts.force) {
         return { status: "foreign-kept", detail: "a different statusLine is configured — kept it (pass --yes to use bastra's)" };
       }
-    } else if (statuslineMatches(existing)) {
+    } else if (statuslineMatches(existing, command)) {
       return { status: "already-installed", detail: "bastra statusLine already configured" };
     }
 
     if (opts.dryRun) {
       const verb = !present ? "would add" : isOurStatusline(existing) ? "would update" : "would replace foreign";
-      return { status: "would-install", detail: `${verb} statusLine → ${STATUSLINE_COMMAND}` };
+      return { status: "would-install", detail: `${verb} statusLine → ${command}` };
     }
 
     const backupPath = await backupConfig(CLAUDE_CODE_SETTINGS);
-    data.statusLine = buildStatuslineBlock();
+    data.statusLine = buildStatuslineBlock(command);
     await atomicWriteJson(CLAUDE_CODE_SETTINGS, data);
     const how = !present ? "powerline, refreshInterval 1s" : isOurStatusline(existing) ? "path updated" : "replaced foreign";
     return { status: "installed", detail: `statusLine registered (${how})`, backupPath: backupPath ?? undefined };
@@ -307,6 +322,10 @@ async function claudeCodeInstall(opts: InstallOpts): Promise<InstallResult> {
   if ("error" in vault) return { status: "error", message: vault.error, configPath };
 
   const fwd = await ensureStableForwarder({ dryRun: opts.dryRun });
+  // #180: hooks and statusline must survive npx-cache eviction like the
+  // forwarder — register the stable-runtime copy of every bin when active.
+  // On non-npx installs mapBin is the identity (byte-identical no-op).
+  const mapBin = (bin: string) => mapBinToStableRuntime(bin, fwd);
   const block = buildServerBlock(vault.path, fwd.path);
   const read = await readJsonConfig(configPath);
   if ("error" in read) return { status: "error", message: read.error, configPath };
@@ -319,8 +338,13 @@ async function claudeCodeInstall(opts: InstallOpts): Promise<InstallResult> {
   const hookResult = await patchClaudeCodeHooks("install", {
     dryRun: opts.dryRun,
     includeStop: opts.withStopHook === true,
+    mapBin,
   });
-  const statuslineResult = await patchClaudeCodeStatusline("install", { dryRun: opts.dryRun, force: opts.force === true });
+  const statuslineResult = await patchClaudeCodeStatusline("install", {
+    dryRun: opts.dryRun,
+    force: opts.force === true,
+    bin: mapBin(STATUSLINE_BIN),
+  });
 
   if (skillResult.status === "error") return { status: "error", message: `skill: ${skillResult.detail}`, configPath };
   if (hookResult.status === "error") return { status: "error", message: `hooks: ${hookResult.detail}`, configPath };
@@ -395,7 +419,7 @@ async function claudeCodeUninstall(opts: { dryRun: boolean }): Promise<Uninstall
   const statuslineResult = await patchClaudeCodeStatusline("uninstall", { dryRun: opts.dryRun, force: false });
 
   if (!mcpPresent && hookResult.status === "not-present" && statuslineResult.status === "not-present") {
-    return { status: "not-present", message: "nothing to remove (skill kept in case Claude Desktop still uses it)", configPath };
+    return { status: "not-present", message: "nothing to remove (skill: shared file — final sweep decides)", configPath };
   }
 
   if (opts.dryRun) {
@@ -403,7 +427,7 @@ async function claudeCodeUninstall(opts: { dryRun: boolean }): Promise<Uninstall
     steps.push(mcpPresent ? `mcp: would remove '${SERVER_KEY}'` : "mcp: not present");
     steps.push(`hooks: ${hookResult.detail}`);
     steps.push(`statusline: ${statuslineResult.detail}`);
-    steps.push("skill: kept (shared with Claude Desktop)");
+    steps.push("skill: shared file — final sweep decides");
     return { status: "would-remove", message: steps.join("\n  · "), configPath };
   }
 
@@ -420,7 +444,7 @@ async function claudeCodeUninstall(opts: { dryRun: boolean }): Promise<Uninstall
   lines.push(mcpPresent ? `mcp: removed '${SERVER_KEY}'` : "mcp: not present");
   lines.push(`hooks: ${hookResult.detail}`);
   lines.push(`statusline: ${statuslineResult.detail}`);
-  lines.push("skill: kept (shared with Claude Desktop)");
+  lines.push("skill: shared file — final sweep decides");
   lines.push("restart Claude Code to drop the connection");
 
   return {

--- a/packages/daemon/src/cli/adapters/claude-code.ts
+++ b/packages/daemon/src/cli/adapters/claude-code.ts
@@ -24,6 +24,7 @@ import {
   resolveVault,
 } from "../helpers.js";
 import { copySkill } from "../skill.js";
+import { checkForwarderRegistration, ensureStableForwarder } from "../stable-runtime.js";
 import type { Adapter, DoctorResult, InstallOpts, InstallResult, UninstallResult } from "../types.js";
 
 // ─── Hook helpers (claude-code-only surface) ─────────────────────
@@ -305,7 +306,8 @@ async function claudeCodeInstall(opts: InstallOpts): Promise<InstallResult> {
   const vault = await resolveVault(opts);
   if ("error" in vault) return { status: "error", message: vault.error, configPath };
 
-  const block = buildServerBlock(vault.path);
+  const fwd = await ensureStableForwarder({ dryRun: opts.dryRun });
+  const block = buildServerBlock(vault.path, fwd.path);
   const read = await readJsonConfig(configPath);
   if ("error" in read) return { status: "error", message: read.error, configPath };
 
@@ -343,6 +345,7 @@ async function claudeCodeInstall(opts: InstallOpts): Promise<InstallResult> {
 
   if (opts.dryRun) {
     const steps: string[] = [];
+    if (fwd.note) steps.push(`runtime: ${fwd.note}`);
     if (!mcpMatches) steps.push(`mcp: would register '${SERVER_KEY}' in ${configPath}`);
     else steps.push("mcp: already matches");
     steps.push(`skill: ${skillResult.detail}`);
@@ -360,6 +363,7 @@ async function claudeCodeInstall(opts: InstallOpts): Promise<InstallResult> {
   }
 
   const lines: string[] = [];
+  if (fwd.note) lines.push(`runtime: ${fwd.note}`);
   lines.push(mcpMatches ? "mcp: already matches" : `mcp: registered '${SERVER_KEY}'`);
   lines.push(`skill: ${skillResult.detail}`);
   lines.push(`hooks: ${hookResult.detail}`);
@@ -384,9 +388,9 @@ async function claudeCodeUninstall(opts: { dryRun: boolean }): Promise<Uninstall
   const mcpPresent = !!(servers && SERVER_KEY in servers);
 
   // Skill is shared with Claude Desktop (~/.claude/skills/bastra-recall).
-  // We don't remove it here — Claude Desktop might still need it. To purge
-  // the skill, run a separate `bastra uninstall --purge-skill` or remove
-  // the file manually.
+  // We don't remove it here — Claude Desktop might still need it. Once no
+  // surface registration references it, cmdUninstall's final sweep removes
+  // it (#181).
   const hookResult = await patchClaudeCodeHooks("uninstall", { dryRun: opts.dryRun });
   const statuslineResult = await patchClaudeCodeStatusline("uninstall", { dryRun: opts.dryRun, force: false });
 
@@ -439,12 +443,15 @@ async function claudeCodeDoctor(): Promise<DoctorResult> {
   const registered = SERVER_KEY in servers;
   details["mcp-registration"] = registered ? "present" : "missing";
 
+  let forwarderBroken = false;
   if (registered) {
     const block = servers[SERVER_KEY] as Record<string, unknown>;
     const args = Array.isArray(block?.args) ? block.args : [];
     const fwd = args[0];
     if (typeof fwd === "string") {
-      details["forwarder-path"] = (await fileExists(fwd)) ? `${fwd} (exists)` : `${fwd} (MISSING)`;
+      const check = checkForwarderRegistration(fwd, await fileExists(fwd), "claude-code");
+      details["forwarder-path"] = check.detail;
+      forwarderBroken = check.broken;
     }
     const env = block?.env as Record<string, unknown> | undefined;
     const vault = env?.BASTRA_VAULT_PATH;
@@ -494,11 +501,11 @@ async function claudeCodeDoctor(): Promise<DoctorResult> {
 
   if (!registered) return { status: "missing", message: "MCP not registered with Claude Code", details };
   const broken =
-    details["forwarder-path"]?.includes("MISSING") === true ||
+    forwarderBroken ||
     details["vault-path"]?.includes("MISSING") === true ||
     requiredHooksMissing ||
     details["skill"] === "missing";
-  if (broken) return { status: "broken", message: "registered but some pieces are missing", details };
+  if (broken) return { status: "broken", message: "registered but some pieces need repair — re-run 'bastra install claude-code'", details };
   return { status: "ok", message: "MCP + skill + required hooks registered and healthy", details };
 }
 

--- a/packages/daemon/src/cli/adapters/claude-desktop.ts
+++ b/packages/daemon/src/cli/adapters/claude-desktop.ts
@@ -12,6 +12,7 @@ import {
   resolveVault,
 } from "../helpers.js";
 import { copySkill } from "../skill.js";
+import { checkForwarderRegistration, ensureStableForwarder } from "../stable-runtime.js";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import type { Adapter, DoctorResult, InstallOpts, InstallResult, UninstallResult } from "../types.js";
@@ -21,7 +22,8 @@ async function claudeDesktopInstall(opts: InstallOpts): Promise<InstallResult> {
   const vault = await resolveVault(opts);
   if ("error" in vault) return { status: "error", message: vault.error, configPath };
 
-  const block = buildServerBlock(vault.path);
+  const fwd = await ensureStableForwarder({ dryRun: opts.dryRun });
+  const block = buildServerBlock(vault.path, fwd.path);
   const read = await readJsonConfig(configPath);
   if ("error" in read) return { status: "error", message: read.error, configPath };
 
@@ -45,6 +47,7 @@ async function claudeDesktopInstall(opts: InstallOpts): Promise<InstallResult> {
 
   if (opts.dryRun) {
     const steps: string[] = [];
+    if (fwd.note) steps.push(`runtime: ${fwd.note}`);
     steps.push(mcpMatches ? "mcp: already matches" : `mcp: would register '${SERVER_KEY}' (vault=${vault.path})`);
     steps.push(`skill: ${skillResult.detail}`);
     return { status: "would-install", message: steps.join("\n  · "), configPath };
@@ -58,6 +61,7 @@ async function claudeDesktopInstall(opts: InstallOpts): Promise<InstallResult> {
   }
 
   const lines: string[] = [];
+  if (fwd.note) lines.push(`runtime: ${fwd.note}`);
   lines.push(mcpMatches ? "mcp: already matches" : `mcp: registered '${SERVER_KEY}'`);
   lines.push(`skill: ${skillResult.detail}`);
   lines.push("restart Claude Desktop to activate");
@@ -118,14 +122,18 @@ async function claudeDesktopDoctor(): Promise<DoctorResult> {
   const registered = SERVER_KEY in servers;
   details["mcp-registration"] = registered ? "present" : "missing";
 
+  let forwarderBroken = false;
   if (registered) {
     const block = servers[SERVER_KEY] as Record<string, unknown>;
     const args = Array.isArray(block?.args) ? block.args : [];
     const fwd = args[0];
     if (typeof fwd === "string") {
-      details["forwarder-path"] = (await fileExists(fwd)) ? `${fwd} (exists)` : `${fwd} (MISSING)`;
+      const check = checkForwarderRegistration(fwd, await fileExists(fwd), "claude-desktop");
+      details["forwarder-path"] = check.detail;
+      forwarderBroken = check.broken;
     } else {
       details["forwarder-path"] = "no path in args[0]";
+      forwarderBroken = true;
     }
     const env = block?.env as Record<string, unknown> | undefined;
     const vault = env?.BASTRA_VAULT_PATH;
@@ -145,12 +153,11 @@ async function claudeDesktopDoctor(): Promise<DoctorResult> {
 
   if (!registered) return { status: "missing", message: "not registered with Claude Desktop", details };
   const broken =
-    details["forwarder-path"]?.includes("MISSING") === true ||
+    forwarderBroken ||
     details["vault-path"]?.includes("MISSING") === true ||
-    details["forwarder-path"]?.startsWith("no ") === true ||
     details["vault-path"]?.startsWith("not ") === true ||
     details["skill"] === "missing";
-  if (broken) return { status: "broken", message: "registered but skill or referenced paths are missing", details };
+  if (broken) return { status: "broken", message: "registered but skill or referenced paths need repair — re-run 'bastra install claude-desktop'", details };
   return { status: "ok", message: "registered with skill, looks healthy", details };
 }
 

--- a/packages/daemon/src/cli/adapters/cursor.ts
+++ b/packages/daemon/src/cli/adapters/cursor.ts
@@ -13,6 +13,7 @@ import {
   readJsonConfig,
   resolveVault,
 } from "../helpers.js";
+import { checkForwarderRegistration, ensureStableForwarder } from "../stable-runtime.js";
 import type { Adapter, DoctorResult, InstallOpts, InstallResult, UninstallResult } from "../types.js";
 
 async function cursorInstall(opts: InstallOpts): Promise<InstallResult> {
@@ -20,7 +21,9 @@ async function cursorInstall(opts: InstallOpts): Promise<InstallResult> {
   const vault = await resolveVault(opts);
   if ("error" in vault) return { status: "error", message: vault.error, configPath };
 
-  const block = buildServerBlock(vault.path);
+  const fwd = await ensureStableForwarder({ dryRun: opts.dryRun });
+  const runtimeNote = fwd.note ? `\n  · runtime: ${fwd.note}` : "";
+  const block = buildServerBlock(vault.path, fwd.path);
   const read = await readJsonConfig(configPath);
   if ("error" in read) return { status: "error", message: read.error, configPath };
 
@@ -37,7 +40,7 @@ async function cursorInstall(opts: InstallOpts): Promise<InstallResult> {
   if (opts.dryRun) {
     return {
       status: "would-install",
-      message: `would register '${SERVER_KEY}' (vault=${vault.path}, forwarder=${block.args[0]})`,
+      message: `would register '${SERVER_KEY}' (vault=${vault.path}, forwarder=${block.args[0]})${runtimeNote}`,
       configPath,
     };
   }
@@ -46,7 +49,7 @@ async function cursorInstall(opts: InstallOpts): Promise<InstallResult> {
   await atomicWriteJson(configPath, data);
   return {
     status: "installed",
-    message: `registered '${SERVER_KEY}' — restart Cursor (Cursor Rules layer not installed; coming next)`,
+    message: `registered '${SERVER_KEY}' — restart Cursor (Cursor Rules layer not installed; coming next)${runtimeNote}`,
     configPath,
     backupPath: backupPath ?? undefined,
   };
@@ -95,12 +98,15 @@ async function cursorDoctor(): Promise<DoctorResult> {
   const registered = SERVER_KEY in servers;
   details["mcp-registration"] = registered ? "present" : "missing";
 
+  let forwarderBroken = false;
   if (registered) {
     const block = servers[SERVER_KEY] as Record<string, unknown>;
     const args = Array.isArray(block?.args) ? block.args : [];
     const fwd = args[0];
     if (typeof fwd === "string") {
-      details["forwarder-path"] = (await fileExists(fwd)) ? `${fwd} (exists)` : `${fwd} (MISSING)`;
+      const check = checkForwarderRegistration(fwd, await fileExists(fwd), "cursor");
+      details["forwarder-path"] = check.detail;
+      forwarderBroken = check.broken;
     }
     const env = block?.env as Record<string, unknown> | undefined;
     const vault = env?.BASTRA_VAULT_PATH;
@@ -114,9 +120,9 @@ async function cursorDoctor(): Promise<DoctorResult> {
 
   if (!registered) return { status: "missing", message: "not registered with Cursor", details };
   const broken =
-    details["forwarder-path"]?.includes("MISSING") === true ||
+    forwarderBroken ||
     details["vault-path"]?.includes("MISSING") === true;
-  if (broken) return { status: "broken", message: "registered but referenced paths are missing", details };
+  if (broken) return { status: "broken", message: "registered but referenced paths need repair — re-run 'bastra install cursor'", details };
   return { status: "ok", message: "registered (no Cursor Rules layer yet — roadmap)", details };
 }
 

--- a/packages/daemon/src/cli/commands.ts
+++ b/packages/daemon/src/cli/commands.ts
@@ -10,6 +10,7 @@ import {
   VAULT_REQUIRED_ERROR,
 } from "./helpers.js";
 import { installSemanticRecallStep, printEmbeddingDoctorNote } from "./embeddings-cmd.js";
+import { sweepSharedSkill } from "./skill.js";
 import { runInstallWizard, shouldRunWizard } from "./wizard.js";
 import { confirm, isInteractive } from "./prompt.js";
 import { getEmbeddingProvider } from "../settings.js";
@@ -27,7 +28,8 @@ Commands:
   install                    Guided setup (interactive): pick vault, clients,
                              semantic recall from selection lists
   install <surface|all>      Register bastra-recall with the AI client
-  uninstall <surface|all>    Remove the registration (skill is kept; it's shared)
+  uninstall <surface|all>    Remove the registration (the shared skill is
+                             removed once no surface references it anymore)
   update                     brew upgrade (if brew-installed) + re-register +
                              daemon restart. Use this after pulling new code.
   embeddings <on|off|status> Semantic recall (multilingual vector search):
@@ -274,6 +276,16 @@ export async function cmdUninstall(args: ParsedArgs): Promise<number> {
       process.stdout.write(`  error: ${(err as Error).message}\n`);
     }
     process.stdout.write("\n");
+  }
+
+  // The shared skill survives per-surface uninstalls by design; once the loop
+  // leaves no surface registration referencing it, it's an orphan — sweep it
+  // so a full uninstall leaves nothing behind (#181). Silent when kept or
+  // already absent.
+  const sweep = await sweepSharedSkill({ surface: args.surface, dryRun: args.dryRun });
+  if (sweep.status === "removed" || sweep.status === "would-remove") {
+    process.stdout.write("→ skill (shared across Claude surfaces)\n");
+    process.stdout.write(`  ${formatStatus(sweep.status)}: ${sweep.detail}\n\n`);
   }
 
   // Ollama is global, not a surface. On a full uninstall, if bastra activated

--- a/packages/daemon/src/cli/commands.ts
+++ b/packages/daemon/src/cli/commands.ts
@@ -11,6 +11,7 @@ import {
 } from "./helpers.js";
 import { installSemanticRecallStep, printEmbeddingDoctorNote } from "./embeddings-cmd.js";
 import { sweepSharedSkill } from "./skill.js";
+import { removeRuntimeBase } from "./stable-runtime.js";
 import { runInstallWizard, shouldRunWizard } from "./wizard.js";
 import { confirm, isInteractive } from "./prompt.js";
 import { getEmbeddingProvider } from "../settings.js";
@@ -263,6 +264,7 @@ export async function cmdUninstall(args: ParsedArgs): Promise<number> {
   }
 
   let hadError = false;
+  const succeededSurfaces: string[] = [];
   for (const adapter of targets) {
     process.stdout.write(`→ ${adapter.surface} (${adapter.description})\n`);
     process.stdout.write(`  config: ${adapter.configPath}\n`);
@@ -271,6 +273,9 @@ export async function cmdUninstall(args: ParsedArgs): Promise<number> {
       process.stdout.write(`  ${formatStatus(r.status)}: ${r.message}\n`);
       if (r.backupPath) process.stdout.write(`  backup: ${r.backupPath}\n`);
       if (r.status === "error") hadError = true;
+      if (r.status === "removed" || r.status === "would-remove" || r.status === "not-present") {
+        succeededSurfaces.push(adapter.surface);
+      }
     } catch (err) {
       hadError = true;
       process.stdout.write(`  error: ${(err as Error).message}\n`);
@@ -281,11 +286,22 @@ export async function cmdUninstall(args: ParsedArgs): Promise<number> {
   // The shared skill survives per-surface uninstalls by design; once the loop
   // leaves no surface registration referencing it, it's an orphan — sweep it
   // so a full uninstall leaves nothing behind (#181). Silent when kept or
-  // already absent.
-  const sweep = await sweepSharedSkill({ surface: args.surface, dryRun: args.dryRun });
+  // already absent. Only surfaces whose uninstall SUCCEEDED enter the
+  // decision — a failed one counts as still registered.
+  const sweep = await sweepSharedSkill({ surface: args.surface, dryRun: args.dryRun, succeededSurfaces });
   if (sweep.status === "removed" || sweep.status === "would-remove") {
     process.stdout.write("→ skill (shared across Claude surfaces)\n");
     process.stdout.write(`  ${formatStatus(sweep.status)}: ${sweep.detail}\n\n`);
+  }
+
+  // Full uninstall: nothing references the pinned npx runtimes anymore —
+  // remove ~/.bastra/runtime entirely (#180). Best-effort and silent when
+  // absent; skipped when any surface errored (its registration may still
+  // point into the runtime). A live daemon spawned from a runtime dir keeps
+  // running via its open fds; the next install re-creates the dir.
+  if (args.surface === "all" && !args.dryRun && !hadError && (await removeRuntimeBase())) {
+    process.stdout.write("→ runtime (pinned npx runtime, ~/.bastra/runtime)\n");
+    process.stdout.write(`  ${formatStatus("removed")}: no surface registration references it anymore\n\n`);
   }
 
   // Ollama is global, not a surface. On a full uninstall, if bastra activated

--- a/packages/daemon/src/cli/helpers.ts
+++ b/packages/daemon/src/cli/helpers.ts
@@ -15,10 +15,12 @@ export interface McpServerBlock {
   env: Record<string, string>;
 }
 
-export function buildServerBlock(vaultPath: string): McpServerBlock {
+// forwarderPath defaults to this CLI's own dist; npx installs pass the
+// stable-runtime copy instead (#180 — the npx cache is ephemeral).
+export function buildServerBlock(vaultPath: string, forwarderPath: string = FORWARDER_SCRIPT_PATH): McpServerBlock {
   return {
     command: "node",
-    args: [FORWARDER_SCRIPT_PATH],
+    args: [forwarderPath],
     env: { BASTRA_VAULT_PATH: vaultPath },
   };
 }

--- a/packages/daemon/src/cli/skill.ts
+++ b/packages/daemon/src/cli/skill.ts
@@ -39,16 +39,33 @@ export async function copySkill(opts: { dryRun: boolean }): Promise<{ status: Sk
 /** Surfaces that share the skill under ~/.claude/skills/ (Cursor doesn't). */
 export const SKILL_SHARING_SURFACES = ["claude-desktop", "claude-code"] as const;
 
+/** Skill-sharing surfaces this run must uninstall cleanly before a sweep. */
+function requiredSweepSurfaces(surface: string | null): string[] {
+  if (surface === "all") return [...SKILL_SHARING_SURFACES];
+  return (SKILL_SHARING_SURFACES as readonly string[]).includes(surface ?? "") ? [surface as string] : [];
+}
+
 /**
  * Pure guard for the final sweep after the uninstall surface loop: sweep only
  * when this run targeted a skill-sharing surface (or 'all') AND no surface
  * registration still references the skill. A remaining registration always
  * wins; runs that never touch ~/.claude/skills (cursor) never sweep.
+ * `succeededSurfaces` (when given) lists the surfaces whose uninstall
+ * reported removed/would-remove/not-present — a covered surface missing from
+ * it FAILED and counts as still registered, so a failed uninstall never
+ * triggers (or dry-run-promises) the sweep.
  */
-export function shouldSweepSkill(i: { surface: string | null; remainingRegistrations: string[] }): boolean {
+export function shouldSweepSkill(i: {
+  surface: string | null;
+  remainingRegistrations: string[];
+  succeededSurfaces?: string[];
+}): boolean {
   const covers =
     i.surface === "all" || (SKILL_SHARING_SURFACES as readonly string[]).includes(i.surface ?? "");
-  return covers && i.remainingRegistrations.length === 0;
+  if (!covers || i.remainingRegistrations.length > 0) return false;
+  if (i.succeededSurfaces === undefined) return true;
+  const succeeded = i.succeededSurfaces;
+  return requiredSweepSurfaces(i.surface).every((s) => succeeded.includes(s));
 }
 
 /**
@@ -76,11 +93,14 @@ async function liveSkillRegistrations(configPaths: Record<string, string>): Prom
  * bastra-recall behind. Registrations are read live AFTER the loop — a failed
  * surface uninstall keeps its registration and blocks the sweep. Under
  * --dry-run nothing was removed yet, so surfaces covered by this run are
- * subtracted instead. Best-effort: never throws; missing dir = not-present.
- * `io` is injectable for tests only (real paths live under HOME).
+ * subtracted instead — but only those whose uninstall reported
+ * removed/would-remove/not-present (`succeededSurfaces`): a surface that
+ * ERRORED counts as still registered. Best-effort: never throws; missing
+ * dir = not-present. `io` is injectable for tests only (real paths live
+ * under HOME).
  */
 export async function sweepSharedSkill(
-  opts: { surface: string | null; dryRun: boolean },
+  opts: { surface: string | null; dryRun: boolean; succeededSurfaces?: string[] },
   io: { skillDir?: string; configPaths?: Record<string, string> } = {},
 ): Promise<{ status: "removed" | "would-remove" | "kept" | "not-present"; detail: string }> {
   try {
@@ -90,12 +110,24 @@ export async function sweepSharedSkill(
       "claude-desktop": CLAUDE_DESKTOP_CONFIG,
       "claude-code": CLAUDE_CODE_CONFIG,
     };
+    const succeeded = (s: string) =>
+      opts.succeededSurfaces === undefined || opts.succeededSurfaces.includes(s);
+    const coveredByRun = (s: string) => opts.surface === "all" || s === opts.surface;
     const live = await liveSkillRegistrations(configPaths);
     const remaining = opts.dryRun
-      ? live.filter((s) => opts.surface !== "all" && s !== opts.surface)
+      ? live.filter((s) => !coveredByRun(s) || !succeeded(s))
       : live;
-    if (!shouldSweepSkill({ surface: opts.surface, remainingRegistrations: remaining })) {
-      return { status: "kept", detail: `kept (still registered: ${remaining.join(", ") || "none"})` };
+    if (!shouldSweepSkill({
+      surface: opts.surface,
+      remainingRegistrations: remaining,
+      succeededSurfaces: opts.succeededSurfaces,
+    })) {
+      const failed = requiredSweepSurfaces(opts.surface).filter((s) => !succeeded(s));
+      const why = [
+        remaining.length > 0 ? `still registered: ${remaining.join(", ")}` : "",
+        failed.length > 0 ? `uninstall failed: ${failed.join(", ")}` : "",
+      ].filter(Boolean).join("; ") || "still registered: none";
+      return { status: "kept", detail: `kept (${why})` };
     }
     if (opts.dryRun) {
       return { status: "would-remove", detail: `${skillDir} — no surface registration would remain` };

--- a/packages/daemon/src/cli/skill.ts
+++ b/packages/daemon/src/cli/skill.ts
@@ -1,6 +1,12 @@
-import { copyFile, mkdir, readFile } from "node:fs/promises";
-import { fileExists } from "./helpers.js";
-import { SKILL_SOURCE_PATH, SKILL_TARGET_DIR, SKILL_TARGET_FILE } from "./paths.js";
+import { copyFile, mkdir, readFile, rm } from "node:fs/promises";
+import { SERVER_KEY, fileExists, getServersBlock, readJsonConfig } from "./helpers.js";
+import {
+  CLAUDE_CODE_CONFIG,
+  CLAUDE_DESKTOP_CONFIG,
+  SKILL_SOURCE_PATH,
+  SKILL_TARGET_DIR,
+  SKILL_TARGET_FILE,
+} from "./paths.js";
 
 export type SkillStepStatus =
   | "installed"
@@ -26,4 +32,78 @@ export async function copySkill(opts: { dryRun: boolean }): Promise<{ status: Sk
   await mkdir(SKILL_TARGET_DIR, { recursive: true });
   await copyFile(SKILL_SOURCE_PATH, SKILL_TARGET_FILE);
   return { status: "installed", detail: `skill installed at ${SKILL_TARGET_FILE}` };
+}
+
+// ─── post-uninstall skill sweep (#181) ───────────────────────────────────────
+
+/** Surfaces that share the skill under ~/.claude/skills/ (Cursor doesn't). */
+export const SKILL_SHARING_SURFACES = ["claude-desktop", "claude-code"] as const;
+
+/**
+ * Pure guard for the final sweep after the uninstall surface loop: sweep only
+ * when this run targeted a skill-sharing surface (or 'all') AND no surface
+ * registration still references the skill. A remaining registration always
+ * wins; runs that never touch ~/.claude/skills (cursor) never sweep.
+ */
+export function shouldSweepSkill(i: { surface: string | null; remainingRegistrations: string[] }): boolean {
+  const covers =
+    i.surface === "all" || (SKILL_SHARING_SURFACES as readonly string[]).includes(i.surface ?? "");
+  return covers && i.remainingRegistrations.length === 0;
+}
+
+/**
+ * Skill-sharing surfaces whose config still registers the MCP server.
+ * An unreadable/invalid config counts as registered — never delete on
+ * uncertainty.
+ */
+async function liveSkillRegistrations(configPaths: Record<string, string>): Promise<string[]> {
+  const registered: string[] = [];
+  for (const [surface, path] of Object.entries(configPaths)) {
+    const read = await readJsonConfig(path);
+    if ("error" in read) {
+      registered.push(surface);
+      continue;
+    }
+    const servers = getServersBlock(read.data);
+    if (servers && SERVER_KEY in servers) registered.push(surface);
+  }
+  return registered;
+}
+
+/**
+ * Final sweep after the uninstall surface loop (#181): per-surface uninstalls
+ * keep the shared skill, so a full run used to leave ~/.claude/skills/
+ * bastra-recall behind. Registrations are read live AFTER the loop — a failed
+ * surface uninstall keeps its registration and blocks the sweep. Under
+ * --dry-run nothing was removed yet, so surfaces covered by this run are
+ * subtracted instead. Best-effort: never throws; missing dir = not-present.
+ * `io` is injectable for tests only (real paths live under HOME).
+ */
+export async function sweepSharedSkill(
+  opts: { surface: string | null; dryRun: boolean },
+  io: { skillDir?: string; configPaths?: Record<string, string> } = {},
+): Promise<{ status: "removed" | "would-remove" | "kept" | "not-present"; detail: string }> {
+  try {
+    const skillDir = io.skillDir ?? SKILL_TARGET_DIR;
+    if (!(await fileExists(skillDir))) return { status: "not-present", detail: `no skill at ${skillDir}` };
+    const configPaths = io.configPaths ?? {
+      "claude-desktop": CLAUDE_DESKTOP_CONFIG,
+      "claude-code": CLAUDE_CODE_CONFIG,
+    };
+    const live = await liveSkillRegistrations(configPaths);
+    const remaining = opts.dryRun
+      ? live.filter((s) => opts.surface !== "all" && s !== opts.surface)
+      : live;
+    if (!shouldSweepSkill({ surface: opts.surface, remainingRegistrations: remaining })) {
+      return { status: "kept", detail: `kept (still registered: ${remaining.join(", ") || "none"})` };
+    }
+    if (opts.dryRun) {
+      return { status: "would-remove", detail: `${skillDir} — no surface registration would remain` };
+    }
+    await rm(skillDir, { recursive: true, force: true });
+    return { status: "removed", detail: `${skillDir} — no surface registration references it anymore` };
+  } catch (err) {
+    // Cleanup must never fail the uninstall — an unregistered skill is inert.
+    return { status: "kept", detail: `kept (${(err as Error).message})` };
+  }
 }

--- a/packages/daemon/src/cli/stable-runtime.ts
+++ b/packages/daemon/src/cli/stable-runtime.ts
@@ -1,0 +1,158 @@
+/**
+ * Stable runtime for npx-based installs (#180).
+ *
+ * `npx …` runs this CLI out of the npm exec cache
+ * (~/.npm/_npx/<hash>/node_modules/…). Registering FORWARDER_SCRIPT_PATH from
+ * there plants a time bomb: npm evicts _npx entries at will, and every MCP
+ * registration then points at a file that no longer exists. Fix: when install
+ * detects it is running from an npx cache, it copies the resolved runtime to
+ * ~/.bastra/runtime/<version>/ and registers THAT forwarder path.
+ *
+ * What gets copied: the cache's flat node_modules tree — the daemon package
+ * plus exactly the production deps npx materialized. dist/ alone would NOT
+ * suffice: the forwarder imports @bastra-recall/core and the MCP SDK at
+ * runtime and spawns dist/index.js (the daemon), which needs the full
+ * dependency set. Copying the tree verbatim keeps ESM resolution untouched.
+ *
+ * Idempotent: same version = reuse the existing copy (marker + forwarder
+ * present). Old version dirs are left in place on upgrade — another surface
+ * may still be registered against them until its own re-install re-points it.
+ */
+import { cp, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { FORWARDER_SCRIPT_PATH } from "./paths.js";
+import { VERSION, fileExists } from "./helpers.js";
+
+/**
+ * True when the path lives inside an npm exec cache. "_npx" is matched as a
+ * path SEGMENT, never a substring — "my_npx_tools" is a permanent install.
+ * Both separators: npx caches exist on Windows too.
+ */
+export function isEphemeralInstallPath(p: string): boolean {
+  return p.split(/[\\/]+/).includes("_npx");
+}
+
+export interface RuntimeTarget {
+  /** ~/.bastra/runtime/<version> */
+  rootDir: string;
+  /** <rootDir>/node_modules/@bastra-recall/daemon/dist/mcp-forwarder.js */
+  forwarderPath: string;
+  /** <rootDir>/runtime-source.json — records where the copy came from */
+  markerPath: string;
+}
+
+export function stableRuntimeTarget(version: string, home: string = homedir()): RuntimeTarget {
+  const rootDir = join(home, ".bastra", "runtime", version);
+  return {
+    rootDir,
+    forwarderPath: join(rootDir, "node_modules", "@bastra-recall", "daemon", "dist", "mcp-forwarder.js"),
+    markerPath: join(rootDir, "runtime-source.json"),
+  };
+}
+
+/**
+ * The node_modules dir hosting the daemon package
+ * (…/node_modules/@bastra-recall/daemon → …/node_modules), or null when the
+ * layout is not a node_modules install (source checkout: packages/daemon).
+ */
+export function resolveNodeModulesRoot(packageRoot: string): string | null {
+  const nmDir = dirname(dirname(packageRoot));
+  return basename(nmDir) === "node_modules" ? nmDir : null;
+}
+
+/**
+ * Copies the flat node_modules tree into the versioned runtime dir. Staging
+ * dir + rename, so a killed install never leaves a half-copied tree at the
+ * final path.
+ */
+export async function copyRuntimeTree(
+  sourceNodeModules: string,
+  target: RuntimeTarget,
+  version: string,
+): Promise<void> {
+  const staging = `${target.rootDir}.tmp-${process.pid}`;
+  try {
+    await rm(staging, { recursive: true, force: true });
+    await mkdir(staging, { recursive: true });
+    await cp(sourceNodeModules, join(staging, "node_modules"), { recursive: true });
+    const marker = { version, source: sourceNodeModules, copied_at: new Date().toISOString() };
+    await writeFile(join(staging, basename(target.markerPath)), JSON.stringify(marker, null, 2) + "\n", "utf8");
+    await rm(target.rootDir, { recursive: true, force: true });
+    await rename(staging, target.rootDir);
+  } catch (e) {
+    await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+    throw e;
+  }
+}
+
+export interface ForwarderResolution {
+  /** The forwarder path install should register. */
+  path: string;
+  action: "native" | "reused" | "copied" | "would-copy" | "fallback";
+  /** Human line for the install output (`runtime: …`); absent on "native". */
+  note?: string;
+}
+
+/**
+ * Resolves the forwarder path install should register. Permanent installs
+ * (source checkout, Homebrew, global npm) pass through untouched; npx-cache
+ * installs get the runtime pinned under ~/.bastra/runtime/<version>/ first.
+ * Best-effort: a failed copy falls back to the cache path (today's behavior)
+ * with a note — install never throws over this.
+ */
+export async function ensureStableForwarder(
+  opts: { dryRun: boolean },
+  io: { forwarderPath?: string; version?: string; home?: string } = {},
+): Promise<ForwarderResolution> {
+  const fwd = io.forwarderPath ?? FORWARDER_SCRIPT_PATH;
+  if (!isEphemeralInstallPath(fwd)) return { path: fwd, action: "native" };
+
+  const version = io.version ?? VERSION;
+  const target = stableRuntimeTarget(version, io.home);
+  if ((await fileExists(target.markerPath)) && (await fileExists(target.forwarderPath))) {
+    return { path: target.forwarderPath, action: "reused", note: `stable runtime ${version} reused (${target.rootDir})` };
+  }
+  if (opts.dryRun) {
+    return { path: target.forwarderPath, action: "would-copy", note: `would copy runtime to ${target.rootDir} (npx cache is ephemeral)` };
+  }
+
+  // FORWARDER_SCRIPT_PATH is <packageRoot>/dist/mcp-forwarder.js.
+  const nmRoot = resolveNodeModulesRoot(dirname(dirname(fwd)));
+  if (!nmRoot) {
+    return { path: fwd, action: "fallback", note: "npx cache detected but package layout unexpected — registering the cache path (prefer a permanent install: npm i -g)" };
+  }
+  try {
+    await copyRuntimeTree(nmRoot, target, version);
+    return { path: target.forwarderPath, action: "copied", note: `copied to ${target.rootDir} (npx cache is ephemeral — registrations now survive cache eviction)` };
+  } catch (e) {
+    // Concurrent install may have won the rename race — the copy is there.
+    if (await fileExists(target.forwarderPath)) {
+      return { path: target.forwarderPath, action: "reused", note: `stable runtime ${version} reused (${target.rootDir})` };
+    }
+    return { path: fwd, action: "fallback", note: `runtime copy failed (${(e as Error).message}) — registering the npx cache path` };
+  }
+}
+
+export interface ForwarderPathCheck {
+  detail: string;
+  broken: boolean;
+}
+
+/**
+ * Doctor's forwarder-path line (#180). A registration inside the npx cache
+ * still works today but breaks silently when npm evicts the cache entry —
+ * flag it with the fix-it hint before that happens.
+ */
+export function checkForwarderRegistration(fwd: string, exists: boolean, surface: string): ForwarderPathCheck {
+  if (!exists) {
+    return { detail: `${fwd} (MISSING — re-run 'bastra install ${surface}')`, broken: true };
+  }
+  if (isEphemeralInstallPath(fwd)) {
+    return {
+      detail: `${fwd} (EPHEMERAL npx cache — breaks when npm evicts it; re-run 'bastra install ${surface}' to pin ~/.bastra/runtime)`,
+      broken: true,
+    };
+  }
+  return { detail: `${fwd} (exists)`, broken: false };
+}

--- a/packages/daemon/src/cli/stable-runtime.ts
+++ b/packages/daemon/src/cli/stable-runtime.ts
@@ -15,11 +15,13 @@
  * dependency set. Copying the tree verbatim keeps ESM resolution untouched.
  *
  * Idempotent: same version = reuse the existing copy (marker + forwarder
- * present). Old version dirs are left in place on upgrade — another surface
- * may still be registered against them until its own re-install re-points it.
+ * present). After a successful copy, OTHER version dirs are pruned
+ * (best-effort) so ~/.bastra/runtime never grows unbounded — a live daemon
+ * spawned from an old dir keeps running via its open fds; the next spawn
+ * uses the new path.
  */
-import { cp, mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { cp, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { homedir } from "node:os";
 import { FORWARDER_SCRIPT_PATH } from "./paths.js";
 import { VERSION, fileExists } from "./helpers.js";
@@ -92,6 +94,68 @@ export interface ForwarderResolution {
   action: "native" | "reused" | "copied" | "would-copy" | "fallback";
   /** Human line for the install output (`runtime: …`); absent on "native". */
   note?: string;
+  /** ~/.bastra/runtime/<version> when the stable runtime is (or would be) active. */
+  rootDir?: string;
+  /** The source node_modules the runtime is copied from — bins under it map into the copy. */
+  sourceNodeModules?: string;
+}
+
+/**
+ * Maps a bin from the install source tree into the stable runtime copy (#180).
+ * Everything the claude-code adapter registers (hooks, statusline) must point
+ * into ~/.bastra/runtime too — not just the forwarder — or npm evicting the
+ * npx cache breaks 6-7 registrations silently. The copied tree mirrors the
+ * source node_modules verbatim, so a bin under it lives at the same relative
+ * path under <rootDir>/node_modules. Non-stable resolutions and bins outside
+ * the copied tree (source checkouts) pass through untouched — non-npx
+ * installs stay byte-identical.
+ */
+export function mapBinToStableRuntime(
+  bin: string,
+  res: Pick<ForwarderResolution, "rootDir" | "sourceNodeModules">,
+): string {
+  if (!res.rootDir || !res.sourceNodeModules) return bin;
+  const rel = relative(res.sourceNodeModules, bin);
+  if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) return bin;
+  return join(res.rootDir, "node_modules", rel);
+}
+
+/**
+ * Best-effort prune after a successful copy: every sibling of the version dir
+ * just installed goes (old versions, stale .tmp staging). Never the fresh one.
+ * Constraint: a live daemon spawned from an old dir keeps running via its
+ * open fds; the next spawn uses the new path. Never throws — an unpruned dir
+ * is only disk usage.
+ */
+export async function pruneOldRuntimes(target: RuntimeTarget): Promise<void> {
+  try {
+    const runtimeBase = dirname(target.rootDir);
+    const keep = basename(target.rootDir);
+    for (const entry of await readdir(runtimeBase)) {
+      if (entry === keep) continue;
+      await rm(join(runtimeBase, entry), { recursive: true, force: true }).catch(() => undefined);
+    }
+  } catch {
+    // readdir failed (dir gone?) — nothing to prune.
+  }
+}
+
+/**
+ * Full-uninstall cleanup (`uninstall all`): with every surface registration
+ * gone nothing references ~/.bastra/runtime anymore — remove it entirely.
+ * Constraint: a live daemon spawned from a runtime dir keeps running via its
+ * open fds; the next install re-creates the dir. Best-effort, never throws.
+ * Returns true when a dir was actually removed (caller prints a line then).
+ */
+export async function removeRuntimeBase(home: string = homedir()): Promise<boolean> {
+  try {
+    const dir = join(home, ".bastra", "runtime");
+    if (!(await fileExists(dir))) return false;
+    await rm(dir, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -110,25 +174,29 @@ export async function ensureStableForwarder(
 
   const version = io.version ?? VERSION;
   const target = stableRuntimeTarget(version, io.home);
-  if ((await fileExists(target.markerPath)) && (await fileExists(target.forwarderPath))) {
-    return { path: target.forwarderPath, action: "reused", note: `stable runtime ${version} reused (${target.rootDir})` };
-  }
-  if (opts.dryRun) {
-    return { path: target.forwarderPath, action: "would-copy", note: `would copy runtime to ${target.rootDir} (npx cache is ephemeral)` };
-  }
-
   // FORWARDER_SCRIPT_PATH is <packageRoot>/dist/mcp-forwarder.js.
   const nmRoot = resolveNodeModulesRoot(dirname(dirname(fwd)));
+  // Attached to every stable resolution so the claude-code adapter can map
+  // its hook/statusline bins into the copy (#180 — see mapBinToStableRuntime).
+  const stable = { rootDir: target.rootDir, sourceNodeModules: nmRoot ?? undefined };
+  if ((await fileExists(target.markerPath)) && (await fileExists(target.forwarderPath))) {
+    return { path: target.forwarderPath, action: "reused", note: `stable runtime ${version} reused (${target.rootDir})`, ...stable };
+  }
+  if (opts.dryRun) {
+    return { path: target.forwarderPath, action: "would-copy", note: `would copy runtime to ${target.rootDir} (npx cache is ephemeral)`, ...stable };
+  }
+
   if (!nmRoot) {
     return { path: fwd, action: "fallback", note: "npx cache detected but package layout unexpected — registering the cache path (prefer a permanent install: npm i -g)" };
   }
   try {
     await copyRuntimeTree(nmRoot, target, version);
-    return { path: target.forwarderPath, action: "copied", note: `copied to ${target.rootDir} (npx cache is ephemeral — registrations now survive cache eviction)` };
+    await pruneOldRuntimes(target);
+    return { path: target.forwarderPath, action: "copied", note: `copied to ${target.rootDir} (npx cache is ephemeral — registrations now survive cache eviction)`, ...stable };
   } catch (e) {
     // Concurrent install may have won the rename race — the copy is there.
     if (await fileExists(target.forwarderPath)) {
-      return { path: target.forwarderPath, action: "reused", note: `stable runtime ${version} reused (${target.rootDir})` };
+      return { path: target.forwarderPath, action: "reused", note: `stable runtime ${version} reused (${target.rootDir})`, ...stable };
     }
     return { path: fwd, action: "fallback", note: `runtime copy failed (${(e as Error).message}) — registering the npx cache path` };
   }

--- a/packages/daemon/src/documents-write-handler.ts
+++ b/packages/daemon/src/documents-write-handler.ts
@@ -246,6 +246,7 @@ interface DocumentFrontmatter {
   id: string;
   title: string;
   type: "doc";
+  aliases: string[];
   summary: string;
   topic_path: string[];
   tags: string[];
@@ -261,7 +262,8 @@ interface DocumentFrontmatter {
   folder_path: string;
 }
 
-function buildFrontmatter(args: {
+/** Exported for tests (pure). */
+export function buildFrontmatter(args: {
   id: string;
   title: string;
   summary: string;
@@ -273,6 +275,8 @@ function buildFrontmatter(args: {
   folderPath: string;
   created: string;
   updated: string;
+  /** Bestehende Aliases (User-editiert in Obsidian) — werden übernommen. */
+  aliases?: string[];
 }): DocumentFrontmatter {
   const topicPath: string[] = ["documents"];
   if (args.folderPath) {
@@ -280,10 +284,20 @@ function buildFrontmatter(args: {
   } else {
     topicPath.push(args.category);
   }
+  // Obsidian löst [[wikilinks]] gegen die `aliases`-Frontmatter-Liste auf
+  // (Standard-Obsidian-Feature). Das Sidecar heißt nach dem Original-File
+  // (`<file>.jpg.md`), nicht nach der id — ohne die id als Alias wären die
+  // [[<doc-id>]]-Cross-Links des RelatedEnrichers in Obsidian unauflösbar
+  // und ein Klick legt eine leere Stray-Note an (#188).
+  const existingAliases = args.aliases ?? [];
+  const aliases = existingAliases.includes(args.id)
+    ? existingAliases
+    : [...existingAliases, args.id];
   return {
     id: args.id,
     title: args.title,
     type: "doc",
+    aliases,
     summary: args.summary,
     topic_path: topicPath,
     tags: args.tags,
@@ -426,6 +440,7 @@ export async function recategorizeDocument(
     document_category?: string;
     folder_path?: string;
     linked_file?: boolean;
+    aliases?: string[];
   };
 
   // Wenn Folder geändert: erst move (verschiebt Files + Sidecar). Sonst nur
@@ -460,6 +475,7 @@ export async function recategorizeDocument(
     folderPath,
     created: m.fm.created,
     updated: todayISO(),
+    aliases: fm.aliases,
   });
 
   await atomicWriteFile(sidecarPath, renderSidecar(updated, m.body));
@@ -482,6 +498,7 @@ export async function moveDocument(
     original_path?: string;
     folder_path?: string;
     linked_file?: boolean;
+    aliases?: string[];
   };
 
   const moved = await moveDocumentFiles(vault, {
@@ -505,6 +522,7 @@ export async function moveDocument(
     folderPath: args.folder_path,
     created: m.fm.created,
     updated: todayISO(),
+    aliases: fm.aliases,
   });
   await atomicWriteFile(moved.newSidecarPath, renderSidecar(updated, m.body));
   await vault.reindexFile(moved.newSidecarPath);

--- a/packages/daemon/src/embedding-breaker.ts
+++ b/packages/daemon/src/embedding-breaker.ts
@@ -41,6 +41,9 @@ export class EmbeddingBreaker {
   private openedAtMs: number | null = null;
   /** Set while the single half-open probe is in flight. */
   private probeStartedAtMs: number | null = null;
+  /** Root-cause message of the last recorded failure — surfaced by
+   *  BreakerOpenError so /health keeps showing WHY the breaker opened. */
+  private lastFailureMsg: string | null = null;
 
   constructor(
     private readonly failureThreshold: number = BREAKER_FAILURE_THRESHOLD,
@@ -67,10 +70,12 @@ export class EmbeddingBreaker {
     this.failures = 0;
     this.openedAtMs = null;
     this.probeStartedAtMs = null;
+    this.lastFailureMsg = null;
   }
 
-  recordFailure(nowMs: number): void {
+  recordFailure(nowMs: number, message?: string): void {
     this.failures++;
+    if (message) this.lastFailureMsg = message;
     if (this.probeStartedAtMs !== null) {
       // Half-open probe failed → re-open with a fresh cooldown window.
       this.openedAtMs = nowMs;
@@ -81,6 +86,19 @@ export class EmbeddingBreaker {
       this.openedAtMs = nowMs;
     }
     // Already open (straggler that started before opening): keep the window.
+  }
+
+  /** Hard reset to CLOSED, counter 0 (#165 autostart window): early boot-time
+   *  embed failures against a still-down Ollama must not pin the session's
+   *  first recalls to BM25 for a full cooldown once the daemon's autostart
+   *  has brought the server up seconds later. */
+  reset(): void {
+    this.recordSuccess();
+  }
+
+  /** Root-cause message of the last recorded failure, null when healthy. */
+  lastFailureMessage(): string | null {
+    return this.lastFailureMsg;
   }
 
   /** Side-effect-free peek — does NOT claim the probe slot. */
@@ -108,12 +126,26 @@ export class EmbeddingBreaker {
 
 /** Thrown instead of calling the provider while the breaker is open.
  *  EmbeddingIndex treats it like any provider error: query path returns an
- *  empty vector leg (BM25-only), batch path requeues without a retry storm. */
+ *  empty vector leg (BM25-only), batch path requeues without a retry storm.
+ *  Carries the last recorded root cause — EmbeddingIndex stores err.message
+ *  as its runtime lastError, so without it /health would only show the
+ *  generic "circuit open" text instead of WHY the breaker opened. */
 export class BreakerOpenError extends Error {
-  constructor() {
-    super("embedding circuit open — provider call skipped, recall degraded to BM25-only until the cooldown probe succeeds");
+  constructor(lastError?: string | null) {
+    super(
+      "embedding breaker open — provider call skipped, recall degraded to BM25-only until the cooldown probe succeeds" +
+        (lastError ? ` (last error: ${lastError})` : ""),
+    );
     this.name = "BreakerOpenError";
   }
+}
+
+/** Data-shaped batch failure: core/embeddings.ts throws
+ *  "Ollama embed: expected N embeddings, got M" when the response row count
+ *  does not match the input batch. Pure decision function (testable). */
+export function isBatchShapeMismatch(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /expected \d+ embeddings, got (\d+|none)/.test(msg);
 }
 
 /** Provider-boundary wrapper. Mirrors id/dim of the inner provider — the
@@ -136,13 +168,22 @@ export class BreakerGuardedProvider implements EmbeddingProvider {
     // Empty input returns [] without a provider roundtrip — no evidence of
     // health either way, so it must neither trip nor close the breaker.
     if (texts.length === 0) return this.inner.embed(texts);
-    if (!this.breaker.shouldAttempt(this.now())) throw new BreakerOpenError();
+    if (!this.breaker.shouldAttempt(this.now())) {
+      throw new BreakerOpenError(this.breaker.lastFailureMessage());
+    }
     try {
       const out = await this.inner.embed(texts);
       this.breaker.recordSuccess();
       return out;
     } catch (err) {
-      this.breaker.recordFailure(this.now());
+      // Constraint: the "expected N embeddings, got M" mismatch is data-shaped
+      // (deterministic per batch content — e.g. one poisoned document), not an
+      // availability signal. It must NOT count toward the breaker, otherwise a
+      // single poisoned backfill batch retries itself into an open breaker and
+      // degrades ALL recalls to BM25 while the provider is perfectly healthy.
+      if (!isBatchShapeMismatch(err)) {
+        this.breaker.recordFailure(this.now(), err instanceof Error ? err.message : String(err));
+      }
       throw err;
     }
   }

--- a/packages/daemon/src/embedding-breaker.ts
+++ b/packages/daemon/src/embedding-breaker.ts
@@ -1,0 +1,149 @@
+/**
+ * Embedding circuit breaker (#165) — degrade hybrid recall to BM25-only
+ * after consecutive provider failures instead of paying a timeout per query
+ * against a wedged/cold Ollama. Recall latency is sacred; the lexical leg
+ * works without embeddings.
+ *
+ * State machine (pure, nowMs injected — hermetic tests):
+ *   CLOSED    — attempts allowed. K consecutive failures → OPEN.
+ *   OPEN      — attempts denied for a cooldown window (no provider call,
+ *               no timeout cost). Cooldown elapsed → HALF-OPEN.
+ *   HALF-OPEN — exactly ONE probe call attempts the provider; success
+ *               re-closes, failure re-opens with a fresh cooldown.
+ * A success anywhere (query or backfill batch) resets the failure counter —
+ * the breaker sits at the provider boundary, so both paths feed it.
+ *
+ * Wiring: BreakerGuardedProvider wraps the resolved EmbeddingProvider in
+ * index.ts. EmbeddingIndex.search() already catches embed errors and falls
+ * back to an empty vector leg, so a BreakerOpenError degrades recallHybrid
+ * to BM25-only without touching any search code.
+ */
+import type { EmbeddingProvider } from "@bastra-recall/core";
+
+/** K — consecutive failures before the breaker opens. */
+export const BREAKER_FAILURE_THRESHOLD = 3;
+/** Cooldown while OPEN before the single HALF-OPEN probe is allowed. */
+export const BREAKER_COOLDOWN_MS = 60_000;
+
+export type BreakerState = "closed" | "open" | "half-open";
+
+/** JSON-friendly snapshot for /health (snake_case like the rest of the payload). */
+export interface EmbeddingBreakerSnapshot {
+  state: BreakerState;
+  consecutive_failures: number;
+  opened_at_ms: number | null;
+  /** ms until the next probe is allowed; 0 in half-open, null when closed. */
+  cooldown_remaining_ms: number | null;
+}
+
+export class EmbeddingBreaker {
+  private failures = 0;
+  private openedAtMs: number | null = null;
+  /** Set while the single half-open probe is in flight. */
+  private probeStartedAtMs: number | null = null;
+
+  constructor(
+    private readonly failureThreshold: number = BREAKER_FAILURE_THRESHOLD,
+    private readonly cooldownMs: number = BREAKER_COOLDOWN_MS,
+  ) {}
+
+  /** May this call hit the provider? Claims the half-open probe slot as a
+   *  side effect — callers MUST follow up with recordSuccess/recordFailure. */
+  shouldAttempt(nowMs: number): boolean {
+    if (this.openedAtMs === null) return true;
+    if (this.probeStartedAtMs !== null) {
+      // Probe in flight: deny — unless the probe holder never reported back
+      // (crashed caller). After a full cooldown the claim expires.
+      if (nowMs - this.probeStartedAtMs < this.cooldownMs) return false;
+      this.probeStartedAtMs = nowMs;
+      return true;
+    }
+    if (nowMs - this.openedAtMs < this.cooldownMs) return false;
+    this.probeStartedAtMs = nowMs; // half-open: claim the single probe
+    return true;
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.openedAtMs = null;
+    this.probeStartedAtMs = null;
+  }
+
+  recordFailure(nowMs: number): void {
+    this.failures++;
+    if (this.probeStartedAtMs !== null) {
+      // Half-open probe failed → re-open with a fresh cooldown window.
+      this.openedAtMs = nowMs;
+      this.probeStartedAtMs = null;
+      return;
+    }
+    if (this.openedAtMs === null && this.failures >= this.failureThreshold) {
+      this.openedAtMs = nowMs;
+    }
+    // Already open (straggler that started before opening): keep the window.
+  }
+
+  /** Side-effect-free peek — does NOT claim the probe slot. */
+  state(nowMs: number): BreakerState {
+    if (this.openedAtMs === null) return "closed";
+    if (this.probeStartedAtMs !== null) return "half-open";
+    return nowMs - this.openedAtMs < this.cooldownMs ? "open" : "half-open";
+  }
+
+  snapshot(nowMs: number): EmbeddingBreakerSnapshot {
+    const state = this.state(nowMs);
+    return {
+      state,
+      consecutive_failures: this.failures,
+      opened_at_ms: this.openedAtMs,
+      cooldown_remaining_ms:
+        state === "open"
+          ? Math.max(0, (this.openedAtMs as number) + this.cooldownMs - nowMs)
+          : state === "half-open"
+            ? 0
+            : null,
+    };
+  }
+}
+
+/** Thrown instead of calling the provider while the breaker is open.
+ *  EmbeddingIndex treats it like any provider error: query path returns an
+ *  empty vector leg (BM25-only), batch path requeues without a retry storm. */
+export class BreakerOpenError extends Error {
+  constructor() {
+    super("embedding circuit open — provider call skipped, recall degraded to BM25-only until the cooldown probe succeeds");
+    this.name = "BreakerOpenError";
+  }
+}
+
+/** Provider-boundary wrapper. Mirrors id/dim of the inner provider — the
+ *  persisted vector index keys on provider.id, so wrapping must never look
+ *  like a provider change (which would invalidate all vectors). */
+export class BreakerGuardedProvider implements EmbeddingProvider {
+  readonly id: string;
+  readonly dim: number;
+
+  constructor(
+    private readonly inner: EmbeddingProvider,
+    private readonly breaker: EmbeddingBreaker,
+    private readonly now: () => number = Date.now,
+  ) {
+    this.id = inner.id;
+    this.dim = inner.dim;
+  }
+
+  async embed(texts: string[]): Promise<Float32Array[]> {
+    // Empty input returns [] without a provider roundtrip — no evidence of
+    // health either way, so it must neither trip nor close the breaker.
+    if (texts.length === 0) return this.inner.embed(texts);
+    if (!this.breaker.shouldAttempt(this.now())) throw new BreakerOpenError();
+    try {
+      const out = await this.inner.embed(texts);
+      this.breaker.recordSuccess();
+      return out;
+    } catch (err) {
+      this.breaker.recordFailure(this.now());
+      throw err;
+    }
+  }
+}

--- a/packages/daemon/src/hook.ts
+++ b/packages/daemon/src/hook.ts
@@ -259,7 +259,8 @@ async function main(): Promise<void> {
   // 7b) Empty-streak backoff (#161): if this source's recent injections went
   //     unconsumed (no load-marker newer than the emit), widen the cadence —
   //     skip the next min(streak, cap) would-be injections, then probe.
-  //     Best-effort: state errors fail open and we emit normally.
+  //     REQUIRED-band hits (score >= MUST_LOAD_SCORE) bypass suppression —
+  //     see decideBackoff. Best-effort: state errors fail open, emit normally.
   let backoffStreak = 0;
   let suppressed = false;
   let suppressedTokensEst = 0;
@@ -267,7 +268,7 @@ async function main(): Promise<void> {
   if (dedupActive && totalHints > 0) {
     const entry = sessionState.sources?.[BACKOFF_SOURCE];
     backoffConsumed = await wasEmitConsumed(entry);
-    const decision = decideBackoff(entry, backoffConsumed);
+    const decision = decideBackoff(entry, backoffConsumed, requiredHits.length > 0);
     backoffStreak = decision.streak;
     suppressed = decision.suppress;
     if (suppressed) status = "suppressed";
@@ -331,7 +332,9 @@ async function main(): Promise<void> {
     daemon_url: url,
     daemon_reachable: resp !== null,
     hint_count: suppressed ? 0 : totalHints,
-    required_count: requiredHits.length,
+    // Suppressed events zero ALL per-hit fields (like hint_count/hinted_ids).
+    // With the REQUIRED-band bypass this is provably 0 anyway — defensive.
+    required_count: suppressed ? 0 : requiredHits.length,
     top_score: topScore,
     latency_ms_total: totalMs,
     dropped_dedup_count: droppedDedupCount,

--- a/packages/daemon/src/hook.ts
+++ b/packages/daemon/src/hook.ts
@@ -14,6 +14,8 @@
  *     → POST 127.0.0.1:BASTRA_HTTP_PORT/hook/recall
  *     → per-session dedup (#32): drop hits shown >= 3 times within 4h
  *       (unless load_memory marker is newer than last show)
+ *     → empty-streak backoff (#161): unconsumed injection streaks widen the
+ *       cadence per source ("write-edit"); consumption resets it
  *     → format hits as <recall-hints>…</recall-hints>
  *     → stdout: {"hookSpecificOutput": { hookEventName, additionalContext }}
  *
@@ -38,10 +40,14 @@ import { reportHinted } from "./hook-hinted.js";
 import {
   bumpShown,
   cleanupOldStates,
+  decideBackoff,
   getLoadedMarkerMtime,
   loadSessionState,
+  recordSourceEmit,
+  recordSourceSuppressed,
   saveSessionState,
   shouldDropHit,
+  wasEmitConsumed,
   type SessionState,
 } from "./session-state.js";
 
@@ -53,6 +59,9 @@ const SCORE_FLOOR = envInt("BASTRA_RECALL_FLOOR", 30); // mirror SKILL.md: <30 i
 // can lift the REQUIRED band (e.g. to 130) from telemetry without a rebuild,
 // but the default stays 100 until the data says to raise it.
 const MUST_LOAD_SCORE = envInt("BASTRA_MUST_LOAD_SCORE", 100);
+// #161: backoff source key — write-edit hints back off independently of the
+// other hook sources (bash-tripwire, bash-fail, prompt-lookup, todo-plan).
+const BACKOFF_SOURCE = "write-edit";
 
 interface ClaudeHookPayload {
   session_id?: string;
@@ -81,7 +90,14 @@ interface RecallResponse {
   recall_id: string;
 }
 
-type HookStatus = "ok" | "no-hits" | "skipped" | "daemon-unreachable" | "timeout" | "error";
+type HookStatus =
+  | "ok"
+  | "no-hits"
+  | "skipped"
+  | "suppressed"
+  | "daemon-unreachable"
+  | "timeout"
+  | "error";
 
 const SUPPORTED_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
@@ -127,6 +143,9 @@ async function main(): Promise<void> {
       dropped_scope_count: 0,
       hint_tokens_est: 0,
       hinted_ids: [],
+      backoff_streak: 0,
+      suppressed: false,
+      suppressed_tokens_est: 0,
       status: "skipped",
       error: null,
     });
@@ -237,6 +256,23 @@ async function main(): Promise<void> {
 
   const topScore = resp?.hits?.[0]?.score ?? null;
 
+  // 7b) Empty-streak backoff (#161): if this source's recent injections went
+  //     unconsumed (no load-marker newer than the emit), widen the cadence —
+  //     skip the next min(streak, cap) would-be injections, then probe.
+  //     Best-effort: state errors fail open and we emit normally.
+  let backoffStreak = 0;
+  let suppressed = false;
+  let suppressedTokensEst = 0;
+  let backoffConsumed = false;
+  if (dedupActive && totalHints > 0) {
+    const entry = sessionState.sources?.[BACKOFF_SOURCE];
+    backoffConsumed = await wasEmitConsumed(entry);
+    const decision = decideBackoff(entry, backoffConsumed);
+    backoffStreak = decision.streak;
+    suppressed = decision.suppress;
+    if (suppressed) status = "suppressed";
+  }
+
   // 8) Emit Claude-Code hookSpecificOutput first — that's the hot path.
   // hint_tokens_est (#72): grobe Token-Schätzung (~4 chars/token) des
   // tatsächlich injizierten Blocks — die Kostenseite der net-context-ROI.
@@ -244,6 +280,13 @@ async function main(): Promise<void> {
   let hintedIds: string[] = [];
   if (totalHints === 0) {
     emitEmpty();
+  } else if (suppressed) {
+    // Suppressed emits {} exactly like the empty path; the would-be cost is
+    // logged as suppressed_tokens_est so net-context-ROI counts the savings.
+    emitEmpty();
+    const block = formatHintBlock(requiredHits, optionalHits, project);
+    suppressedTokensEst = Math.ceil(block.length / 4);
+    recordSourceSuppressed(sessionState, BACKOFF_SOURCE);
   } else {
     const block = formatHintBlock(requiredHits, optionalHits, project);
     hintTokensEst = Math.ceil(block.length / 4);
@@ -256,12 +299,16 @@ async function main(): Promise<void> {
         },
       }),
     );
+    recordSourceEmit(sessionState, BACKOFF_SOURCE, hintedIds, backoffConsumed);
   }
 
-  // 9) Bump shown-counts for everything we surfaced, then persist.
+  // 9) Bump shown-counts for everything we surfaced, then persist. When
+  //    suppressed nothing was shown — only the backoff counter changed.
   if (dedupActive && survivingHits.length > 0) {
-    const now = Date.now();
-    for (const h of survivingHits) bumpShown(sessionState, h.id, now);
+    if (!suppressed) {
+      const now = Date.now();
+      for (const h of survivingHits) bumpShown(sessionState, h.id, now);
+    }
     await saveSessionState(sessionId, sessionState);
   }
 
@@ -283,7 +330,7 @@ async function main(): Promise<void> {
     query_chars: topics.query.length,
     daemon_url: url,
     daemon_reachable: resp !== null,
-    hint_count: totalHints,
+    hint_count: suppressed ? 0 : totalHints,
     required_count: requiredHits.length,
     top_score: topScore,
     latency_ms_total: totalMs,
@@ -291,6 +338,9 @@ async function main(): Promise<void> {
     dropped_scope_count: droppedScopeCount,
     hint_tokens_est: hintTokensEst,
     hinted_ids: hintedIds,
+    backoff_streak: backoffStreak,
+    suppressed,
+    suppressed_tokens_est: suppressedTokensEst,
     status,
     error: errMsg,
   });
@@ -431,6 +481,12 @@ interface HookCallTelemetry {
   hint_tokens_est: number;
   /** IDs, die tatsächlich emittiert wurden (#72 context-tax per memory). */
   hinted_ids: string[];
+  /** #161: aufgelöster Streak der Backoff-Entscheidung dieses Events. */
+  backoff_streak: number;
+  /** #161: true, wenn der Backoff die Injektion unterdrückt hat. */
+  suppressed: boolean;
+  /** #161: Tokens des NICHT injizierten Blocks — die Sparseite der ROI. */
+  suppressed_tokens_est: number;
   status: HookStatus;
   error: string | null;
 }

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -708,6 +708,10 @@ function handleHookRecall(
         candidatePool = pool.map((h) => ({ id: h.id, score: h.score }));
       };
       const tRecall0 = Date.now();
+      // #165: VOR dem Recall festgehalten, damit der Flag den Recall
+      // beschreibt, der tatsächlich serviert wird (siehe recallHandler).
+      const embeddingDegradedAtRecall =
+        search.hasEmbeddings() && (embeddingDegraded?.() ?? false);
       const hits = search.hasEmbeddings()
         ? await search.recallHybrid(expansion.query, { k, scope, type, expand_hops, onStage, onCandidatePool })
         : search.recall(expansion.query, { k, scope, type, expand_hops, onStage, onCandidatePool });
@@ -751,8 +755,8 @@ function handleHookRecall(
           bridge_expansion:
             expansion.lang && expansion.added.length > 0 ? { lang: expansion.lang, added: expansion.added } : undefined,
           candidate_pool: candidatePool.length > 0 ? candidatePool : undefined,
-          // #165: post-recall ausgewertet, siehe recallHandler.
-          embedding_degraded: search.hasEmbeddings() && (embeddingDegraded?.() ?? false) ? true : undefined,
+          // #165: pre-recall festgehalten, siehe oben / recallHandler.
+          embedding_degraded: embeddingDegradedAtRecall ? true : undefined,
         }),
       );
 

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -52,6 +52,7 @@ import { createServer, type Server, type IncomingMessage, type ServerResponse } 
 import { timingSafeEqual } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import type { Vault, SearchIndex, RecallStage, StageListener, EmbeddingRuntimeHealth } from "@bastra-recall/core";
+import type { EmbeddingBreakerSnapshot } from "./embedding-breaker.js";
 import { fireAndForget, type Telemetry } from "./telemetry.js";
 import {
   recallHandler,
@@ -114,6 +115,9 @@ export interface HttpOptions {
    *  Zustand nach Boot ändert (Modell gelöscht, Ollama down → degraded;
    *  nächster Erfolg → wieder ok). null = kein Index aktiv. */
   embeddingHealth?: () => EmbeddingRuntimeHealth | null;
+  /** Circuit-Breaker-Zustand (#165) für /health. null = kein Breaker aktiv
+   *  (embeddings off). */
+  embeddingBreaker?: () => EmbeddingBreakerSnapshot | null;
   /** Curator-Deps (#155/#156) für die /curator/*-Loopback-Endpoints. */
   curator?: CuratorRunDeps;
 }
@@ -293,6 +297,9 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
       // of advertising semantic recall that silently runs BM25-only.
       const rt = opts.embeddingHealth?.() ?? null;
       const degraded = opts.embedding.on && rt !== null && !rt.ok;
+      // Breaker-Zustand (#165): billiger Snapshot, macht sichtbar ob Recall
+      // gerade bewusst BM25-only serviert wird (open) statt nur "degraded".
+      const breaker = opts.embeddingBreaker?.() ?? null;
       sendJson(res, 200, {
         ok: true,
         vault_size: vault.size(),
@@ -303,6 +310,7 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
         embedding_mode: opts.embedding.providerId ?? "disabled",
         embedding_source: opts.embedding.source,
         ...(degraded ? { embedding_error: rt.lastError } : {}),
+        ...(breaker ? { embedding_breaker: breaker } : {}),
         update_available: updateState && updateState.hasUpdate
           ? {
               current: updateState.current,
@@ -338,7 +346,7 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
     }
 
     if (method === "POST" && url === "/hook/recall") {
-      handleHookRecall(req, res, t0, vault, search, telemetry, toolDeps.learnedBridges, toolDeps.sharedRecallLang);
+      handleHookRecall(req, res, t0, vault, search, telemetry, toolDeps.learnedBridges, toolDeps.sharedRecallLang, toolDeps.embeddingDegraded);
       return;
     }
 
@@ -614,6 +622,7 @@ function handleHookRecall(
   telemetry: Telemetry,
   learnedBridges?: BridgePool | null,
   sharedRecallLang?: SupportedLanguage | null,
+  embeddingDegraded?: () => boolean,
 ): void {
   // SSE-Branch (#38): wenn der Caller `Accept: text/event-stream`
   // sendet, streamen wir Stages live. Default-JSON-Response bleibt
@@ -742,6 +751,8 @@ function handleHookRecall(
           bridge_expansion:
             expansion.lang && expansion.added.length > 0 ? { lang: expansion.lang, added: expansion.added } : undefined,
           candidate_pool: candidatePool.length > 0 ? candidatePool : undefined,
+          // #165: post-recall ausgewertet, siehe recallHandler.
+          embedding_degraded: search.hasEmbeddings() && (embeddingDegraded?.() ?? false) ? true : undefined,
         }),
       );
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -78,6 +78,7 @@ import { startBackgroundCheck } from "./update-check.js";
 import { writeSharedVaultSize } from "./statusline-session.js";
 import { reapStaleForwarderProcesses } from "./reap-forwarders.js";
 import { prewarmOllamaModel, unloadOllamaModel } from "./ollama-lifecycle.js";
+import { EmbeddingBreaker, BreakerGuardedProvider } from "./embedding-breaker.js";
 import { ensureOllamaServerForDaemon } from "./cli/ollama.js";
 import { spawnSync } from "node:child_process";
 
@@ -220,11 +221,17 @@ async function main(): Promise<void> {
     /* kein State = keine Demotions */
   }
 
-  const { provider, status: embeddingStatus, ollama } = await resolveEmbedding();
+  const { provider: rawProvider, status: embeddingStatus, ollama } = await resolveEmbedding();
   console.error(embeddingStatusLine(embeddingStatus));
   // Für /health (#92): Runtime-Health des Index, nicht nur die Boot-Config.
   let embIdxForHealth: EmbeddingIndex | null = null;
-  if (provider) {
+  // Circuit breaker (#165) am Provider-Boundary: nach 3 konsekutiven
+  // Provider-Fehlern skipt Hybrid-Recall den Embed-Versuch komplett
+  // (BM25-only, kein Timeout pro Query gegen ein wedged Ollama); nach dem
+  // Cooldown testet genau EIN Probe-Call, ob der Provider wieder lebt.
+  const embeddingBreaker = rawProvider ? new EmbeddingBreaker() : null;
+  if (rawProvider && embeddingBreaker) {
+    const provider = new BreakerGuardedProvider(rawProvider, embeddingBreaker);
     const persistPath = path.join(VAULT_PATH!, ".bastra", "embeddings.json");
     const embIdx = new EmbeddingIndex(vault, provider, persistPath);
     embIdxForHealth = embIdx;
@@ -332,6 +339,11 @@ async function main(): Promise<void> {
     commonsVerifications,
     learnedBridges,
     sharedRecallLang,
+    // #165: Recall-Telemetrie flaggt Events als embedding_degraded, wenn der
+    // Breaker gerade offen ist (Vector-Leg geskippt, BM25-only serviert).
+    embeddingDegraded: embeddingBreaker
+      ? () => embeddingBreaker.state(Date.now()) === "open"
+      : undefined,
   };
 
   // Idle self-shutdown: the shared daemon is spawned on demand by the
@@ -359,6 +371,7 @@ async function main(): Promise<void> {
           onActivity: markActivity,
           embedding: embeddingStatus,
           embeddingHealth: () => embIdxForHealth?.runtimeHealth() ?? null,
+          embeddingBreaker: () => embeddingBreaker?.snapshot(Date.now()) ?? null,
           curator: { vaultRoot: VAULT_PATH!, vault, setDemotions: (ids) => search.setDemotions(ids) },
         });
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -246,6 +246,14 @@ async function main(): Promise<void> {
         if (auto.detail !== "already running") {
           console.error(`[bastra-recall] ollama autostart: ${auto.detail}`);
         }
+        // #165 Autostart-Fenster: frühe Embed-Fehler beim Boot (Ollama noch
+        // down) haben den Breaker evtl. schon geöffnet und würden die ersten
+        // Recalls der Session für einen vollen Cooldown auf BM25 pinnen,
+        // obwohl der Server jetzt steht. Läuft er (frisch gestartet oder
+        // schon da), Breaker hart zurücksetzen: closed, Counter 0.
+        if (auto.started || auto.detail === "already running") {
+          embeddingBreaker.reset();
+        }
         const ok = await prewarmOllamaModel(ollama.baseURL, ollama.model, ollama.keepAlive);
         void telemetry.logOllamaLifecycle({
           action: "prewarm",

--- a/packages/daemon/src/learned-recall/bridges.ts
+++ b/packages/daemon/src/learned-recall/bridges.ts
@@ -28,6 +28,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
+import { capAtWordBoundary } from "@bastra-recall/core";
 import { detectLanguage, isSupportedLanguage, type SupportedLanguage } from "./language.js";
 
 export interface Bridge {
@@ -150,6 +151,13 @@ export function scrubBridge(b: Bridge): Bridge | null {
 
 const MAX_QUERY_EXPANSION = 12; // cap how much a single query can be widened
 
+// #162: the base query is capped BEFORE expansion terms are appended, so the
+// appended terms always survive core's downstream QUERY_MAX_CHARS (8000)
+// defense cap — otherwise a long base pushes the tail-appended expansions
+// past the cap and telemetry claims an expansion that was silently dropped.
+// 4000 base + ≤12 terms of ≤24 chars stays far below the core cap.
+const MAX_BASE_QUERY_CHARS = 4000;
+
 /**
  * A language-partitioned, read-only set of bridges. Built once at daemon boot from
  * <root>/bridges/<lang>/*.json (mirroring the Commons recipes layout). Never written.
@@ -252,7 +260,8 @@ function isValidBridge(b: unknown): b is Bridge {
 // ─── Query expansion (the recall-time integration helper) ────────────────────
 
 export interface ExpansionResult {
-  /** The query to actually run — original, plus any bridge expansion terms appended. */
+  /** The query to actually run — original (base capped at MAX_BASE_QUERY_CHARS
+   *  when expansions fire), plus any bridge expansion terms appended. */
   query: string;
   /** The language the bridge layer routed on (null = abstained, no expansion). */
   lang: SupportedLanguage | null;
@@ -277,5 +286,9 @@ export function expandQuery(
   if (!lang) return { query, lang: null, added: [] };
   const added = pool.expansionsFor(query, lang);
   if (added.length === 0) return { query, lang, added: [] };
-  return { query: `${query} ${added.join(" ")}`, lang, added };
+  // Trigger-Matching (expansionsFor) sah die VOLLE Query; nur die Basis des
+  // zusammengesetzten Suchstrings wird gedeckelt (Wortgrenze, nie im Token),
+  // damit die Expansions strukturell vor dem Core-Cap sicher sind (#162).
+  const base = capAtWordBoundary(query, MAX_BASE_QUERY_CHARS);
+  return { query: `${base} ${added.join(" ")}`, lang, added };
 }

--- a/packages/daemon/src/prompt-hook.ts
+++ b/packages/daemon/src/prompt-hook.ts
@@ -30,6 +30,14 @@ import { defaultLogDir } from "./telemetry.js";
 import { claudeSessionPid, sessionFeedPath, STATUSLINE_DIR } from "./statusline-session.js";
 import { idleStatuslineState } from "./statusline-feed.js";
 import { reportHinted } from "./hook-hinted.js";
+import {
+  decideBackoff,
+  loadSessionState,
+  recordSourceEmit,
+  recordSourceSuppressed,
+  saveSessionState,
+  wasEmitConsumed,
+} from "./session-state.js";
 
 // Session-namespaced feed — same path the forwarder of THIS session writes
 // (claude ancestor PID, since CC sends no session id — #41836).
@@ -71,6 +79,8 @@ const DEFAULT_PORT = 6723;
 const HOOK_VERSION = "0.2.0";
 const SCORE_FLOOR = 50; // higher than PreToolUse: prompts rarely match recall_when exactly
 const MUST_LOAD_SCORE = 100;
+// #161: backoff source key — prompt-lookup hints back off independently.
+const BACKOFF_SOURCE = "prompt-lookup";
 
 /** "retrieval-only" (default) or "all" (also recall on non-lookup prompts, score-gated to MUST_LOAD_SCORE). */
 type PromptHookMode = "retrieval-only" | "all";
@@ -268,20 +278,42 @@ async function main(): Promise<void> {
   }
   if (resp && filtered.length === 0) status = "no-hits";
 
+  let backoffStreak = 0;
+  let suppressed = false;
+  let suppressedTokensEst = 0;
   if (filtered.length === 0) {
     emitEmpty();
   } else {
+    // #161 empty-streak backoff (see session-state.ts): unconsumed injection
+    // streaks widen the cadence; any load of an emitted candidate resets.
+    const sessionId = payload.session_id ?? "";
+    const state = await loadSessionState(sessionId);
+    const entry = state.sources?.[BACKOFF_SOURCE];
+    const consumed = await wasEmitConsumed(entry);
+    const decision = decideBackoff(entry, consumed);
+    backoffStreak = decision.streak;
+    suppressed = decision.suppress;
     const block = formatHintBlock(filtered, project, detectedMode);
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "UserPromptSubmit",
-          additionalContext: block,
-        },
-      }),
-    );
-    // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
-    await reportHinted(url, filtered.map((h) => h.id));
+    if (suppressed) {
+      // Suppressed emits {} exactly like the empty path (#161).
+      suppressedTokensEst = Math.ceil(block.length / 4);
+      recordSourceSuppressed(state, BACKOFF_SOURCE);
+      await saveSessionState(sessionId, state);
+      emitEmpty();
+    } else {
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "UserPromptSubmit",
+            additionalContext: block,
+          },
+        }),
+      );
+      recordSourceEmit(state, BACKOFF_SOURCE, filtered.map((h) => h.id), consumed);
+      await saveSessionState(sessionId, state);
+      // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
+      await reportHinted(url, filtered.map((h) => h.id));
+    }
   }
 
   await writeTelemetry({
@@ -289,10 +321,13 @@ async function main(): Promise<void> {
     prompt_chars: prompt.length,
     daemon_url: url,
     daemon_reachable: resp !== null,
-    hint_count: filtered.length,
+    hint_count: suppressed ? 0 : filtered.length,
     top_score: resp?.hits?.[0]?.score ?? null,
     latency_ms_total: Date.now() - startedAt,
-    status,
+    backoff_streak: backoffStreak,
+    suppressed,
+    suppressed_tokens_est: suppressedTokensEst,
+    status: suppressed ? "suppressed" : status,
     error: errMsg,
   });
 }
@@ -435,7 +470,13 @@ interface PromptHookTelemetry {
   hint_count: number;
   top_score: number | null;
   latency_ms_total: number;
-  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" | "gated";
+  /** #161: resolved streak of this event's backoff decision. */
+  backoff_streak?: number;
+  /** #161: true when the empty-streak backoff suppressed the injection. */
+  suppressed?: boolean;
+  /** #161: est. tokens of the NOT-injected block — the savings side of ROI. */
+  suppressed_tokens_est?: number;
+  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" | "gated" | "suppressed";
   error: string | null;
 }
 

--- a/packages/daemon/src/prompt-hook.ts
+++ b/packages/daemon/src/prompt-hook.ts
@@ -78,7 +78,7 @@ const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 250, "NEXUS_HOOK_TIMEOU
 const DEFAULT_PORT = 6723;
 const HOOK_VERSION = "0.2.0";
 const SCORE_FLOOR = 50; // higher than PreToolUse: prompts rarely match recall_when exactly
-const MUST_LOAD_SCORE = 100;
+export const MUST_LOAD_SCORE = 100;
 // #161: backoff source key — prompt-lookup hints back off independently.
 const BACKOFF_SOURCE = "prompt-lookup";
 
@@ -158,6 +158,17 @@ export function isTrivialPrompt(prompt: string): boolean {
   if (TRIVIAL_ACKS.has(bare)) return true;
   if (bare.length <= 2) return true;
   return false;
+}
+
+/**
+ * Score floor per detected mode. "generic" floors at MUST_LOAD_SCORE — only
+ * very strong matches may interrupt arbitrary prompts. #161 corollary: every
+ * hit surviving the generic floor sits in the REQUIRED band, so the
+ * hasRequired bypass in decideBackoff makes suppression impossible there by
+ * construction (asserted in prompt-hook.test.ts instead of special-casing).
+ */
+export function effectiveScoreFloor(mode: DetectedMode): number {
+  return mode === "generic" ? MUST_LOAD_SCORE : SCORE_FLOOR;
 }
 
 export function extractPrompt(payload: ClaudeHookPayload): string | null {
@@ -244,9 +255,7 @@ async function main(): Promise<void> {
 
   // For "generic" mode we only show top-tier hits, so request fewer (k=3).
   const k = detectedMode === "retrieval" ? 5 : 3;
-  // In "generic" mode bump the score floor to MUST_LOAD_SCORE — only show
-  // very strong matches to avoid noise on every single prompt.
-  const effectiveFloor = detectedMode === "generic" ? MUST_LOAD_SCORE : SCORE_FLOOR;
+  const effectiveFloor = effectiveScoreFloor(detectedMode);
 
   let resp: RecallResponse | null = null;
   let status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" = "ok";
@@ -286,13 +295,18 @@ async function main(): Promise<void> {
   } else {
     // #161 empty-streak backoff (see session-state.ts): unconsumed injection
     // streaks widen the cadence; any load of an emitted candidate resets.
+    // REQUIRED-band hits bypass suppression (decideBackoff hasRequired), and
+    // retrieval mode is exempt entirely — the user explicitly asked for a
+    // lookup, answering it is never noise. Streak bookkeeping stays regular
+    // either way; only consumption resets the streak.
     const sessionId = payload.session_id ?? "";
     const state = await loadSessionState(sessionId);
     const entry = state.sources?.[BACKOFF_SOURCE];
     const consumed = await wasEmitConsumed(entry);
-    const decision = decideBackoff(entry, consumed);
+    const hasRequired = filtered.some((h) => h.score >= MUST_LOAD_SCORE);
+    const decision = decideBackoff(entry, consumed, hasRequired);
     backoffStreak = decision.streak;
-    suppressed = decision.suppress;
+    suppressed = detectedMode === "retrieval" ? false : decision.suppress;
     const block = formatHintBlock(filtered, project, detectedMode);
     if (suppressed) {
       // Suppressed emits {} exactly like the empty path (#161).

--- a/packages/daemon/src/session-state.ts
+++ b/packages/daemon/src/session-state.ts
@@ -262,8 +262,19 @@ export interface BackoffDecision {
  * Decide whether this injection-worthy event should be suppressed. Pure —
  * `consumed` is resolved separately (wasEmitConsumed) so tests can pin the
  * matrix without I/O. Malformed entries fail open (emit normally).
+ *
+ * `hasRequired` (#161 review): true when the pending emission contains ANY
+ * hit at/above MUST_LOAD_SCORE. REQUIRED-band hits are non-negotiable loads —
+ * suppressing them would silently drop exactly the hints the scoring model
+ * marked as must-see, so they BYPASS suppression. The bypass emit is regular
+ * streak bookkeeping (recordSourceEmit as usual); only consumption resets
+ * the streak. One rule here, shared by every backoff-consulting emitter.
  */
-export function decideBackoff(entry: SourceBackoff | undefined, consumed: boolean): BackoffDecision {
+export function decideBackoff(
+  entry: SourceBackoff | undefined,
+  consumed: boolean,
+  hasRequired: boolean,
+): BackoffDecision {
   if (
     !entry ||
     typeof entry.streak !== "number" ||
@@ -275,7 +286,9 @@ export function decideBackoff(entry: SourceBackoff | undefined, consumed: boolea
   }
   const streak = consumed ? 0 : entry.streak;
   const suppress =
-    streak >= BACKOFF_MIN_STREAK && entry.skipped < Math.min(streak, BACKOFF_STREAK_CAP);
+    !hasRequired &&
+    streak >= BACKOFF_MIN_STREAK &&
+    entry.skipped < Math.min(streak, BACKOFF_STREAK_CAP);
   return { suppress, streak };
 }
 

--- a/packages/daemon/src/session-state.ts
+++ b/packages/daemon/src/session-state.ts
@@ -34,8 +34,23 @@ export interface ShownEntry {
   at: number; // ms since epoch when last shown
 }
 
+/** #161: per hook-source empty-streak backoff state — see the backoff
+ *  section at the bottom of this file. */
+export interface SourceBackoff {
+  /** consecutive unconsumed emits (incremented at emit, reset on consumption) */
+  streak: number;
+  /** ms epoch of the last actual emit for this source */
+  at: number;
+  /** candidate ids of that emit — consumption anchors on these */
+  ids: string[];
+  /** would-be injections suppressed since the last emit */
+  skipped: number;
+}
+
 export interface SessionState {
   shown: Record<string, ShownEntry>;
+  /** #161: keyed by hook source ("write-edit", "bash-tripwire", …) */
+  sources?: Record<string, SourceBackoff>;
 }
 
 /** Threshold above which a memory is dropped from hints. #32 startete mit 3;
@@ -81,7 +96,13 @@ export async function loadSessionState(sessionId: string): Promise<SessionState>
     if (!parsed || typeof parsed !== "object" || !parsed.shown) {
       return { shown: {} };
     }
-    return { shown: parsed.shown as Record<string, ShownEntry> };
+    const state: SessionState = { shown: parsed.shown as Record<string, ShownEntry> };
+    // #161: carry the backoff section through — dropping it here would reset
+    // every streak on the next dedup save.
+    if (parsed.sources && typeof parsed.sources === "object") {
+      state.sources = parsed.sources as Record<string, SourceBackoff>;
+    }
+    return state;
   } catch {
     return { shown: {} };
   }
@@ -202,4 +223,102 @@ export function bumpShown(state: SessionState, memId: string, now: number = Date
   } else {
     state.shown[memId] = { count: prev.count + 1, at: now };
   }
+}
+
+/* ── #161: per hook-source empty-streak backoff ────────────────────────────
+ *
+ * Telemetry showed long streaks of injected hint candidates that are never
+ * loaded (bash-tripwire: 162 surfaced / 0 loaded) while the injection
+ * cadence stayed fixed. Each hook source now tracks, per session:
+ *
+ *   - streak: consecutive emits whose candidates saw NO load-marker newer
+ *     than the emit. Incremented at emit time; any consumption resets to 0.
+ *   - skipped: would-be injections suppressed since the last emit.
+ *
+ * The cadence unit is EVENTS, not wall time: hooks only run on tool events
+ * (there is no timer to widen against) and event rates differ wildly per
+ * source — so a source with streak N skips the next min(N, cap) injection-
+ * worthy events, then probes with a real emit. Deterministic, testable, and
+ * costs only the state read + marker stats the dedup path already pays.
+ *
+ * Consumption reuses the load-marker touch files: a marker mtime newer than
+ * the entry's emit ts means the agent loaded one of the emitted candidates.
+ */
+
+/** Suppression starts once this many consecutive emits went unconsumed. */
+export const BACKOFF_MIN_STREAK = 2;
+/** Cadence never widens beyond 1 emit per (cap + 1) injection-worthy events. */
+export const BACKOFF_STREAK_CAP = 8;
+/** Bound state size — hooks emit ≤5 candidate ids per block today. */
+const BACKOFF_IDS_CAP = 10;
+
+export interface BackoffDecision {
+  suppress: boolean;
+  /** streak after resolving the previous emit's consumption (telemetry). */
+  streak: number;
+}
+
+/**
+ * Decide whether this injection-worthy event should be suppressed. Pure —
+ * `consumed` is resolved separately (wasEmitConsumed) so tests can pin the
+ * matrix without I/O. Malformed entries fail open (emit normally).
+ */
+export function decideBackoff(entry: SourceBackoff | undefined, consumed: boolean): BackoffDecision {
+  if (
+    !entry ||
+    typeof entry.streak !== "number" ||
+    typeof entry.at !== "number" ||
+    typeof entry.skipped !== "number" ||
+    entry.at <= 0
+  ) {
+    return { suppress: false, streak: 0 };
+  }
+  const streak = consumed ? 0 : entry.streak;
+  const suppress =
+    streak >= BACKOFF_MIN_STREAK && entry.skipped < Math.min(streak, BACKOFF_STREAK_CAP);
+  return { suppress, streak };
+}
+
+/**
+ * Was the source's last emit consumed? True if any of its candidate ids has
+ * a load-marker newer than the emit timestamp. Best-effort fs stats via
+ * getLoadedMarkerMtime — never throws.
+ */
+export async function wasEmitConsumed(entry: SourceBackoff | undefined): Promise<boolean> {
+  if (!entry || typeof entry.at !== "number" || entry.at <= 0 || !Array.isArray(entry.ids)) {
+    return false;
+  }
+  for (const id of entry.ids) {
+    if (typeof id !== "string") continue;
+    const mtime = await getLoadedMarkerMtime(id);
+    if (mtime !== null && mtime > entry.at) return true;
+  }
+  return false;
+}
+
+/**
+ * Record an actual emit for `source` (mutates in place). The streak
+ * increments only here — and only when a previous emit exists that went
+ * unconsumed; consumption (or no prior emit) resets it to 0.
+ */
+export function recordSourceEmit(
+  state: SessionState,
+  source: string,
+  ids: string[],
+  consumed: boolean,
+  now: number = Date.now(),
+): void {
+  const prev = state.sources?.[source];
+  const hadPrev = !!prev && typeof prev.at === "number" && prev.at > 0;
+  const prevStreak = hadPrev && typeof prev.streak === "number" ? prev.streak : 0;
+  const streak = hadPrev && !consumed ? prevStreak + 1 : 0;
+  if (!state.sources) state.sources = {};
+  state.sources[source] = { streak, at: now, ids: ids.slice(0, BACKOFF_IDS_CAP), skipped: 0 };
+}
+
+/** Record a suppressed would-be injection (mutates in place). */
+export function recordSourceSuppressed(state: SessionState, source: string): void {
+  const entry = state.sources?.[source];
+  if (!entry || typeof entry.skipped !== "number") return; // decide() required an entry
+  entry.skipped += 1;
 }

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -87,6 +87,10 @@ export interface RecallEvent extends BaseEvent {
   /** #121: the deeper candidate pool (incl. below-floor ranks) behind this recall,
    *  so the far slice is observable for offline harvesting. Lean {id, score} only. */
   candidate_pool?: { id: string; score: number }[];
+  /** #165: served BM25-only because the embedding circuit breaker was open
+   *  (no embed attempt). Absent = healthy hybrid or embeddings off — lets
+   *  stats separate degraded from normal recalls. */
+  embedding_degraded?: boolean;
 }
 
 export interface LoadMemoryEvent extends BaseEvent {
@@ -178,6 +182,8 @@ export interface HookRecallEvent extends BaseEvent {
   bridge_expansion?: BridgeExpansion;
   /** #121: the deeper candidate pool (incl. below-floor ranks) behind this recall. */
   candidate_pool?: { id: string; score: number }[];
+  /** #165: served BM25-only because the embedding circuit breaker was open. */
+  embedding_degraded?: boolean;
 }
 
 /**

--- a/packages/daemon/src/todo-hook.ts
+++ b/packages/daemon/src/todo-hook.ts
@@ -248,11 +248,13 @@ async function main(): Promise<void> {
   } else {
     // #161 empty-streak backoff (see session-state.ts): unconsumed injection
     // streaks widen the cadence; any load of an emitted candidate resets.
+    // REQUIRED-band hits (score >= MUST_LOAD_SCORE) bypass suppression.
     const sessionId = payload.session_id ?? "";
     const state = await loadSessionState(sessionId);
     const entry = state.sources?.[BACKOFF_SOURCE];
     const consumed = await wasEmitConsumed(entry);
-    const decision = decideBackoff(entry, consumed);
+    const hasRequired = filtered.some((h) => h.score >= MUST_LOAD_SCORE);
+    const decision = decideBackoff(entry, consumed, hasRequired);
     backoffStreak = decision.streak;
     suppressed = decision.suppress;
     const block = formatHintBlock(filtered, project, extraction.topics);

--- a/packages/daemon/src/todo-hook.ts
+++ b/packages/daemon/src/todo-hook.ts
@@ -27,12 +27,22 @@ import { randomUUID } from "node:crypto";
 import { envFirst, envInt } from "./env.js";
 import { defaultLogDir } from "./telemetry.js";
 import { reportHinted } from "./hook-hinted.js";
+import {
+  decideBackoff,
+  loadSessionState,
+  recordSourceEmit,
+  recordSourceSuppressed,
+  saveSessionState,
+  wasEmitConsumed,
+} from "./session-state.js";
 
 const HOOK_TIMEOUT_MS = envInt("BASTRA_HOOK_TIMEOUT_MS", 250, "NEXUS_HOOK_TIMEOUT_MS");
 const DEFAULT_PORT = 6723;
 const HOOK_VERSION = "0.2.0";
 const SCORE_FLOOR = 50;
 const MUST_LOAD_SCORE = 100;
+// #161: backoff source key — todo-plan hints back off independently.
+const BACKOFF_SOURCE = "todo-plan";
 const TOPIC_WORD_CAP = 3;
 const MIN_QUERY_LEN_WITHOUT_TOPICS = 10;
 
@@ -230,20 +240,42 @@ async function main(): Promise<void> {
   }
   if (resp && filtered.length === 0) status = "no-hits";
 
+  let backoffStreak = 0;
+  let suppressed = false;
+  let suppressedTokensEst = 0;
   if (filtered.length === 0) {
     emitEmpty();
   } else {
+    // #161 empty-streak backoff (see session-state.ts): unconsumed injection
+    // streaks widen the cadence; any load of an emitted candidate resets.
+    const sessionId = payload.session_id ?? "";
+    const state = await loadSessionState(sessionId);
+    const entry = state.sources?.[BACKOFF_SOURCE];
+    const consumed = await wasEmitConsumed(entry);
+    const decision = decideBackoff(entry, consumed);
+    backoffStreak = decision.streak;
+    suppressed = decision.suppress;
     const block = formatHintBlock(filtered, project, extraction.topics);
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          additionalContext: block,
-        },
-      }),
-    );
-    // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
-    await reportHinted(url, filtered.map((h) => h.id));
+    if (suppressed) {
+      // Suppressed emits {} exactly like the empty path (#161).
+      suppressedTokensEst = Math.ceil(block.length / 4);
+      recordSourceSuppressed(state, BACKOFF_SOURCE);
+      await saveSessionState(sessionId, state);
+      emitEmpty();
+    } else {
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            additionalContext: block,
+          },
+        }),
+      );
+      recordSourceEmit(state, BACKOFF_SOURCE, filtered.map((h) => h.id), consumed);
+      await saveSessionState(sessionId, state);
+      // Usage sidecar (#154): only what was ACTUALLY injected counts as surfaced.
+      await reportHinted(url, filtered.map((h) => h.id));
+    }
   }
 
   await writeTelemetry({
@@ -252,10 +284,13 @@ async function main(): Promise<void> {
     query_chars: extraction.query.length,
     daemon_url: url,
     daemon_reachable: resp !== null,
-    hit_count: filtered.length,
+    hit_count: suppressed ? 0 : filtered.length,
     top_score: resp?.hits?.[0]?.score ?? null,
     latency_ms_total: Date.now() - startedAt,
-    status,
+    backoff_streak: backoffStreak,
+    suppressed,
+    suppressed_tokens_est: suppressedTokensEst,
+    status: suppressed ? "suppressed" : status,
     error: errMsg,
   });
 }
@@ -395,7 +430,20 @@ interface TodoHookTelemetry {
   hit_count: number;
   top_score: number | null;
   latency_ms_total: number;
-  status: "ok" | "no-hits" | "daemon-unreachable" | "timeout" | "error" | "low-confidence";
+  /** #161: resolved streak of this event's backoff decision. */
+  backoff_streak?: number;
+  /** #161: true when the empty-streak backoff suppressed the injection. */
+  suppressed?: boolean;
+  /** #161: est. tokens of the NOT-injected block — the savings side of ROI. */
+  suppressed_tokens_est?: number;
+  status:
+    | "ok"
+    | "no-hits"
+    | "daemon-unreachable"
+    | "timeout"
+    | "error"
+    | "low-confidence"
+    | "suppressed";
   error: string | null;
 }
 

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -51,6 +51,10 @@ export interface ToolDeps {
   /** Optional query-language override for the bridge pool (sharedRecall.language);
    *  null/absent = auto-detect the query language per recall. */
   sharedRecallLang?: SupportedLanguage | null;
+  /** #165: true while the embedding circuit breaker is open — hybrid recall
+   *  is silently served BM25-only (no embed attempt). Recall telemetry flags
+   *  those events as embedding_degraded. Absent = no breaker (embeddings off). */
+  embeddingDegraded?: () => boolean;
 }
 
 // ─── Zod-Schemas ────────────────────────────────────────────────
@@ -255,6 +259,11 @@ export async function recallHandler(
   const hits = rawHits.filter((h) => h.score >= floor);
   const droppedBelowFloor = rawHits.length - hits.length;
 
+  // #165: BM25-only serviert, weil der Embedding-Breaker offen ist. Nach dem
+  // Recall ausgewertet — ein Probe-Call, der gerade fehlschlug, re-öffnet den
+  // Breaker und zählt korrekt als degraded.
+  const embeddingDegraded = deps.search.hasEmbeddings() && (deps.embeddingDegraded?.() ?? false);
+
   const recallId = deps.telemetry.newRecallId();
   fireAndForget(
     deps.telemetry.logRecall({
@@ -273,6 +282,7 @@ export async function recallHandler(
       bridge_expansion:
         expansion.lang && expansion.added.length > 0 ? { lang: expansion.lang, added: expansion.added } : undefined,
       candidate_pool: candidatePool.length > 0 ? candidatePool : undefined,
+      embedding_degraded: embeddingDegraded ? true : undefined,
     }),
   );
 

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -233,6 +233,11 @@ export async function recallHandler(
   const expansion = expandQuery(parsed.data.query, deps.learnedBridges, {
     configuredLang: deps.sharedRecallLang ?? null,
   });
+  // #165: VOR dem Recall ausgewertet — der Flag muss den Recall beschreiben,
+  // der gleich serviert wird. Post-Recall könnte ein parallel fehlschlagender
+  // Backfill-Batch den Breaker öffnen und einen gesunden Hybrid-Recall
+  // fälschlich als degraded loggen (bzw. ein Probe-Erfolg das Umgekehrte).
+  const embeddingDegraded = deps.search.hasEmbeddings() && (deps.embeddingDegraded?.() ?? false);
   let rawHits = deps.search.hasEmbeddings()
     ? await deps.search.recallHybrid(expansion.query, recallOpts)
     : deps.search.recall(expansion.query, recallOpts);
@@ -258,11 +263,6 @@ export async function recallHandler(
   const floor = parsed.data.min_score ?? RECALL_FLOOR;
   const hits = rawHits.filter((h) => h.score >= floor);
   const droppedBelowFloor = rawHits.length - hits.length;
-
-  // #165: BM25-only serviert, weil der Embedding-Breaker offen ist. Nach dem
-  // Recall ausgewertet — ein Probe-Call, der gerade fehlschlug, re-öffnet den
-  // Breaker und zählt korrekt als degraded.
-  const embeddingDegraded = deps.search.hasEmbeddings() && (deps.embeddingDegraded?.() ?? false);
 
   const recallId = deps.telemetry.newRecallId();
   fireAndForget(
@@ -571,7 +571,10 @@ function scoreSaveQuality(deps: ToolDeps, input: SaveMemoryInput): SaveQualityRe
     score -= 20;
   }
 
-  const duplicateQuery = [input.title, input.summary, ...input.recall_when, ...input.tags].join(" ");
+  // #162: kurze, diskriminierende Felder (title, tags, recall_when) zuerst,
+  // die potentiell lange summary zuletzt — falls der QUERY_MAX_CHARS-Cap
+  // greift, fällt nur Summary-Schwanz weg, nie ein diskriminierender Term.
+  const duplicateQuery = [input.title, ...input.tags, ...input.recall_when, input.summary].join(" ");
   const duplicateCandidates = deps.search
     .recall(duplicateQuery, { k: 5, scope: input.scope, type: input.type, allow_private: false })
     .filter((hit) => hit.id !== input.id)
@@ -692,10 +695,18 @@ async function saveMemoryInner(
   // routing silently relocates it on any edit (and trashes the original) — e.g.
   // a memories/people/ memo updated without folder gets re-routed to
   // memories/projects/<scope>/. An explicit folder still moves it (#64 re-filing).
+  // #188: Bestehende Obsidian-Aliases durchreichen — saveMemory erhält sie
+  // sonst nur beim Same-Path-Overwrite; beim Re-Filing (neuer Ordner) liest
+  // es den neuen Pfad und fände sie nicht. Kein Tool-Schema-Feld: aliases
+  // ist Substrat-Plumbing, kein Agent-Knob.
+  const base =
+    previous && parsed.data.aliases === undefined
+      ? { ...parsed.data, aliases: previous.fm.aliases }
+      : parsed.data;
   const input =
     previous && !parsed.data.folder
-      ? { ...parsed.data, folder: relative(deps.vaultPath, dirname(previous.filePath)) }
-      : parsed.data;
+      ? { ...base, folder: relative(deps.vaultPath, dirname(previous.filePath)) }
+      : base;
 
   const result = await saveMemory(deps.vaultPath, input);
   if (previous && previous.filePath !== result.file_path) {

--- a/packages/eval/__tests__/boost-drift.test.ts
+++ b/packages/eval/__tests__/boost-drift.test.ts
@@ -2,10 +2,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { Memory } from "@bastra-recall/core";
 import {
   BASE_BOOST,
   TREATMENT_RECALL_WHEN_BOOST,
   EXPANDED_RECALL_WHEN_BOOST,
+  buildIndex,
 } from "../src/index-config.js";
 
 /**
@@ -37,4 +39,56 @@ test("ablation field weights stay in sync with core SearchIndex", () => {
       `core/src/search.ts should boost ${field} at ${weight} — update index-config.ts if core changed`,
     );
   }
+});
+
+/**
+ * Tokenizer drift guard (#162). Core swapped MiniSearch's default tokenizer
+ * for the identifier-preserving `tokenizeWithIdentifiers` on BOTH the index
+ * and the query side. The ablation must tokenize identically, or its BM25
+ * numbers describe a different index than production. index-config.ts
+ * IMPORTS the tokenizer (no hand mirror), so the only drift left to guard is
+ * the wiring itself — on both sides.
+ */
+const indexConfigSrc = readFileSync(
+  resolve(import.meta.dirname, "../src/index-config.ts"),
+  "utf8",
+);
+
+test("tokenizer wiring stays in sync with core SearchIndex", () => {
+  assert.match(
+    searchSrc,
+    /tokenize:\s*tokenizeWithIdentifiers/,
+    "core/src/search.ts should wire tokenizeWithIdentifiers as the top-level tokenizer — update index-config.ts if core changed",
+  );
+  assert.match(
+    indexConfigSrc,
+    /tokenize:\s*tokenizeWithIdentifiers/,
+    "index-config.ts should pass core's tokenizeWithIdentifiers as the top-level tokenizer",
+  );
+  assert.doesNotMatch(
+    indexConfigSrc,
+    /searchOptions:[^}]*tokenize/s,
+    "no separate searchOptions.tokenize — that would break index/query tokenization symmetry (see core query-normalize.ts)",
+  );
+});
+
+test("ablation index dual-emits identifiers exactly like core (behavioral pin)", () => {
+  const memory = {
+    fm: {
+      id: "tok-probe",
+      title: "vite aliases in my-app.config.ts",
+      summary: "alias block mirrors tsconfig paths",
+      tags: ["vite"],
+      topic_path: ["test"],
+      recall_when: ["editing my-app.config.ts build settings"],
+    },
+    body: "Alias block in my-app.config.ts must mirror tsconfig paths.",
+  } as unknown as Memory;
+  const idx = buildIndex([memory], { kind: "treatment", boost: TREATMENT_RECALL_WHEN_BOOST });
+  const hits = idx.search("my-app.config.ts");
+  assert.equal(hits[0]?.id, "tok-probe");
+  assert.ok(
+    hits[0].terms.includes("my-app.config.ts"),
+    `the JOINED identifier must be a matched term, not just its split parts (got: ${hits[0].terms.join(", ")})`,
+  );
 });

--- a/packages/eval/src/index-config.ts
+++ b/packages/eval/src/index-config.ts
@@ -1,4 +1,5 @@
 import MiniSearch from "minisearch";
+import { tokenizeWithIdentifiers } from "@bastra-recall/core";
 import type { Memory } from "@bastra-recall/core";
 
 /**
@@ -91,6 +92,11 @@ export function buildIndex(memories: Memory[], arm: Arm): MiniSearch<IndexDoc> {
   const mini = new MiniSearch<IndexDoc>({
     fields,
     storeFields: ["id"],
+    // Core's identifier-preserving tokenizer (#162) — top-level `tokenize`
+    // applies to index AND query side (no searchOptions.tokenize, same
+    // symmetry rule as core SearchIndex). Imported, not mirrored, so the
+    // ablation cannot drift from production tokenization.
+    tokenize: tokenizeWithIdentifiers,
     searchOptions: { boost, ...SEARCH_OPTIONS },
   });
   mini.addAll(memories.map(toDoc));


### PR DESCRIPTION
## What

Six independent v0.8 issues, implemented in parallel and integrated:

- **#165 Embedding circuit breaker** — after 3 consecutive provider failures, hybrid recall degrades silently to BM25-only for a 60s cooldown (no per-query timeout cost), half-open probe re-closes. Resets on Ollama autostart; poisoned-batch shape mismatches don't trip it; `/health` carries the breaker snapshot incl. root cause; telemetry flags degraded episodes (`embedding_degraded`, captured pre-recall).
- **#162 Query normalizer** — identifier-preserving tokenization (`my-app.config.ts`, `chat-send`, `P2.2`) via a shared MiniSearch tokenizer on **both** index and query side (dual-emission: joined + parts, so recall ≥ status quo). Hostile-input hygiene: 8000-char cap at word boundaries, dangling-operator strip. Bridge expansion terms structurally survive the cap (base capped before append). Eval harness now imports the same tokenizer, drift-guarded.
- **#161 Hook empty-streak backoff** — per source + session: hint injections whose predecessors go unconsumed widen their cadence (cap 8×); any load/acted_on resets. **Safety carve-outs (from review):** the bash-tripwire STOP warning is fully exempt; emissions containing REQUIRED-band hits (≥ MUST_LOAD_SCORE) always emit; explicit retrieval prompts never suppress. Suppressed events log `backoff_streak`/`suppressed` for net-context-ROI.
- **#180 npx stable runtime** — npx-based installs copy the runtime to `~/.bastra/runtime/<version>/` and register **all** paths (forwarder, 6–7 hooks, statusline) from there instead of the ephemeral npx cache; old versions pruned on install, removed on `uninstall all`; doctor warns on remaining `_npx` registrations.
- **#181 Uninstall skill sweep** — after the surface loop, the shared skill is removed when no skill-sharing registration remains (failed surfaces count as still registered); adapter output defers to the sweep; dry-run honest.
- **#188 Sidecar aliases** — document sidecars carry `aliases: [<doc-id>]` so the enricher's `[[doc-id]]` cross-links resolve in Obsidian (no more empty stray notes). Schema coerces any YAML alias shape (numbers, dates, bare scalars, null) — a memory is never rejected over aliases; `save_memory` overwrite preserves them.

## Process

Implemented as 6 parallel worktree agents (91 new tests), then adversarially reviewed by a 25-agent workflow (5 dimensions → per-finding refutation): **20 findings confirmed, 0 refuted — all 20 fixed** in a second parallel round (5 fix clusters), including one critical (backoff could suppress the destructive-command STOP warning) and the REQUIRED-band/npx-bins gaps.

## Verification

- Suites: **core 141, daemon 466, eval 9 — all green** (+150 tests vs. main)
- Full typecheck clean across packages

Closes #165. Closes #162. Closes #161. Closes #180. Closes #181. Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)