### PR TITLE
eval: d2q wiki stand, plus the docs/live/graph fixes that were sitting local

### DIFF
--- a/packages/core/__tests__/graph-import-cluster.test.ts
+++ b/packages/core/__tests__/graph-import-cluster.test.ts
@@ -1,0 +1,70 @@
+/**
+ * A single imported batch must not collapse into one cluster.
+ *
+ * #217 gives each batch its own cluster (`<label> (import)`), which keeps two
+ * imports apart — but with one batch there is nothing to keep apart and the
+ * blob returns. `import vault` writes every file flat into
+ * `memories/imported/<label>/`, so the folder axis carries no information for
+ * those notes; the importer records the source hierarchy in `topic_path`
+ * (["imported", <label>, …rel]). clusterKeyFor/subKeyFor read that, the same
+ * way `projects` is unpacked so a single blob doesn't swallow the map. The
+ * " (import)" suffix stays on either path, so the collision guard holds.
+ *
+ * Runner: `tsx --test __tests__/graph-import-cluster.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { clusterKeyFor, subKeyFor } from "../src/graph.js";
+import type { Memory } from "../src/schema.js";
+
+const ROOT = "/vault";
+
+function mem(relPath: string, topic_path: string[], scope = "batch"): Memory {
+  return {
+    fm: { id: "x", title: "x", type: "reference", scope, topic_path, tags: [] },
+    filePath: join(ROOT, relPath),
+  } as unknown as Memory;
+}
+
+test("imported note takes its cluster from the source subfolder", () => {
+  const m = mem("memories/imported/batch/note.md", ["imported", "batch", "recipes"]);
+  assert.equal(clusterKeyFor(m, ROOT), "recipes (import)");
+});
+
+test("imported note flat in the source falls back to the batch label", () => {
+  const m = mem("memories/imported/batch/note.md", ["imported", "batch"]);
+  assert.equal(clusterKeyFor(m, ROOT), "batch (import)");
+});
+
+test("second source level becomes the sub-area", () => {
+  const m = mem("memories/imported/batch/note.md", ["imported", "batch", "recipes", "drafts"]);
+  assert.equal(clusterKeyFor(m, ROOT), "recipes (import)");
+  assert.equal(subKeyFor(m, ROOT), "drafts");
+});
+
+test("flat imported note has no sub-area", () => {
+  const m = mem("memories/imported/batch/note.md", ["imported", "batch"]);
+  assert.equal(subKeyFor(m, ROOT), "general");
+});
+
+test("a topic_path not written by the importer is left alone", () => {
+  // Hand-authored note that merely happens to live in the imported folder:
+  // no "imported" head, so the label stays the cluster.
+  const m = mem("memories/imported/batch/note.md", ["personal", "notes"]);
+  assert.equal(clusterKeyFor(m, ROOT), "batch (import)");
+  assert.equal(subKeyFor(m, ROOT), "general");
+});
+
+test("the (import) suffix never collides with a real cluster of the same name", () => {
+  const imported = mem("memories/imported/batch/note.md", ["imported", "batch", "acme"]);
+  const real = mem("memories/projects/acme/plan.md", ["projects", "acme"]);
+  assert.notEqual(clusterKeyFor(imported, ROOT), clusterKeyFor(real, ROOT));
+});
+
+test("non-imported clusters are unchanged", () => {
+  const proj = mem("memories/projects/acme/plan.md", ["projects", "acme"]);
+  assert.equal(clusterKeyFor(proj, ROOT), "acme");
+  const user = mem("memories/user/profile.md", ["user"]);
+  assert.equal(clusterKeyFor(user, ROOT), "user");
+});

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -90,10 +90,18 @@ export interface VaultGraph {
   edge_counts: { related: number; related_via: number };
 }
 
+/** Source hierarchy an import batch recorded in `topic_path`, past its own
+ *  ["imported", <label>] prefix. Empty for files that sat flat in the source. */
+function importedTopicSegments(m: Memory): string[] {
+  const tp = m.fm.topic_path ?? [];
+  return tp[0] === "imported" ? tp.slice(2) : [];
+}
+
 /**
  * Cluster key from the memory's location in the vault:
  *   memories/projects/<scope>/… → "<scope>"
- *   memories/imported/<label>/… → "<label> (import)"
+ *   memories/imported/<label>/… → "<source folder> (import)", else
+ *                                 "<label> (import)"
  *   memories/<top>/…            → "<top>"
  *   <top>/…                     → "<top>"   (e.g. dokumentationen)
  * Files outside the root (linked docs) fall back to the frontmatter scope.
@@ -103,6 +111,18 @@ export interface VaultGraph {
  * its own color, visually dissolving as adoption drains it. The " (import)"
  * suffix keeps the key from ever colliding with a real project cluster of
  * the same name.
+ *
+ * Per label is necessary but not sufficient: with a SINGLE batch there is
+ * nothing to keep apart, and the blob comes back whole. The importer writes
+ * every file flat into `memories/imported/<label>/`, so the folder axis is
+ * empty by construction — but the source hierarchy is not lost, only unread:
+ * it sits in `topic_path` as ["imported", <label>, …sourceSegments]. Read it,
+ * and keep the suffix, so the collision guard above still holds.
+ *
+ * This moves keys only: node, edge and ghost counts are identical either way.
+ * The fixture in graph-import-cluster.test.ts pins both halves — a nested
+ * source keeps its top folder as the cluster, a flat one falls back to the
+ * batch label, and non-imported clusters stay untouched.
  */
 export function clusterKeyFor(m: Memory, vaultRoot: string): string {
   const rel = relative(vaultRoot, m.filePath);
@@ -114,7 +134,7 @@ export function clusterKeyFor(m: Memory, vaultRoot: string): string {
     return parts[2];
   }
   if (top === "imported" && parts[0] === "memories" && parts.length > 3) {
-    return `${parts[2]} (import)`;
+    return `${importedTopicSegments(m)[0] ?? parts[2]} (import)`;
   }
   return top;
 }
@@ -179,6 +199,11 @@ export function subKeyFor(m: Memory, vaultRoot: string): string {
     idx = (parts[1] === "projects" || parts[1] === "imported") && parts.length > 3 ? 2 : 1;
   } else {
     idx = 0;
+  }
+  // Imported sets are flat on disk, so the folder axis can never answer this.
+  // The second source segment is the sub-area, same as a folder would be.
+  if (parts[0] === "memories" && parts[1] === "imported") {
+    return importedTopicSegments(m)[1] ?? "general";
   }
   // a sub-area exists when there is at least one more folder before the file
   return parts.length > idx + 2 ? parts[idx + 1] : "general";

--- a/packages/daemon/__tests__/documents-empty-corpus.test.ts
+++ b/packages/daemon/__tests__/documents-empty-corpus.test.ts
@@ -1,0 +1,131 @@
+/**
+ * `find_document` liefert `docs_indexed` — das Gegenstück zu `vault_size`
+ * bei `recall`.
+ *
+ * Ohne die Zahl ist `hits: []` auf einem nie befüllten Doc-Vault nicht von
+ * „gesucht und nichts gefunden" zu unterscheiden. Ein Agent liest die leere
+ * Liste dann als Aussage über die Welt („der User hat das Dokument nicht")
+ * statt als Zustand des Index — und die Tool-Beschreibung weist ihn an,
+ * `find_document` VOR anderen Lookups zu fragen. Genau dieser stille
+ * Nullfall wird hier festgenagelt.
+ *
+ * Runner: `node --import tsx --test packages/daemon/__tests__/documents-empty-corpus.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+
+import { findDocument } from "../src/documents-handler.js";
+
+function memoryMarkdown(
+  id: string,
+  title: string,
+  type: string,
+  sensitivity?: string,
+): string {
+  const ts = new Date().toISOString();
+  return [
+    "---",
+    `id: ${id}`,
+    `title: ${title}`,
+    `type: ${type}`,
+    `summary: ${title} summary`,
+    ...(sensitivity ? [`sensitivity: ${sensitivity}`] : []),
+    "topic_path:",
+    "  - test",
+    "tags:",
+    "  - test",
+    "scope: empty-corpus-test",
+    "recall_when:",
+    `  - ${title}`,
+    `created: ${ts}`,
+    `updated: ${ts}`,
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+async function makeVault(
+  files: Array<{ name: string; content: string }>,
+): Promise<{ vault: Vault; search: SearchIndex; close: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-empty-corpus-"));
+  for (const f of files) {
+    await writeFile(join(dir, f.name), f.content, "utf8");
+  }
+  const vault = new Vault(dir);
+  await vault.init();
+  const search = new SearchIndex(vault);
+  search.start();
+  return {
+    vault,
+    search,
+    close: async () => {
+      search.stop();
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("leerer Doc-Vault meldet docs_indexed: 0", async () => {
+  const { vault, search, close } = await makeVault([
+    // Memories ja, Documents nein — der reale Zustand eines frischen Vaults.
+    { name: "lesson.md", content: memoryMarkdown("a-lesson", "zebra handling", "lesson") },
+  ]);
+  try {
+    const res = findDocument(search, vault, { query: "zebra handling" });
+    assert.equal(res.docs_indexed, 0);
+    assert.deepEqual(res.hits, []);
+  } finally {
+    await close();
+  }
+});
+
+test("befüllter Doc-Vault: erfolgloser Query liefert hits: [] MIT docs_indexed > 0", async () => {
+  const { vault, search, close } = await makeVault([
+    { name: "doc.md", content: memoryMarkdown("zebra-doc", "zebra handling", "doc") },
+  ]);
+  try {
+    const miss = findDocument(search, vault, { query: "quantenchromodynamik" });
+    // Der eigentliche Punkt: dieselbe leere hits-Liste wie oben, aber
+    // unterscheidbar — hier wurde wirklich gesucht.
+    assert.deepEqual(miss.hits, []);
+    assert.equal(miss.docs_indexed, 1);
+
+    const hit = findDocument(search, vault, { query: "zebra handling" });
+    assert.equal(hit.docs_indexed, 1);
+    assert.ok(hit.hits.length > 0, "passender Query muss den Doc-Hit liefern");
+  } finally {
+    await close();
+  }
+});
+
+test("docs_indexed respektiert den Sensitivity-Filter des Callers", async () => {
+  const { vault, search, close } = await makeVault([
+    {
+      name: "private-doc.md",
+      content: memoryMarkdown("secret-doc", "zebra handling", "doc", "private"),
+    },
+  ]);
+  try {
+    // Externer MCP-Caller: private Docs existieren für ihn nicht — die Zahl
+    // darf ihre Existenz nicht verraten.
+    const external = findDocument(search, vault, { query: "zebra handling" });
+    assert.equal(external.docs_indexed, 0);
+
+    // Mac-App ruft mit allowPrivate.
+    const internal = findDocument(
+      search,
+      vault,
+      { query: "zebra handling" },
+      { allowPrivate: true },
+    );
+    assert.equal(internal.docs_indexed, 1);
+  } finally {
+    await close();
+  }
+});

--- a/packages/daemon/__tests__/live-updates.test.ts
+++ b/packages/daemon/__tests__/live-updates.test.ts
@@ -282,3 +282,60 @@ test("live updates: buffer overflow surfaces a gap signal, never a silent drop",
     await h.cleanup();
   }
 });
+
+test("live updates: a recall notice carries its band and re-announces at most once per window", async () => {
+  // #221: recall is the loudest path in the system — the same memory is a top
+  // hit dozens of times per working session. Coalescing does not cover that
+  // (those events are minutes apart, not milliseconds), so the id-level
+  // re-announce window is what keeps the card from looping the same title.
+  const REANN = 500;
+  const QUIET = REANN + 120; // comfortably past one re-announce window
+  const h = await harness({ reannounceMs: REANN });
+  const { vault, memDir, live, call } = h;
+  const file = join(memDir, "hot-note.md");
+
+  try {
+    await h.enableUi();
+    await writeFile(file, memoryMarkdown("hot-note", "Hot note"));
+    await vault.reindexFile(file);
+    await delay(AFTER);
+    let r = await call(0);
+    assert.equal(r.json.updates.length, 1, "the memory is born");
+    let cursor = r.json.updates[0].seq;
+    await delay(QUIET); // let the birth's window expire
+
+    // a served hit announces itself, and says which band served it
+    live.notifyRead("hot-note", "required");
+    await delay(AFTER);
+    r = await call(cursor);
+    assert.equal(r.json.updates.length, 1);
+    assert.equal(r.json.updates[0].kind, "read");
+    assert.equal(r.json.updates[0].band, "required", "the band travels with the notice");
+    cursor = r.json.updates[0].seq;
+
+    // a recall storm inside the window adds nothing — this is the flood guard
+    live.notifyRead("hot-note", "optional");
+    live.notifyRead("hot-note", "required");
+    await delay(AFTER);
+    assert.equal((await call(cursor)).json.updates.length, 0, "re-surfaced inside the window stays quiet");
+
+    // what the user actually changes is never silenced by the read cooldown
+    await writeFile(file, memoryMarkdown("hot-note", "Hot note v2"));
+    await vault.reindexFile(file);
+    await delay(AFTER);
+    r = await call(cursor);
+    assert.equal(r.json.updates.length, 1);
+    assert.equal(r.json.updates[0].kind, "change", "vault events ignore the read cooldown");
+    cursor = r.json.updates[0].seq;
+
+    // past the window the same memory may speak again
+    await delay(QUIET);
+    live.notifyRead("hot-note", "optional");
+    await delay(AFTER);
+    r = await call(cursor);
+    assert.equal(r.json.updates.length, 1, "the window reopens");
+    assert.equal(r.json.updates[0].band, "optional");
+  } finally {
+    await h.cleanup();
+  }
+});

--- a/packages/daemon/__tests__/telemetry-surfaced-notice.test.ts
+++ b/packages/daemon/__tests__/telemetry-surfaced-notice.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests für die "surfaced"-Notice (#221): recall UND hook_recall lassen ihre
+ * Top-3-Treffer über den onRecalled-Hook aufleuchten — nicht nur das seltene
+ * load_memory. Der Hook feuert VOR dem enabled-Gate (UI-Signal, nicht
+ * Persistenz) und deckelt auf Top-3.
+ *
+ * Runner: `tsx --test __tests__/telemetry-surfaced-notice.test.ts`
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Telemetry } from "../src/telemetry.js";
+
+const hit = (id: string, score: number) => ({ id, score, type: "memory" });
+
+test("onRecalled fires with the top-3 recall hits (capped)", async () => {
+  const telemetry = new Telemetry();
+  const seen: string[][] = [];
+  telemetry.onRecalled = (ids) => seen.push(ids);
+
+  await telemetry.logRecall({
+    recall_id: "r1",
+    query: "q",
+    k: 5,
+    scope: null,
+    type: null,
+    vault_size: 10,
+    hit_count: 5,
+    top_score: 90,
+    hits: [hit("a", 90), hit("b", 80), hit("c", 70), hit("d", 60), hit("e", 50)],
+    latency_ms: 1,
+    recall_stages: undefined,
+    dropped_below_floor: 0,
+  });
+
+  assert.deepEqual(seen, [["a", "b", "c"]], "only the top-3 ids light up");
+});
+
+test("onRecalled fires on the hook_recall path too", async () => {
+  const telemetry = new Telemetry();
+  const seen: string[][] = [];
+  telemetry.onRecalled = (ids) => seen.push(ids);
+
+  await telemetry.logHookRecall({
+    recall_id: "h1",
+    query: "q",
+    hits: [hit("x", 88), hit("y", 77)],
+  });
+
+  assert.deepEqual(seen, [["x", "y"]], "hook_recall surfaces its hits (< 3 = all)");
+});
+
+test("a throwing onRecalled never breaks the recall", async () => {
+  const telemetry = new Telemetry();
+  telemetry.onRecalled = () => {
+    throw new Error("notice sink blew up");
+  };
+  await assert.doesNotReject(
+    telemetry.logRecall({
+      recall_id: "r2",
+      query: "q",
+      k: 1,
+      scope: null,
+      type: null,
+      vault_size: 1,
+      hit_count: 1,
+      top_score: 90,
+      hits: [hit("a", 90)],
+      latency_ms: 1,
+      recall_stages: undefined,
+      dropped_below_floor: 0,
+    }),
+  );
+});

--- a/packages/daemon/__tests__/telemetry-surfaced-notice.test.ts
+++ b/packages/daemon/__tests__/telemetry-surfaced-notice.test.ts
@@ -1,21 +1,29 @@
 /**
  * Tests für die "surfaced"-Notice (#221): recall UND hook_recall lassen ihre
- * Top-3-Treffer über den onRecalled-Hook aufleuchten — nicht nur das seltene
- * load_memory. Der Hook feuert VOR dem enabled-Gate (UI-Signal, nicht
- * Persistenz) und deckelt auf Top-3.
+ * servierten Treffer über den onRecalled-Hook aufleuchten — nicht nur das
+ * seltene load_memory. Der Hook feuert VOR dem enabled-Gate (UI-Signal, nicht
+ * Persistenz).
+ *
+ * Was "serviert" heißt, entscheidet das Band (BASTRA_RECALL_FLOOR /
+ * BASTRA_MUST_LOAD_SCORE), nicht ein von Hand gesetztes Top-N: ein
+ * `below_floor`-Treffer wurde dem Modell nie gezeigt, eine Notice dafür würde
+ * der Karte etwas anzeigen, das der Turn nicht gesehen hat. Die Deckelung auf
+ * drei bleibt als Obergrenze bestehen.
  *
  * Runner: `tsx --test __tests__/telemetry-surfaced-notice.test.ts`
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { Telemetry } from "../src/telemetry.js";
+import type { RecallBand } from "../src/telemetry.js";
 
 const hit = (id: string, score: number) => ({ id, score, type: "memory" });
+type Notice = { id: string; band: RecallBand };
 
-test("onRecalled fires with the top-3 recall hits (capped)", async () => {
+test("onRecalled fires with the served recall hits, capped at three", async () => {
   const telemetry = new Telemetry();
-  const seen: string[][] = [];
-  telemetry.onRecalled = (ids) => seen.push(ids);
+  const seen: Notice[][] = [];
+  telemetry.onRecalled = (hits) => seen.push(hits);
 
   await telemetry.logRecall({
     recall_id: "r1",
@@ -32,13 +40,21 @@ test("onRecalled fires with the top-3 recall hits (capped)", async () => {
     dropped_below_floor: 0,
   });
 
-  assert.deepEqual(seen, [["a", "b", "c"]], "only the top-3 ids light up");
+  assert.deepEqual(
+    seen,
+    [[
+      { id: "a", band: "optional" },
+      { id: "b", band: "optional" },
+      { id: "c", band: "optional" },
+    ]],
+    "only three light up, each carrying the band that served it",
+  );
 });
 
 test("onRecalled fires on the hook_recall path too", async () => {
   const telemetry = new Telemetry();
-  const seen: string[][] = [];
-  telemetry.onRecalled = (ids) => seen.push(ids);
+  const seen: Notice[][] = [];
+  telemetry.onRecalled = (hits) => seen.push(hits);
 
   await telemetry.logHookRecall({
     recall_id: "h1",
@@ -46,7 +62,48 @@ test("onRecalled fires on the hook_recall path too", async () => {
     hits: [hit("x", 88), hit("y", 77)],
   });
 
-  assert.deepEqual(seen, [["x", "y"]], "hook_recall surfaces its hits (< 3 = all)");
+  assert.deepEqual(
+    seen,
+    [[
+      { id: "x", band: "optional" },
+      { id: "y", band: "optional" },
+    ]],
+    "hook_recall surfaces its hits (< 3 = all)",
+  );
+});
+
+test("the band labels a notice, it never swallows one", async () => {
+  const telemetry = new Telemetry();
+  const seen: Notice[][] = [];
+  telemetry.onRecalled = (hits) => seen.push(hits);
+
+  await telemetry.logRecall({
+    recall_id: "r3",
+    query: "q",
+    k: 3,
+    scope: null,
+    type: null,
+    vault_size: 10,
+    hit_count: 3,
+    top_score: 140,
+    // whatever sits in hits[] was already served — on this path behind the
+    // caller's own min_score, which may legitimately sit under the global
+    // floor. Re-cutting it here would hide something the turn did see.
+    hits: [hit("must", 140), hit("maybe", 45), hit("faint", 3)],
+    latency_ms: 1,
+    recall_stages: undefined,
+    dropped_below_floor: 0,
+  });
+
+  assert.deepEqual(
+    seen,
+    [[
+      { id: "must", band: "required" },
+      { id: "maybe", band: "optional" },
+      { id: "faint", band: "below_floor" },
+    ]],
+    "every served hit lights up, each carrying the band it was served in",
+  );
 });
 
 test("a throwing onRecalled never breaks the recall", async () => {

--- a/packages/daemon/src/documents-handler.ts
+++ b/packages/daemon/src/documents-handler.ts
@@ -37,7 +37,13 @@ export const documentTools = [
     description:
       "Search the user's document vault (PDFs, notes, contracts, code) " +
       "and return top-3 hits with id, title, summary and score. " +
-      "Pair with read_document to load full content.",
+      "Pair with read_document to load full content. " +
+      "The response carries `docs_indexed`: how many documents this caller " +
+      "can see at all. When it is 0 the vault holds no documents yet — an " +
+      "empty `hits` array then says nothing about whether the user has the " +
+      "thing you are looking for, so do NOT report it as absent; fall back " +
+      "to other lookups (recall, the filesystem) and say which surface you " +
+      "actually searched.",
     inputSchema: {
       type: "object",
       properties: {
@@ -93,23 +99,53 @@ export const documentTools = [
 // ─── Handler implementations ─────────────────────────────────────
 
 /**
+ * Zählt die Documents, die DIESER Caller sehen darf. Spiegelt den
+ * Sensitivity-Filter aus `findDocument`/`readDocument`, damit die Zahl nie
+ * die Existenz privater Docs an externe MCP-Caller verrät.
+ */
+function visibleDocCount(vault: Vault, allowPrivate: boolean): number {
+  let n = 0;
+  for (const m of vault.list()) {
+    if (m.fm.type !== "doc") continue;
+    if (!allowPrivate && (m.fm as { sensitivity?: string }).sensitivity === "private") {
+      continue;
+    }
+    n++;
+  }
+  return n;
+}
+
+/**
  * Filtert Recall-Hits auf type=doc und liefert die Top-k. SearchIndex
  * versteht den `type`-Filter bereits — wir delegieren komplett dahin.
  * Sensitivity (#58) wird über `allowPrivate` propagiert: externe MCP-Caller
  * sehen nur `team`+`public` Documents, die Mac-App ruft mit `true`.
+ *
+ * `docs_indexed` ist das Gegenstück zu `vault_size` bei `recall`: ohne die
+ * Zahl ist `hits: []` auf einem NIE befüllten Doc-Vault nicht von „gesucht
+ * und nichts gefunden" zu unterscheiden — der Caller liest die leere Liste
+ * als Antwort über die Welt statt als Zustand des Index. Da die Tool-
+ * Beschreibung Agents anweist, `find_document` VOR anderen Lookups zu
+ * fragen, ist dieser stille Nullfall besonders teuer.
  */
 export function findDocument(
   search: SearchIndex,
+  vault: Vault,
   args: { query: string; k?: number },
   opts: { allowPrivate?: boolean } = {},
-): { query: string; hits: Array<unknown> } {
+): { query: string; docs_indexed: number; hits: Array<unknown> } {
   const k = args.k ?? 3;
+  const allowPrivate = opts.allowPrivate ?? false;
   const hits = search.recall(args.query, {
     k,
     type: "doc",
-    allow_private: opts.allowPrivate ?? false,
+    allow_private: allowPrivate,
   });
-  return { query: args.query, hits };
+  return {
+    query: args.query,
+    docs_indexed: visibleDocCount(vault, allowPrivate),
+    hits,
+  };
 }
 
 /**

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -1151,7 +1151,7 @@ async function dispatchApi(
     case "find_document": {
       const parsed = FindDocumentArgs.safeParse(body);
       if (!parsed.success) throw new Error(parsed.error.message);
-      return findDocument(search, parsed.data);
+      return findDocument(search, vault, parsed.data);
     }
     case "read_document": {
       const parsed = ReadDocumentArgs.safeParse(body);

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -292,11 +292,13 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
   const liveUpdates = createLiveUpdates(vault);
   // "read"-Notices (#216): jeder load_memory landet als Live-Ereignis in der Map
   telemetry.onMemoryLoaded = (id) => liveUpdates.notifyRead(id);
-  // "surfaced"-Notices (#221): recall/hook_recall lassen ihre Top-Treffer
-  // aufleuchten — nicht nur das seltene load_memory. Der REANNOUNCE-Cooldown
-  // in live-updates deckelt die Frequenz pro id.
-  telemetry.onRecalled = (ids) => {
-    for (const id of ids) liveUpdates.notifyRead(id);
+  // "surfaced"-Notices (#221): recall/hook_recall lassen ihre servierten
+  // Treffer aufleuchten — nicht nur das seltene load_memory. Was serviert
+  // gilt, entscheidet das Band (`surfacedHits` in telemetry.ts), nicht ein
+  // hier gesetztes Top-N; der REANNOUNCE-Cooldown in live-updates deckelt
+  // dann die Frequenz pro id.
+  telemetry.onRecalled = (hits) => {
+    for (const h of hits) liveUpdates.notifyRead(h.id, h.band);
   };
 
   // env wins (ops override); else the token minted by `bastra token` in

--- a/packages/daemon/src/http.ts
+++ b/packages/daemon/src/http.ts
@@ -292,6 +292,12 @@ export async function startHttpServer(opts: HttpOptions): Promise<HttpHandle> {
   const liveUpdates = createLiveUpdates(vault);
   // "read"-Notices (#216): jeder load_memory landet als Live-Ereignis in der Map
   telemetry.onMemoryLoaded = (id) => liveUpdates.notifyRead(id);
+  // "surfaced"-Notices (#221): recall/hook_recall lassen ihre Top-Treffer
+  // aufleuchten — nicht nur das seltene load_memory. Der REANNOUNCE-Cooldown
+  // in live-updates deckelt die Frequenz pro id.
+  telemetry.onRecalled = (ids) => {
+    for (const id of ids) liveUpdates.notifyRead(id);
+  };
 
   // env wins (ops override); else the token minted by `bastra token` in
   // cli-settings.json. Empty = no token issued → browser clients are rejected.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -530,7 +530,7 @@ async function main(): Promise<void> {
     if (name === "find_document") {
       const parsed = FindDocumentArgs.safeParse(args);
       if (!parsed.success) return errorResult(parsed.error.message);
-      const result = findDocument(search, parsed.data);
+      const result = findDocument(search, vault, parsed.data);
       return {
         content: [
           { type: "text", text: JSON.stringify(result, null, 2) },

--- a/packages/daemon/src/live-updates.ts
+++ b/packages/daemon/src/live-updates.ts
@@ -30,6 +30,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { clusterKeyFor, type Memory, type Vault } from "@bastra-recall/core";
 import { sendJsonPlain } from "./webui.js";
 import { getUiEnabled } from "./settings.js";
+import { envInt } from "./env.js";
+import type { RecallBand } from "./telemetry.js";
 
 export type LiveUpdateKind = "add" | "change" | "delete" | "read";
 
@@ -48,10 +50,30 @@ export interface LiveUpdate {
    *  adoptiert ihn als echten Node, ohne auf den Graph-Reload zu warten. */
   salience?: number;
   emotion?: string;
+  /** #221: bei einer recall-getriebenen "read"-Notice das Band, in dem der
+   *  Treffer serviert wurde (`required` | `optional`). Fehlt bei load_memory
+   *  und bei allen Vault-Ereignissen. */
+  band?: RecallBand;
 }
 
 const MAX_ENTRIES = 500; // ring buffer — lossless within realistic poll gaps
 const DEBOUNCE_MS = 2000; // quiet window per memory id before an entry finalizes
+/**
+ * #221: Wiederankündigungs-Sperre pro id. Recall ist der mit Abstand
+ * häufigste Pfad — dieselbe Memory taucht über eine Arbeitssitzung dutzendfach
+ * in den Top-Treffern auf. Die Debounce-Fenster fangen das NICHT: sie
+ * kollabieren nur Bursts innerhalb von Sekunden, während Recalls minutenlang
+ * auseinander liegen und so jedes Mal eine neue Karte erzeugen würden. Ein
+ * Vault-Ereignis (add/change/delete) ist davon nie betroffen — was der Nutzer
+ * tatsächlich ändert, wird immer angekündigt.
+ *
+ * 180s ist gesetzt, nicht gemessen — die ehrliche Zahl wäre der Median-Abstand
+ * zwischen zwei Surfacings derselben id, den die Telemetrie beantworten kann.
+ * Bis dahin env-tunbar wie die übrigen Fenster, damit die Vorgabe kein Dogma
+ * ist. Die Notices selbst sind bewusst DEFAULT AN: ein Feature, das man erst
+ * einschalten muss, wird nie eingeschaltet.
+ */
+const REANNOUNCE_MS = envInt("BASTRA_REANNOUNCE_MS", 180_000);
 
 // hotness rank for coalescing — a hotter kind seen in the window wins the entry
 const KIND_RANK: Record<LiveUpdateKind, number> = { read: 0, change: 1, add: 2, delete: 3 };
@@ -64,17 +86,20 @@ interface PendingEntry {
 
 export function createLiveUpdates(
   vault: Vault,
-  opts: { debounceMs?: number; maxEntries?: number } = {},
+  opts: { debounceMs?: number; maxEntries?: number; reannounceMs?: number } = {},
 ): {
   handleUiUpdates: (req: IncomingMessage, res: ServerResponse, settingsPath?: string) => Promise<void>;
-  notifyRead: (id: string) => void;
+  notifyRead: (id: string, band?: RecallBand) => void;
   stop: () => void;
 } {
   const debounceMs = opts.debounceMs ?? DEBOUNCE_MS;
   const maxEntries = opts.maxEntries ?? MAX_ENTRIES;
+  const reannounceMs = opts.reannounceMs ?? REANNOUNCE_MS;
 
   const recent: LiveUpdate[] = []; // finalized entries, ascending seq
   const pending = new Map<string, PendingEntry>();
+  /** id → ms epoch der letzten finalisierten Notice (Sperre für "read"). */
+  const announcedAt = new Map<string, number>();
   let seq = 0;
 
   const baseFields = (m: Memory, kind: LiveUpdateKind): LiveUpdate => ({
@@ -98,6 +123,17 @@ export function createLiveUpdates(
     pending.delete(id);
     recent.push({ ...p.update, seq: ++seq, count: p.count });
     if (recent.length > maxEntries) recent.splice(0, recent.length - maxEntries);
+    // Sperrfenster startet erst beim Finalisieren — die Karte ist ab JETZT
+    // sichtbar, also läuft die Ruhe ab jetzt und nicht ab dem ersten Ereignis.
+    const now = Date.now();
+    announcedAt.set(id, now);
+    // Der Vault ist endlich, die Map also ohnehin klein; trotzdem nie
+    // unbegrenzt wachsen lassen (Importe legen tausende ids an).
+    if (announcedAt.size > maxEntries * 4) {
+      for (const [key, at] of announcedAt) {
+        if (now - at > reannounceMs) announcedAt.delete(key);
+      }
+    }
   };
 
   // Collapse an event into the pending entry for its id (or open one) and
@@ -147,11 +183,24 @@ export function createLiveUpdates(
     }
   });
 
-  /** "read"-Notice vom load_memory-Pfad (via Telemetry-Hook, best-effort). */
-  const notifyRead = (id: string): void => {
+  /**
+   * "read"-Notice vom load_memory-Pfad und — seit #221 — von jedem Recall,
+   * dessen Treffer über dem Floor serviert wurde (`band`).
+   *
+   * Recall-Notices sind pro id gesperrt (REANNOUNCE_MS): dieselbe Memory
+   * gehört über eine Sitzung hinweg immer wieder zu den Top-Treffern, und
+   * ohne Sperre wäre die Karte eine Endlosschleife derselben drei Titel.
+   * Läuft schon ein Fenster für die id, zählt das Ereignis dort als ×N mit —
+   * das ist Coalescing, keine neue Karte, und wird deshalb nie gesperrt.
+   */
+  const notifyRead = (id: string, band?: RecallBand): void => {
     try {
+      if (!pending.has(id)) {
+        const last = announcedAt.get(id);
+        if (last !== undefined && Date.now() - last < reannounceMs) return;
+      }
       const m = vault.get(id);
-      if (m) ingest(baseFields(m, "read"));
+      if (m) ingest({ ...baseFields(m, "read"), ...(band ? { band } : {}) });
     } catch {
       /* Notices sind Telemetrie-of-Telemetrie — nie einen Load brechen */
     }

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -279,6 +279,34 @@ function bandForScore(score: number | null): RecallBand {
   return "below_floor";
 }
 
+/** Höchstens so viele Treffer eines Recalls bekommen eine Live-Notice. */
+const MAX_SURFACED_NOTICES = 3;
+
+/**
+ * Die Treffer eines Recalls, die eine Map-Notice bekommen (#221).
+ *
+ * Das Band BESCHRIFTET, es filtert NICHT. Was in `hits[]` steht, wurde dem
+ * Aufrufer bereits serviert — auf dem recall-Pfad hinter seinem eigenen
+ * `min_score` (`parsed.data.min_score ?? RECALL_FLOOR`), auf dem Hook-Pfad
+ * ungefiltert. Hier ein zweites Mal gegen den globalen Floor zu schneiden
+ * würde die Entscheidung des Aufrufers überstimmen und Notices für Treffer
+ * verschlucken, die der Turn tatsächlich gesehen hat: gemessen über zwei Tage
+ * lagen 198 von 24 525 recall-Treffern (0,8 %, min 0,39) und 109 von 2 434
+ * Hook-Treffern (4,5 %) unter 30 — alle serviert.
+ *
+ * Gegen Flut hilft nicht der Floor, sondern das Wiederankündigungs-Fenster in
+ * live-updates. Das Band reist trotzdem mit, damit die Karte `required` von
+ * `optional` unterscheiden kann, ohne selbst Schwellen zu kennen.
+ */
+function surfacedHits(
+  hits: { id: string; score: number }[],
+): { id: string; band: RecallBand }[] {
+  return hits.slice(0, MAX_SURFACED_NOTICES).map((h) => ({
+    id: h.id,
+    band: bandForScore(typeof h.score === "number" ? h.score : null),
+  }));
+}
+
 function tokenize(text: string): Set<string> {
   return new Set(text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? []);
 }
@@ -465,9 +493,10 @@ export class Telemetry {
   onMemoryLoaded?: (id: string) => void;
 
   /** Live-Notices "surfaced" (#221): Hook der Map für recall/hook_recall —
-   *  die Top-Treffer eines Recalls leuchten auf, nicht nur das seltene
-   *  load_memory. Best-effort, nie werfend. Der Aufrufer deckelt auf Top-N. */
-  onRecalled?: (ids: string[]) => void;
+   *  die servierten Treffer eines Recalls leuchten auf, nicht nur das seltene
+   *  load_memory. Best-effort, nie werfend. Gefiltert und gedeckelt von
+   *  `surfacedHits` — das Band entscheidet, nicht der Aufrufer. */
+  onRecalled?: (hits: { id: string; band: RecallBand }[]) => void;
 
   recordLoadedMemory(payload: {
     memory_id: string;
@@ -577,9 +606,9 @@ export class Telemetry {
 
   async logRecall(payload: Omit<RecallEvent, "kind" | "ts" | "session_id">): Promise<void> {
     // "surfaced"-Notice VOR dem enabled-Gate — die Map-Notice ist ein UI-Signal,
-    // unabhängig von der Telemetrie-Persistenz (wie onMemoryLoaded). Top-3.
+    // unabhängig von der Telemetrie-Persistenz (wie onMemoryLoaded). Das Band filtert.
     try {
-      this.onRecalled?.(payload.hits.slice(0, 3).map((h) => h.id));
+      this.onRecalled?.(surfacedHits(payload.hits));
     } catch {
       /* Notices dürfen einen Recall nie brechen */
     }
@@ -620,9 +649,9 @@ export class Telemetry {
     payload: Omit<HookRecallEvent, "kind" | "ts" | "session_id">,
   ): Promise<void> {
     // "surfaced"-Notice VOR dem enabled-Gate — der Hook-Pfad ist der
-    // Löwenanteil des Traffics; die Map-Notice ist UI, nicht Persistenz. Top-3.
+    // Löwenanteil des Traffics; die Map-Notice ist UI, nicht Persistenz. Das Band filtert.
     try {
-      this.onRecalled?.(payload.hits.slice(0, 3).map((h) => h.id));
+      this.onRecalled?.(surfacedHits(payload.hits));
     } catch {
       /* Notices dürfen einen Hook-Recall nie brechen */
     }

--- a/packages/daemon/src/telemetry.ts
+++ b/packages/daemon/src/telemetry.ts
@@ -464,6 +464,11 @@ export class Telemetry {
    *  wird dort als "read"-Ereignis angezeigt. Best-effort, nie werfend. */
   onMemoryLoaded?: (id: string) => void;
 
+  /** Live-Notices "surfaced" (#221): Hook der Map für recall/hook_recall —
+   *  die Top-Treffer eines Recalls leuchten auf, nicht nur das seltene
+   *  load_memory. Best-effort, nie werfend. Der Aufrufer deckelt auf Top-N. */
+  onRecalled?: (ids: string[]) => void;
+
   recordLoadedMemory(payload: {
     memory_id: string;
     distinctive_tokens: string[];
@@ -571,6 +576,13 @@ export class Telemetry {
   }
 
   async logRecall(payload: Omit<RecallEvent, "kind" | "ts" | "session_id">): Promise<void> {
+    // "surfaced"-Notice VOR dem enabled-Gate — die Map-Notice ist ein UI-Signal,
+    // unabhängig von der Telemetrie-Persistenz (wie onMemoryLoaded). Top-3.
+    try {
+      this.onRecalled?.(payload.hits.slice(0, 3).map((h) => h.id));
+    } catch {
+      /* Notices dürfen einen Recall nie brechen */
+    }
     if (!this.enabled) return;
     await this.write({
       kind: "recall",
@@ -607,6 +619,13 @@ export class Telemetry {
   async logHookRecall(
     payload: Omit<HookRecallEvent, "kind" | "ts" | "session_id">,
   ): Promise<void> {
+    // "surfaced"-Notice VOR dem enabled-Gate — der Hook-Pfad ist der
+    // Löwenanteil des Traffics; die Map-Notice ist UI, nicht Persistenz. Top-3.
+    try {
+      this.onRecalled?.(payload.hits.slice(0, 3).map((h) => h.id));
+    } catch {
+      /* Notices dürfen einen Hook-Recall nie brechen */
+    }
     if (!this.enabled) return;
     await this.write({
       kind: "hook_recall",

--- a/packages/eval/d2q-wiki-stand/README.md
+++ b/packages/eval/d2q-wiki-stand/README.md
@@ -1,0 +1,57 @@
+# d2q-wiki-stand — doc2query bridge for a colloquial-RU/UA user over an EN corpus
+
+The class this stand exists for: a query like "сенсы мышки какой она была"
+against an English config note. Zero shared tokens with the corpus — dense
+misses deep, BM25 scores flat 0.00. No reranker fixes an empty pool, so the
+only lever that physically builds the bridge is writing the user's register
+*into* the document: doc2query with local models.
+
+Numbers from the private run live in the #119 comment thread. This directory
+is the mechanism, runnable on any corpus with the same shape.
+
+## Pipeline (order matters)
+
+```
+d2q_gen.py <model>        # arm A/B: doc-seeded expansions, floating temperature
+d2q_styled.py <model>     # arm C: doc-seeded, few-shot conditioned on the
+                          #        owner's real replies (voice donor file)
+d2q_filter.py             # candidate triage (#119's question): does the query
+                          #   reach its own doc, does it reach a foreign one first
+d2q_rescue.py             # held-out A/B/C vs baseline vs foreign-seed null
+d2q_alpha.py              # discounted boost channel: score = max(dense, α·exp)
+```
+
+## Expects
+
+- a SQLite corpus table `(id, path, line, doc, heading, embed_text, embedding)`
+  — set `D2Q_CORPUS_DB` / `D2Q_CORPUS_TABLE`;
+- Ollama for generation (`D2Q_GEN_URL`) and embeddings (`D2Q_EMBED_URL`,
+  `D2Q_EMBED_MODEL` — must match the model that built the corpus embeddings,
+  asymmetric prefixes and all);
+- for arm C: a JSONL voice-donor file (`D2Q_VOICES`), lines of
+  `{"surface": "<verbatim user reply>", "acted_on": true}` — only replies that
+  actually triggered something, selection by effect, not by availability;
+- for the held-out stages: a ground-truth file (`D2Q_GT`) of
+  `{"topics": {<name>: {"gold": [section-ids], "ru": "...", "en": "..."}}}`,
+  authored independently of the generators. Not shipped here — it encodes a
+  private corpus. Build your own; queries must avoid the target's vocabulary.
+
+The generation prompts are deliberately Russian: the point is producing the
+user's register, not correct literary queries. Both local models used here
+(gemma4:e4b, qwen3:8b) are reasoning models — `think: false` or the whole
+token budget dies in the thinking field with an empty response.
+
+## Design notes carried in the scripts
+
+- test writes go to a separate `d2q.db`, never into the live index;
+- expansions are generated for a distractor pool, not only for gold —
+  otherwise gold wins by text volume, not by meaning;
+- collision is judged by FILE, not by section: landing on a neighbouring
+  section of the right file is a hit, counting it as collision inflates harm;
+- the null arm (foreign expansions, shift +7) is not optional — it is the
+  difference between "content lifts" and "any extra text lifts";
+- empty model output is a status, not a missing row; `done_reason: length`
+  is not an answer;
+- single-request curl embedding with a short timeout dies the moment the
+  Ollama VRAM scheduler evicts your embedder for someone's chat model —
+  batch `/api/embed`, retries with backoff, `keep_alive`.

--- a/packages/eval/d2q-wiki-stand/README.md
+++ b/packages/eval/d2q-wiki-stand/README.md
@@ -1,10 +1,18 @@
-# d2q-wiki-stand — doc2query bridge for a colloquial-RU/UA user over an EN corpus
+# d2q-wiki-stand — doc2query bridge for a colloquial-RU/UA user's EN target docs
 
 The class this stand exists for: a query like "сенсы мышки какой она была"
-against an English config note. Zero shared tokens with the corpus — dense
+against an English config note. Zero shared tokens with the target — dense
 misses deep, BM25 scores flat 0.00. No reranker fixes an empty pool, so the
 only lever that physically builds the bridge is writing the user's register
 *into* the document: doc2query with local models.
+
+Corpus honesty (measured, after the first version of this README oversold
+it as "an EN corpus"): only ~13% of the motivating corpus is clean EN — the
+majority already carries the owner's Cyrillic. The bridge is for the EN
+islands; sections already written in the owner's register are excluded by
+a guard (`D2Q_SKIP_CYR`, default 0.5 Cyrillic letter share) — expanding a
+doc that already speaks the user's language adds collision surface and
+nothing else.
 
 Numbers from the private run live in the #119 comment thread. This directory
 is the mechanism, runnable on any corpus with the same shape.

--- a/packages/eval/d2q-wiki-stand/d2q_alpha.py
+++ b/packages/eval/d2q-wiki-stand/d2q_alpha.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+d2q_alpha — the consequence the rescue run forces you to face: expansions fix
+the hard class (the cross-lingual query) and TAX the easy one (queries bare
+dense already ranks at 1 — a foreign boost can outbid an honest dense score).
+
+One number answers the deploy question: does a discount on the boost channel
+give the easy class back without losing the rescued hard one?
+
+    score = max(dense, α · max_exp_sim)
+
+The arm is fixed (D2Q_ALPHA_MODEL, an exp.model value, keep-triaged only).
+The α sweep is exploratory — a handful of test queries is a direction,
+not a constant to enshrine.
+"""
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+
+S = Path(__file__).parent
+SRC = Path(os.environ.get("D2Q_CORPUS_DB", Path.home() / "corpus.db"))
+TABLE = os.environ.get("D2Q_CORPUS_TABLE", "wiki")
+DB = Path(os.environ.get("D2Q_DB", S / "d2q.db"))
+GT = Path(os.environ.get("D2Q_GT", S / "gt.json"))
+ARM_MODEL = os.environ.get("D2Q_ALPHA_MODEL", "gemma4:e4b|styled")
+REAL_QUERY = os.environ.get("D2Q_REAL_QUERY", "")
+REAL_TOPIC = os.environ.get("D2Q_REAL_TOPIC", "")
+sys.path.insert(0, str(S))
+from d2q_filter import embed_batch  # noqa: E402
+
+gt = json.load(open(GT))
+tests = []
+for topic, t in gt["topics"].items():
+    tests.append((t["ru"], "ru", t["gold"]))
+    tests.append((t["en"], "en", t["gold"]))
+if REAL_QUERY and REAL_TOPIC:
+    tests.append((REAL_QUERY, "ru-real", gt["topics"][REAL_TOPIC]["gold"]))
+
+db = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
+rows = db.execute("SELECT id, model, temp, queries FROM exp "
+                  "WHERE status='ok' AND model=?", (ARM_MODEL,)).fetchall()
+verd = {(q, sid, m, t): v for q, sid, m, t, v in
+        db.execute("SELECT q, src_id, model, temp, verdict FROM cand")}
+vec = {q: json.loads(v) for q, v in db.execute("SELECT q, vec FROM qvec WHERE vec != ''")}
+universe = sorted({r[0] for r in
+                   db.execute("SELECT DISTINCT id FROM exp WHERE status='ok'")})
+
+src = sqlite3.connect(f"file:{SRC}?mode=ro", uri=True)
+uni = set(universe)
+sec = {i: (p, json.loads(e)) for i, p, e in src.execute(
+    f"SELECT id, path, embedding FROM {TABLE}") if i in uni}
+src.close()
+ids = [i for i in universe if i in sec]
+D = np.array([sec[i][1] for i in ids], dtype=np.float32)
+D /= (np.linalg.norm(D, axis=1, keepdims=True) + 1e-9)
+pos = {i: k for k, i in enumerate(ids)}
+
+exp_of = {}
+for sid, model, temp, qs in rows:
+    for q in json.loads(qs):
+        q = q.strip()
+        if q in vec and verd.get((q, sid, model, temp)) == "keep":
+            exp_of.setdefault(sid, []).append(q)
+
+qv = embed_batch([t[0] for t in tests])
+Q = np.array(qv, dtype=np.float32)
+Q /= (np.linalg.norm(Q, axis=1, keepdims=True) + 1e-9)
+base = Q @ D.T
+
+# boost matrix: (tests × sections), max expansion similarity
+boost = np.full_like(base, -1.0)
+for i in ids:
+    qs = exp_of.get(i, [])
+    if not qs:
+        continue
+    V = np.array([vec[q] for q in qs], dtype=np.float32)
+    V /= (np.linalg.norm(V, axis=1, keepdims=True) + 1e-9)
+    boost[:, pos[i]] = (Q @ V.T).max(axis=1)
+
+
+def agg(scores):
+    out = {}
+    for grp in ("ru", "en", "ru-real"):
+        rr = []
+        for ti, (qt, lang, gold) in enumerate(tests):
+            if lang != grp:
+                continue
+            golds = [pos[g] for g in gold if g in pos]
+            order = np.argsort(-scores[ti])
+            rk = {j: r + 1 for r, j in enumerate(order)}
+            rr.append(min(rk[j] for j in golds))
+        if grp == "ru-real":
+            out[grp] = f"rank {rr[0]}" if rr else "—"
+        else:
+            out[grp] = (f"r@10 {sum(r<=10 for r in rr)/len(rr):.2f} "
+                        f"MRR {sum(1/r for r in rr)/len(rr):.3f}")
+    return out
+
+
+print(f"universe {len(ids)}, arm {ARM_MODEL}/keep")
+print(f"{'α':>5}  {'RU':<22} {'EN':<22} real")
+for a in (0.0, 0.80, 0.85, 0.90, 0.95, 1.0):
+    r = agg(np.maximum(base, a * boost))
+    print(f"{a:>5}  {r['ru']:<22} {r['en']:<22} {r['ru-real']}")

--- a/packages/eval/d2q-wiki-stand/d2q_filter.py
+++ b/packages/eval/d2q-wiki-stand/d2q_filter.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+d2q_filter — candidate triage (the question #119 asks).
+
+The triage question is not "is this a pretty query" but: **does it reach its
+own document, and does it reach a foreign one first.** A candidate that leads
+to a foreign document is WORSE than no candidate — it spends a result slot
+and walks the human away.
+
+CLASSES (by the rank of the candidate's OWN document over the full corpus):
+  keep       own_rank <= KEEP        — the bridge works
+  weak       own_rank >  KEEP        — cannot even reach its own doc, useless
+  collision  top-1 = FOREIGN FILE    — actively harmful
+
+⚠ EASY TO GET WRONG: collision is judged by FILE, not by section. A query
+that lands on a neighbouring section of the SAME file put the human in the
+right place — that is not a collision. Counting by section id inflates the
+harm several-fold.
+
+GUARDS:
+  TEST-IN-PROD     the live index is read-only here; writes go to d2q.db only
+  EMBED-CACHE      qvec table: a re-run does not re-embed (resume)
+  EMPTY-IS-STATUS  a candidate without a vector is marked 'novec', it does
+                   not vanish silently
+  ONE EMBEDDER     must match the model that built the corpus embeddings
+                   (asymmetric prefixes included), or the comparison is void
+"""
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+
+SRC = Path(os.environ.get("D2Q_CORPUS_DB", Path.home() / "corpus.db"))
+TABLE = os.environ.get("D2Q_CORPUS_TABLE", "wiki")
+DST = Path(os.environ.get("D2Q_DB", Path(__file__).parent / "d2q.db"))
+EMBED_URL = os.environ.get("D2Q_EMBED_URL", "http://localhost:11434/api/embed")
+MODEL = os.environ.get("D2Q_EMBED_MODEL", "embeddinggemma")
+QUERY_PREFIX = os.environ.get("D2Q_QUERY_PREFIX", "task: search result | query: ")
+KEEP = 10
+
+
+def embed_batch(texts, tries=5):
+    # Batched /api/embed + retries: a single curl with timeout=60 killed the
+    # run twice when the Ollama VRAM scheduler evicted the embedder under a
+    # foreign chat-model load.
+    import time
+    import urllib.request
+    body = json.dumps({"model": MODEL, "keep_alive": "30m",
+                       "input": [QUERY_PREFIX + t[:2000] for t in texts]}).encode()
+    for attempt in range(tries):
+        try:
+            req = urllib.request.Request(
+                EMBED_URL, data=body,
+                headers={"Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=300) as resp:
+                return json.loads(resp.read())["embeddings"]
+        except Exception as e:
+            wait = 15 * (attempt + 1)
+            print(f"  embed retry {attempt+1}/{tries} ({type(e).__name__}), "
+                  f"waiting {wait}s", flush=True)
+            time.sleep(wait)
+    return None
+
+
+def main():
+    # ── corpus ───────────────────────────────────────────────────────────
+    src = sqlite3.connect(SRC)
+    wiki = src.execute(f"SELECT id, path, embedding FROM {TABLE} ORDER BY id").fetchall()
+    src.close()
+    ids = [r[0] for r in wiki]
+    paths = [r[1] for r in wiki]
+    idx_of = {rid: i for i, rid in enumerate(ids)}
+    M = np.array([json.loads(r[2]) for r in wiki], dtype=np.float32)
+    M /= (np.linalg.norm(M, axis=1, keepdims=True) + 1e-9)
+    print(f"corpus: {M.shape[0]} sections × {M.shape[1]}d", flush=True)
+
+    # ── candidates ───────────────────────────────────────────────────────
+    dst = sqlite3.connect(DST, timeout=120)
+    dst.execute("PRAGMA journal_mode=WAL")
+    dst.execute("PRAGMA busy_timeout=120000")
+    dst.execute("""CREATE TABLE IF NOT EXISTS qvec (
+        q TEXT PRIMARY KEY, vec TEXT)""")
+    dst.execute("""CREATE TABLE IF NOT EXISTS cand (
+        q TEXT, src_id TEXT, model TEXT, temp REAL,
+        own_rank INTEGER, own_sim REAL, top1_id TEXT, top1_path TEXT,
+        verdict TEXT, PRIMARY KEY (q, src_id, model, temp))""")
+    dst.commit()
+
+    rows = dst.execute("SELECT id, model, temp, queries FROM exp WHERE status='ok'").fetchall()
+    cands = []          # (q, src_id, model, temp)
+    for rid, model, temp, qs in rows:
+        seen = set()
+        for q in json.loads(qs):
+            k = q.strip().lower()
+            if not k or k in seen:      # intra-doc dedup (mode-collapse)
+                continue
+            seen.add(k)
+            cands.append((q.strip(), rid, model, temp))
+    uniq = sorted({c[0] for c in cands})
+    print(f"candidates: {len(cands)} (unique strings {len(uniq)})", flush=True)
+
+    # ── embeddings with cache ────────────────────────────────────────────
+    # empty vec = a past embed failure: retry it, do not count it as done
+    have = {q for (q,) in dst.execute("SELECT q FROM qvec WHERE vec != ''")}
+    todo = [q for q in uniq if q not in have]
+    print(f"to embed: {len(todo)}", flush=True)
+    B = 32
+    for off in range(0, len(todo), B):
+        chunk = todo[off:off + B]
+        vs = embed_batch(chunk)
+        if vs is None or len(vs) != len(chunk):
+            # the batch failed even after retries — mark novec, never lose silently
+            print(f"  batch {off} failed after retries, marking novec", flush=True)
+            vs = [None] * len(chunk)
+        for q, v in zip(chunk, vs):
+            dst.execute("INSERT OR REPLACE INTO qvec VALUES (?,?)",
+                        (q, json.dumps(v) if v else ""))
+        dst.commit()
+        if (off // B) % 5 == 0:
+            print(f"  {min(off+B, len(todo))}/{len(todo)}", flush=True)
+
+    vec = {q: (json.loads(v) if v else None)
+           for q, v in dst.execute("SELECT q, vec FROM qvec")}
+
+    # ── scoring ──────────────────────────────────────────────────────────
+    usable = [q for q in uniq if vec.get(q)]
+    Q = np.array([vec[q] for q in usable], dtype=np.float32)
+    Q /= (np.linalg.norm(Q, axis=1, keepdims=True) + 1e-9)
+    S = Q @ M.T                                   # (candidates × sections)
+    order = np.argsort(-S, axis=1)
+    pos_of = {q: i for i, q in enumerate(usable)}
+    print(f"matrix {S.shape} computed", flush=True)
+
+    stat = {"keep": 0, "weak": 0, "collision": 0, "novec": 0}
+    for q, src_id, model, temp in cands:
+        i = pos_of.get(q)
+        if i is None:
+            dst.execute("INSERT OR REPLACE INTO cand VALUES (?,?,?,?,?,?,?,?,?)",
+                        (q, src_id, model, temp, None, None, None, None, "novec"))
+            stat["novec"] += 1
+            continue
+        j = idx_of[src_id]
+        row = order[i]
+        own_rank = int(np.where(row == j)[0][0]) + 1
+        t1 = int(row[0])
+        # Collision by FILE, not by section: a neighbouring section of the
+        # same file is a hit.
+        collision = paths[t1] != paths[j]
+        verdict = "collision" if (collision and own_rank > 1) else (
+            "keep" if own_rank <= KEEP else "weak")
+        stat[verdict] += 1
+        dst.execute("INSERT OR REPLACE INTO cand VALUES (?,?,?,?,?,?,?,?,?)",
+                    (q, src_id, model, temp, own_rank, float(S[i, j]),
+                     ids[t1], paths[t1], verdict))
+    dst.commit()
+
+    print("\n=== TRIAGE ===")
+    tot = sum(stat.values())
+    for k, v in stat.items():
+        print(f"  {k:10} {v:5}  {100*v/tot:5.1f}%")
+    print("\n=== per arm ===")
+    for m, t, kp, cl, wk, n in dst.execute("""
+        SELECT model, temp,
+               SUM(verdict='keep'), SUM(verdict='collision'),
+               SUM(verdict='weak'), COUNT(*)
+        FROM cand GROUP BY model, temp ORDER BY model, temp"""):
+        print(f"  {m:22} t={t}  keep {100*kp/n:5.1f}%  "
+              f"collision {100*cl/n:5.1f}%  weak {100*wk/n:5.1f}%  (n={n})")
+    dst.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/eval/d2q-wiki-stand/d2q_gen.py
+++ b/packages/eval/d2q-wiki-stand/d2q_gen.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+d2q_gen — doc-seeded doc2query expansions (arms A/B of the stand).
+
+Guards, each against a failure mode caught live:
+
+  TEST-IN-PROD        writes to a separate d2q.db, never touches the live index.
+  POOL-NOT-JUST-GOLD  expansions are generated for the whole pool, not only for
+                      gold docs: otherwise gold wins by text volume, not meaning.
+  EMPTY-IS-NOT-ABSENCE  an empty model reply is written as status='empty', not
+                      as a missing row — a summary must not lie by silence.
+  RC-IS-NOT-EFFECT    done_reason is kept: 'length' = truncated, that is NOT
+                      an answer.
+  reasoning models    think=False is mandatory, or the whole budget goes to
+                      the thinking field (measured: gemma4:e4b and qwen3:8b
+                      are both reasoning models).
+  RESUMABLE           INSERT OR IGNORE + commit per row: an abort loses nothing.
+
+Usage: d2q_gen.py <model> [--pool N] [--limit N] [--ids ids.json]
+"""
+import json
+import os
+import sqlite3
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+GEN_URL = os.environ.get("D2Q_GEN_URL", "http://localhost:11434/api/chat")
+SRC = Path(os.environ.get("D2Q_CORPUS_DB", Path.home() / "corpus.db"))
+TABLE = os.environ.get("D2Q_CORPUS_TABLE", "wiki")
+DST = Path(os.environ.get("D2Q_DB", Path(__file__).parent / "d2q.db"))
+
+# The prompt is deliberately Russian: the target register is the owner's
+# colloquial RU (slang, translit, no caps), not correct literary queries.
+PROMPT = (
+    "Заметка:\n{doc}\n\n"
+    "Придумай 6 запросов, которыми человек искал бы эту заметку через полгода, "
+    "забыв точные слова. 4 по-русски разговорно — с сокращениями, сленгом и "
+    "транслитом, как пишут в чате, без заглавных букв. 2 по-английски коротко. "
+    "Не копируй слова заметки дословно. Только запросы, по одному в строке, "
+    "без нумерации и без пояснений."
+)
+
+# Floating temperature: one pass gives one "mood" of voice. Low stays close to
+# the note (terms), high drifts into slang (register). Over-generate at both
+# ends and let the filter sort it out: dropping a candidate is cheaper than
+# not having one.
+TEMPS = (0.7, 1.1)
+
+
+def gen(model: str, doc: str, temp: float, timeout=300):
+    body = {
+        "model": model, "stream": False, "think": False,
+        "options": {"num_predict": 260, "temperature": temp},
+        "messages": [{"role": "user", "content": PROMPT.format(doc=doc[:1400])}],
+    }
+    req = urllib.request.Request(GEN_URL, json.dumps(body).encode(),
+                                 {"Content-Type": "application/json"})
+    r = json.load(urllib.request.urlopen(req, timeout=timeout))
+    return (r.get("message", {}).get("content") or "").strip(), r.get("done_reason"), r.get("eval_count", 0)
+
+
+def clean(raw: str):
+    """Query lines out of the raw reply; junk (numbering, preambles) cut."""
+    out = []
+    for ln in raw.splitlines():
+        s = ln.strip().lstrip("-•*0123456789.) \t").strip().strip('"\'')
+        if not s or len(s) < 4 or len(s) > 160:
+            continue
+        if s.endswith(":") or s.lower().startswith(("вот ", "запросы", "here", "sure")):
+            continue
+        out.append(s)
+    return out[:6]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    model = sys.argv[1]
+    pool_n = int(sys.argv[sys.argv.index("--pool") + 1]) if "--pool" in sys.argv else 400
+    limit = int(sys.argv[sys.argv.index("--limit") + 1]) if "--limit" in sys.argv else 0
+
+    src = sqlite3.connect(SRC)
+    rows = src.execute(
+        f"SELECT id, path, line, doc, heading, embed_text FROM {TABLE} ORDER BY id"
+    ).fetchall()
+    src.close()
+
+    # Explicit section list (--ids file.json) — targeted top-up for the gold
+    # docs of the held-out stage: rescue cannot be measured on docs that have
+    # no expansions.
+    if "--ids" in sys.argv:
+        want = set(json.load(open(sys.argv[sys.argv.index("--ids") + 1])))
+        pool = [r for r in rows if r[0] in want]
+    else:
+        # Deterministic pool: every n-th row, so the whole corpus is covered,
+        # not one section of it.
+        step = max(1, len(rows) // pool_n)
+        pool = rows[::step][:pool_n]
+    if limit:
+        pool = pool[:limit]
+
+    # WAL + busy wait: generator and filter may share this DB. Without it the
+    # second writer dies with 'database is locked' (caught live).
+    dst = sqlite3.connect(DST, timeout=120)
+    dst.execute("PRAGMA journal_mode=WAL")
+    dst.execute("PRAGMA busy_timeout=120000")
+    dst.execute("""CREATE TABLE IF NOT EXISTS exp (
+        id TEXT, model TEXT, temp REAL, path TEXT, line INTEGER, heading TEXT,
+        queries TEXT, raw TEXT, status TEXT, done_reason TEXT,
+        eval_count INTEGER, secs REAL,
+        PRIMARY KEY (id, model, temp))""")
+    dst.commit()
+
+    # Unit of work = (document, temperature). Resume by pair.
+    done = {(r[0], r[1]) for r in
+            dst.execute("SELECT id, temp FROM exp WHERE model=?", (model,))}
+    todo = [(r, t) for r in pool for t in TEMPS if (r[0], t) not in done]
+    print(f"{model}: pool {len(pool)} × temps {TEMPS} = {len(pool)*len(TEMPS)} tasks, "
+          f"done {len(done)}, to generate {len(todo)}", flush=True)
+
+    t0 = time.time()
+    ok = empty = err = 0
+    for i, ((rid, path, line, doc, heading, etext), temp) in enumerate(todo, 1):
+        t = time.time()
+        try:
+            raw, dr, ec = gen(model, etext, temp)
+            qs = clean(raw)
+            # EMPTY is a status, not a missing row.
+            status = "ok" if qs else ("empty" if not raw else "unparsed")
+            if status == "ok":
+                ok += 1
+            else:
+                empty += 1
+        except Exception as e:
+            raw, dr, ec, qs, status = f"{type(e).__name__}: {e}", None, 0, [], "error"
+            err += 1
+        dst.execute("INSERT OR IGNORE INTO exp VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (rid, model, temp, path, line, heading,
+                     json.dumps(qs, ensure_ascii=False),
+                     raw[:2000], status, dr, ec, round(time.time() - t, 2)))
+        dst.commit()
+        if i % 25 == 0 or i == len(todo):
+            el = time.time() - t0
+            print(f"  {i}/{len(todo)}  ok={ok} empty={empty} err={err}  "
+                  f"{el:.0f}s  ETA {el/i*(len(todo)-i)/60:.1f}m", flush=True)
+    dst.close()
+    print(f"DONE {model}: ok={ok} empty={empty} err={err}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/eval/d2q-wiki-stand/d2q_gen.py
+++ b/packages/eval/d2q-wiki-stand/d2q_gen.py
@@ -48,6 +48,17 @@ PROMPT = (
 # not having one.
 TEMPS = (0.7, 1.1)
 
+# Sections at or above this Cyrillic share are skipped: they already speak
+# the owner's register, the bridge is for the EN islands of a mixed corpus.
+CYR_SKIP = float(os.environ.get("D2Q_SKIP_CYR", "0.5"))
+
+
+def cyr_share(text: str) -> float:
+    letters = [c for c in text if c.isalpha()]
+    if not letters:
+        return 0.0
+    return sum("Ѐ" <= c <= "ӿ" for c in letters) / len(letters)
+
 
 def gen(model: str, doc: str, temp: float, timeout=300):
     body = {
@@ -101,6 +112,16 @@ def main():
         pool = rows[::step][:pool_n]
     if limit:
         pool = pool[:limit]
+
+    # REGISTER GUARD: a section already written mostly in the owner's own
+    # language/register does not need a voice bridge — expanding it only adds
+    # collision surface. Measured on the motivating corpus: just 13% of
+    # sections were clean EN; the majority already carries Cyrillic.
+    skipped = [r for r in pool if cyr_share(r[5]) >= CYR_SKIP]
+    if skipped:
+        print(f"guard: skipped {len(skipped)} sections ≥{CYR_SKIP:.0%} Cyrillic "
+              f"(already in the owner's register; not a silent cap)", flush=True)
+    pool = [r for r in pool if cyr_share(r[5]) < CYR_SKIP]
 
     # WAL + busy wait: generator and filter may share this DB. Without it the
     # second writer dies with 'database is locked' (caught live).

--- a/packages/eval/d2q-wiki-stand/d2q_rescue.py
+++ b/packages/eval/d2q-wiki-stand/d2q_rescue.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+d2q_rescue — does the doc2query bridge hold on held-out queries (A/B/C + null).
+
+TEST QUERIES: a ground-truth file (D2Q_GT) authored independently of the
+generators, plus an optional real user query (D2Q_REAL_QUERY, with
+D2Q_REAL_TOPIC naming its gold topic). The generators never saw any of them.
+
+UNIVERSE: only sections that HAVE expansions (distractor pool + gold).
+Measuring over the full corpus would be unfair: sections without a boost
+channel cannot compete, and gold would win by construction. Ranks are
+comparable WITHIN the universe.
+
+ARMS: baseline (bare dense) · A/B doc-seeded · C styled · null (each section
+gets the expansions of a FOREIGN section, shift +7 — catches "any extra text
+lifts the score"; a prior arc run lost 57% of a raw effect to this control).
+Each arm ×2: all candidates / keep-triaged only.
+
+SECTION SCORE = max(sim(q, section vector), max sim(q, its expansion vectors)).
+
+LEAK AUDIT: max word-bigram Jaccard (test query ↔ expansions of its gold).
+"""
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+
+S = Path(__file__).parent
+SRC = Path(os.environ.get("D2Q_CORPUS_DB", Path.home() / "corpus.db"))
+TABLE = os.environ.get("D2Q_CORPUS_TABLE", "wiki")
+DB = Path(os.environ.get("D2Q_DB", S / "d2q.db"))
+GT = Path(os.environ.get("D2Q_GT", S / "gt.json"))
+KEEP_TOP = 10
+REAL_QUERY = os.environ.get("D2Q_REAL_QUERY", "")
+REAL_TOPIC = os.environ.get("D2Q_REAL_TOPIC", "")
+
+sys.path.insert(0, str(S))
+from d2q_filter import embed_batch  # noqa: E402  one embedder for everything
+
+
+def bigrams(s):
+    w = [t for t in "".join(c.lower() if c.isalnum() else " " for c in s).split() if t]
+    return set(zip(w, w[1:])) if len(w) > 1 else {(w[0], "") for w in [w] if w} or set()
+
+
+def main():
+    gt = json.load(open(GT))
+    tests = []  # (qtext, lang, topic, gold_ids)
+    for topic, t in gt["topics"].items():
+        tests.append((t["ru"], "ru", topic, t["gold"]))
+        tests.append((t["en"], "en", topic, t["gold"]))
+    if REAL_QUERY and REAL_TOPIC:
+        tests.append((REAL_QUERY, "ru-real", REAL_TOPIC,
+                      gt["topics"][REAL_TOPIC]["gold"]))
+
+    db = sqlite3.connect(f"file:{DB}?mode=ro", uri=True)
+    # expansions per section; model carries '|styled' for arm C
+    rows = db.execute("SELECT id, model, temp, queries FROM exp WHERE status='ok'").fetchall()
+    verd = {(q, sid, m, t): v for q, sid, m, t, v in
+            db.execute("SELECT q, src_id, model, temp, verdict FROM cand")}
+    vec = {q: json.loads(v) for q, v in db.execute("SELECT q, vec FROM qvec WHERE vec != ''")}
+
+    # universe = sections having expansions from at least one arm
+    universe = sorted({r[0] for r in rows})
+    src = sqlite3.connect(f"file:{SRC}?mode=ro", uri=True)
+    uni = set(universe)
+    sec = {i: (p, json.loads(e)) for i, p, e in src.execute(
+        f"SELECT id, path, embedding FROM {TABLE}") if i in uni}
+    src.close()
+    ids = [i for i in universe if i in sec]
+    D = np.array([sec[i][1] for i in ids], dtype=np.float32)
+    D /= (np.linalg.norm(D, axis=1, keepdims=True) + 1e-9)
+    pos = {i: k for k, i in enumerate(ids)}
+    print(f"universe: {len(ids)} sections (gold present: "
+          f"{sum(1 for t in tests for g in t[3] if g in pos)}/{sum(len(t[3]) for t in tests)})",
+          flush=True)
+
+    # expansion strings per arm: arm -> id -> [(query, kept)]
+    def arm_of(model):
+        base = model.split(":", 1)[0].split("|")[0]
+        return ("C_" + base) if model.endswith("|styled") else ("A_" + base)
+
+    arms = {}
+    for sid, model, temp, qs in rows:
+        a = arm_of(model)
+        for q in json.loads(qs):
+            q = q.strip()
+            if not q or q not in vec:
+                continue
+            kept = verd.get((q, sid, model, temp)) == "keep"
+            arms.setdefault(a, {}).setdefault(sid, []).append((q, kept))
+
+    # null arm: section i receives the expansions of ids[(pos[i]+7) % n]
+    # from the first A-arm
+    donor_name = sorted(a for a in arms if a.startswith("A_"))[0]
+    donor = arms[donor_name]
+    nul = {}
+    for i in ids:
+        d = ids[(pos[i] + 7) % len(ids)]
+        nul[i] = donor.get(d, [])
+    arms["null_shift7"] = nul
+
+    # embed test queries — same embedder, same prefix
+    qv = embed_batch([t[0] for t in tests])
+    Q = np.array(qv, dtype=np.float32)
+    Q /= (np.linalg.norm(Q, axis=1, keepdims=True) + 1e-9)
+    base_sims = Q @ D.T                       # (tests × sections)
+
+    def rank_of_gold(scores, gold):
+        golds = [pos[g] for g in gold if g in pos]
+        if not golds:
+            return None
+        order = np.argsort(-scores)
+        rk = {j: r + 1 for r, j in enumerate(order)}
+        return min(rk[j] for j in golds)
+
+    def eval_arm(name, expmap, kept_only):
+        out = []
+        for ti, (qt, lang, topic, gold) in enumerate(tests):
+            scores = base_sims[ti].copy()
+            for i in ids:
+                cand = [(q, k) for q, k in expmap.get(i, []) if (k or not kept_only)]
+                if not cand:
+                    continue
+                V = np.array([vec[q] for q, _ in cand], dtype=np.float32)
+                V /= (np.linalg.norm(V, axis=1, keepdims=True) + 1e-9)
+                boost = float(np.max(V @ Q[ti]))
+                scores[pos[i]] = max(scores[pos[i]], boost)
+            out.append((lang, topic, rank_of_gold(scores, gold)))
+        return out
+
+    results = {"baseline": [(lang, topic, rank_of_gold(base_sims[ti], gold))
+                            for ti, (qt, lang, topic, gold) in enumerate(tests)]}
+    for a in sorted(arms):
+        results[a + "/all"] = eval_arm(a, arms[a], kept_only=False)
+        if a != "null_shift7":
+            results[a + "/keep"] = eval_arm(a, arms[a], kept_only=True)
+
+    def agg(rows_, langs):
+        rr = [r for lang, _, r in rows_ if r and lang in langs]
+        if not rr:
+            return "—"
+        resc = sum(r <= KEEP_TOP for r in rr) / len(rr)
+        mrr = sum(1 / r for r in rr) / len(rr)
+        med = sorted(rr)[len(rr) // 2]
+        return f"rescue@10 {resc:.2f}  MRR {mrr:.3f}  median {med}"
+
+    print("\n=== RESULT (universe of", len(ids), "sections) ===")
+    for name, rows_ in results.items():
+        print(f"\n{name}")
+        print(f"  RU      {agg(rows_, {'ru'})}")
+        print(f"  EN      {agg(rows_, {'en'})}")
+        real = [r for lang, _, r in rows_ if lang == 'ru-real']
+        if real:
+            print(f"  REAL user query: rank {real[0]}")
+
+    # leak audit
+    print("\n=== LEAK AUDIT (bigram Jaccard, test ↔ its gold's expansions) ===")
+    worst = []
+    for qt, lang, topic, gold in tests:
+        tb = bigrams(qt)
+        best = 0.0
+        for a, m in arms.items():
+            if a == "null_shift7":
+                continue
+            for g in gold:
+                for q, _ in m.get(g, []):
+                    qb = bigrams(q)
+                    if tb and qb:
+                        j = len(tb & qb) / len(tb | qb)
+                        best = max(best, j)
+        worst.append((best, lang, topic, qt))
+    for j, lang, topic, qt in sorted(worst, reverse=True)[:5]:
+        print(f"  {j:.2f}  [{lang}] {topic}: {qt[:60]}")
+    print(f"  median: {sorted(w[0] for w in worst)[len(worst)//2]:.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/eval/d2q-wiki-stand/d2q_styled.py
+++ b/packages/eval/d2q-wiki-stand/d2q_styled.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+d2q_styled — arm C: doc2query CONDITIONED on the owner's register.
+
+The axis (from the owner's earlier bakeoff): seed source decides more than
+the generator.
+  doc-seeded      covers every section, voice of the model
+  query-seeded    champion, but UNAVAILABLE without real query→doc pairs
+This arm is the compromise: the seed stays the document (coverage), but the
+VOICE comes from the owner's real replies.
+
+VOICE DONOR (D2Q_VOICES, jsonl): verbatim user replies with acted_on=true —
+each one already selected by effect ("this is how the person talks when they
+actually need something"), which beats raw prompt logs selected by mere
+availability.
+
+WHY AT ALL: measured — an unconditioned model writes CORRECT Russian ("Как
+настроить мышь в Hyprland?") while the owner writes clipped slang. Between
+the two lies the zero-shared-tokens gap this whole stand is about.
+
+Guards: same as d2q_gen.py, plus:
+  LEAK-HYGIENE   donor replies are used as style samples only; their words
+                 must not leak into a query about an unrelated topic
+                 (checked downstream by the filter).
+  DETERMINISM    few-shot picks hash on the document id, not random() —
+                 the run is reproducible and resume-safe.
+
+Usage: d2q_styled.py <model> [--pool N] [--limit N] [--ids ids.json]
+"""
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+GEN_URL = os.environ.get("D2Q_GEN_URL", "http://localhost:11434/api/chat")
+SRC = Path(os.environ.get("D2Q_CORPUS_DB", Path.home() / "corpus.db"))
+TABLE = os.environ.get("D2Q_CORPUS_TABLE", "wiki")
+ALIAS = Path(os.environ.get("D2Q_VOICES", Path(__file__).parent / "voices.jsonl"))
+DST = Path(os.environ.get("D2Q_DB", Path(__file__).parent / "d2q.db"))
+TEMPS = (0.7, 1.1)
+ARM = "styled"
+
+
+def load_voices():
+    """Owner replies as voice samples. acted_on only — selected by effect."""
+    out = []
+    for ln in ALIAS.read_text(errors="replace").splitlines():
+        if not ln.strip():
+            continue
+        try:
+            r = json.loads(ln)
+        except Exception:
+            continue
+        s = (r.get("surface") or "").strip()
+        if r.get("acted_on") and 15 < len(s) < 130:
+            out.append(s)
+    return out
+
+
+VOICES = load_voices()
+
+# Russian on purpose — see d2q_gen.py.
+PROMPT = (
+    "Вот как ЭТОТ человек формулирует, когда что-то ищет — обрати внимание на "
+    "обрезанность, сленг, транслит, отсутствие заглавных, опечатки:\n{shots}\n\n"
+    "Заметка:\n{doc}\n\n"
+    "Напиши 6 запросов, которыми ИМЕННО ЭТОТ человек искал бы эту заметку через "
+    "полгода, забыв точные слова. Его голосом, не литературным русским. "
+    "4 по-русски, 2 по-английски коротко. Не копируй слова заметки дословно. "
+    "Только запросы, по одному в строке, без нумерации."
+)
+
+
+def shots_for(rid: str, k=5):
+    """Deterministic few-shot pick: hash of the id, not random — resume-safe."""
+    if not VOICES:
+        return ""
+    h = int(hashlib.sha1(rid.encode()).hexdigest(), 16)
+    picked = [VOICES[(h + i * 7) % len(VOICES)] for i in range(k)]
+    return "\n".join("  · " + s for s in picked)
+
+
+def gen(model, doc, rid, temp, timeout=300):
+    body = {
+        "model": model, "stream": False, "think": False,
+        "options": {"num_predict": 260, "temperature": temp},
+        "messages": [{"role": "user", "content": PROMPT.format(
+            shots=shots_for(rid), doc=doc[:1200])}],
+    }
+    req = urllib.request.Request(GEN_URL, json.dumps(body).encode(),
+                                 {"Content-Type": "application/json"})
+    r = json.load(urllib.request.urlopen(req, timeout=timeout))
+    return (r.get("message", {}).get("content") or "").strip(), r.get("done_reason"), r.get("eval_count", 0)
+
+
+def clean(raw):
+    out = []
+    for ln in raw.splitlines():
+        s = ln.strip().lstrip("-•*0123456789.) \t").strip().strip('"\'')
+        if not s or len(s) < 4 or len(s) > 160:
+            continue
+        if s.endswith(":") or s.lower().startswith(("вот ", "запросы", "here", "sure")):
+            continue
+        out.append(s)
+    return out[:6]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    model = sys.argv[1]
+    pool_n = int(sys.argv[sys.argv.index("--pool") + 1]) if "--pool" in sys.argv else 200
+    limit = int(sys.argv[sys.argv.index("--limit") + 1]) if "--limit" in sys.argv else 0
+    tag = f"{model}|{ARM}"
+
+    print(f"voice-donor replies loaded: {len(VOICES)}", flush=True)
+
+    src = sqlite3.connect(SRC)
+    rows = src.execute(f"SELECT id, path, line, doc, heading, embed_text FROM {TABLE} ORDER BY id").fetchall()
+    src.close()
+    if "--ids" in sys.argv:
+        want = set(json.load(open(sys.argv[sys.argv.index("--ids") + 1])))
+        pool = [r for r in rows if r[0] in want]
+    else:
+        step = max(1, len(rows) // pool_n)
+        pool = rows[::step][:pool_n]
+    if limit:
+        pool = pool[:limit]
+
+    dst = sqlite3.connect(DST, timeout=120)
+    dst.execute("PRAGMA journal_mode=WAL")
+    dst.execute("PRAGMA busy_timeout=120000")
+    dst.execute("""CREATE TABLE IF NOT EXISTS exp (
+        id TEXT, model TEXT, temp REAL, path TEXT, line INTEGER, heading TEXT,
+        queries TEXT, raw TEXT, status TEXT, done_reason TEXT,
+        eval_count INTEGER, secs REAL,
+        PRIMARY KEY (id, model, temp))""")
+    dst.commit()
+
+    done = {(r[0], r[1]) for r in
+            dst.execute("SELECT id, temp FROM exp WHERE model=?", (tag,))}
+    todo = [(r, t) for r in pool for t in TEMPS if (r[0], t) not in done]
+    print(f"{tag}: to generate {len(todo)}", flush=True)
+
+    t0 = time.time()
+    ok = bad = 0
+    for i, ((rid, path, line, doc, heading, etext), temp) in enumerate(todo, 1):
+        t = time.time()
+        try:
+            raw, dr, ec = gen(model, etext, rid, temp)
+            qs = clean(raw)
+            status = "ok" if qs else ("empty" if not raw else "unparsed")
+            ok += status == "ok"
+            bad += status != "ok"
+        except Exception as e:
+            raw, dr, ec, qs, status = f"{type(e).__name__}: {e}", None, 0, [], "error"
+            bad += 1
+        dst.execute("INSERT OR IGNORE INTO exp VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (rid, tag, temp, path, line, heading,
+                     json.dumps(qs, ensure_ascii=False),
+                     raw[:2000], status, dr, ec, round(time.time() - t, 2)))
+        dst.commit()
+        if i % 25 == 0 or i == len(todo):
+            el = time.time() - t0
+            print(f"  {i}/{len(todo)} ok={ok} bad={bad} {el:.0f}s "
+                  f"ETA {el/i*(len(todo)-i)/60:.1f}m", flush=True)
+    dst.close()
+    print(f"DONE {tag}: ok={ok} bad={bad}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/eval/d2q-wiki-stand/d2q_styled.py
+++ b/packages/eval/d2q-wiki-stand/d2q_styled.py
@@ -44,6 +44,17 @@ DST = Path(os.environ.get("D2Q_DB", Path(__file__).parent / "d2q.db"))
 TEMPS = (0.7, 1.1)
 ARM = "styled"
 
+# Same register guard as d2q_gen.py: a doc already in the owner's register
+# gets no voice expansion — it would only add collision surface.
+CYR_SKIP = float(os.environ.get("D2Q_SKIP_CYR", "0.5"))
+
+
+def cyr_share(text: str) -> float:
+    letters = [c for c in text if c.isalpha()]
+    if not letters:
+        return 0.0
+    return sum("Ѐ" <= c <= "ӿ" for c in letters) / len(letters)
+
 
 def load_voices():
     """Owner replies as voice samples. acted_on only — selected by effect."""
@@ -131,6 +142,12 @@ def main():
         pool = rows[::step][:pool_n]
     if limit:
         pool = pool[:limit]
+
+    skipped = [r for r in pool if cyr_share(r[5]) >= CYR_SKIP]
+    if skipped:
+        print(f"guard: skipped {len(skipped)} sections ≥{CYR_SKIP:.0%} Cyrillic "
+              f"(already in the owner's register; not a silent cap)", flush=True)
+    pool = [r for r in pool if cyr_share(r[5]) < CYR_SKIP]
 
     dst = sqlite3.connect(DST, timeout=120)
     dst.execute("PRAGMA journal_mode=WAL")


### PR DESCRIPTION
Six commits that were sitting local, in four areas. The title used to name only
the first two; the rest were in the body but not on the tin.

**eval — `packages/eval/d2q-wiki-stand/`** (new)
The doc2query bridge stand for a RU/UA-colloquial user over an EN corpus:
generation arms (doc-seeded + voice-conditioned, local models), file-level
collision triage (#119's question), held-out rescue with a foreign-seed null
arm, discounted boost channel. A follow-up commit adds the **register guard**:
the first README oversold the corpus as "EN". Most sections are in fact mixed,
and a substantial minority are majority-Cyrillic — which also explains the
suspiciously healthy RU baseline in the rescue run (easy RU queries hit
Cyrillic text directly). Exact shares are corpus-specific and left to the
README's own measurement. Both generators now skip sections at or above
`D2Q_SKIP_CYR` (default 0.5) Cyrillic share — a doc that already speaks the
user's language needs no bridge, expanding it only adds collision surface. The
skip is printed, never silent.

**docs — `find_document` reports `docs_indexed`**
An empty `hits: []` on a never-populated doc vault stopped masquerading as
"searched and found nothing". Three regression tests.

**live — recall hits surface as map notices, and the cooldown now exists**
`recall` / `hook_recall` top-3 hits surface as map notices. The re-announce
cooldown was a promise with nothing behind it: `http.ts` referred to it, and
`live-updates.ts` contained no such identifier under any name. Debounce was not
standing in — that window collapses bursts within seconds, while recall
re-surfaces the same memory minutes apart, so the card would loop the same few
titles for a session. The window is real now, keyed per id, and it silences
only `read` — add/change/delete are never throttled, so what the user edits
always announces. Default 180s, env-tunable (`BASTRA_REANNOUNCE_MS`) like the
neighbouring windows; **the number is set, not measured**, and the comment says
so. The honest figure is the median gap between two surfacings of one id, which
the telemetry log can answer.

The score band travels with the notice and **labels rather than filters**. An
earlier draft cut below-floor hits out. That was wrong on both paths, for
different reasons. On the `recall` path whatever sits in `hits[]` was already
served, behind the caller's own `min_score` — which may legitimately sit under
the global floor, so a floor here would overrule the caller and hide what the
turn actually saw. On the hook path `hits[]` is the engine's raw top-k, and the
hook CLIs already drop client-side (their own floors, scope filter, dedup) —
a second floor at this layer would cut blind, and twice. Either way the notice
is a label, not a gate: flooding is the cooldown's job, not the floor's; the map
gets the band so it can tell required from optional without knowing any
thresholds itself.

**graph — a single import batch still collapses into one cluster**
Interior clustering of one import batch is preserved.

The ground-truth file is not included — build your own per the README (queries
must avoid the target's vocabulary).

Known flake, not from this branch: `recall-score-transparency.test.ts` →
`weak_result fires on a nonsense hybrid query, is absent on a genuine match`
fails ~2 runs in 10 in isolation. The file is byte-identical to `main` and
flakes at the same rate on a pristine `main` worktree.