### PR TITLE
fix(save): Unicode-aware save_quality tokenizer + slugify

### DIFF
--- a/packages/core/src/save.ts
+++ b/packages/core/src/save.ts
@@ -234,7 +234,11 @@ export function slugify(input: string): string {
     .normalize("NFKD")
     .replace(/\p{Diacritic}/gu, "");
   const slug = lower
-    .replace(/[^a-z0-9]+/g, "-")
+    // `[^a-z0-9]` erased every non-Latin letter into a separator, so a
+    // Cyrillic/CJK-only title collapsed to "" and threw. `\p{L}\p{N}` + `u`
+    // keep letters of any script (UTF-8 filenames are fine); ASCII titles are
+    // unaffected. Umlauts still transliterate above, before this runs.
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, SLUG_MAX_LEN);
   if (!slug) throw new Error(`cannot slugify: ${JSON.stringify(input)}`);

--- a/packages/daemon/__tests__/save-quality-cyrillic.test.ts
+++ b/packages/daemon/__tests__/save-quality-cyrillic.test.ts
@@ -1,0 +1,102 @@
+/**
+ * save_quality tokeniser must be script-agnostic.
+ *
+ * `words()` matched `[a-z0-9]` only, so a non-Latin recall_when phrase
+ * ("тон письма outward") collapsed to its single Latin token and tripped the
+ * `tokens.length <= 1` → "too short/generic" penalty (−25 each, up to −55).
+ * Every Cyrillic/CJK author was structurally forced into the `low` band no
+ * matter how specific their multi-word triggers were.
+ *
+ * Guard: a genuinely one-word trigger stays flagged — the fix widens the
+ * alphabet, it must not disable the specificity check.
+ *
+ * Runner: `tsx --test __tests__/save-quality-cyrillic.test.ts`
+ * Real file vault, no mocking.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Vault, SearchIndex } from "@bastra-recall/core";
+import { Telemetry } from "../src/telemetry.js";
+import { saveMemoryHandler, type ToolDeps } from "../src/tool-handlers.js";
+
+async function makeDeps(): Promise<{ deps: ToolDeps; close: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "bastra-cyrillic-quality-"));
+  const vault = new Vault(dir);
+  await vault.init();
+  const search = new SearchIndex(vault);
+  search.start();
+  const deps: ToolDeps = { vault, search, telemetry: new Telemetry(), vaultPath: dir };
+  return {
+    deps,
+    close: async () => {
+      search.stop();
+      await vault.stop?.();
+      await rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    },
+  };
+}
+
+const CYRILLIC = {
+  title: "feedback показать и отправить два хода",
+  type: "meta-working",
+  summary: "Показ outward-текста и отправка обязаны быть двумя ходами с ходом юзера между ними.",
+  topic_path: ["feedback", "outward"],
+  tags: ["feedback", "outward", "boundary"],
+  scope: "selftest",
+  recall_when: [
+    "показать и отправить два хода",
+    "разрешение на задачу не подпись под грузом",
+    "юзер видел этот текст отдельным ходом",
+  ],
+  body: "Если ход содержит «вот текст» — ход заканчивается; отправка живёт в следующем вызове.",
+};
+
+test("multi-word Cyrillic recall_when is not flagged as too short/generic", async (t) => {
+  const { deps, close } = await makeDeps();
+  t.after(close);
+
+  const res = await saveMemoryHandler(deps, CYRILLIC);
+  assert.equal(res.created, true);
+
+  const shortIssues = res.save_quality.issues.filter((i) => i.includes("too short/generic"));
+  assert.deepEqual(
+    shortIssues,
+    [],
+    `multi-word Cyrillic triggers must tokenise past 1 word, got: ${JSON.stringify(shortIssues)}`,
+  );
+});
+
+test("a genuinely one-word Cyrillic trigger is still flagged", async (t) => {
+  const { deps, close } = await makeDeps();
+  t.after(close);
+
+  const res = await saveMemoryHandler(deps, {
+    ...CYRILLIC,
+    title: "feedback односложный триггер",
+    recall_when: ["дрейф"],
+  });
+
+  const shortIssues = res.save_quality.issues.filter((i) => i.includes("too short/generic"));
+  assert.ok(
+    shortIssues.length >= 1,
+    "the specificity check must still catch a real one-word trigger — the fix widens the alphabet, not the gate",
+  );
+});
+
+test("a Cyrillic-only title slugifies instead of throwing", async (t) => {
+  const { deps, close } = await makeDeps();
+  t.after(close);
+
+  // Pre-fix `slugify` matched `[^a-z0-9]`, so an all-Cyrillic title collapsed
+  // to "" and threw `cannot slugify` before the memory could be written.
+  const res = await saveMemoryHandler(deps, {
+    ...CYRILLIC,
+    title: "тон письма и регистр",
+  });
+
+  assert.equal(res.created, true);
+  assert.ok(res.id.length > 0, `Cyrillic title must produce a non-empty slug, got '${res.id}'`);
+});

--- a/packages/daemon/src/tool-handlers.ts
+++ b/packages/daemon/src/tool-handlers.ts
@@ -534,8 +534,13 @@ export const GENERIC_TRIGGER_WORDS = new Set([
   "ux",
 ]);
 
+// Unicode-aware: `[a-z0-9]` only matched ASCII, so a non-Latin trigger
+// ("тон письма outward") tokenised to just its one Latin word and tripped the
+// `tokens.length <= 1` "too short/generic" penalty — every Cyrillic/CJK author
+// was structurally penalised on save_quality. `\p{L}\p{N}` + the `u` flag count
+// letters in any script; toLowerCase already folds Unicode case.
 function words(text: string): string[] {
-  return text.toLowerCase().match(/[a-z0-9][a-z0-9_-]*/g) ?? [];
+  return text.toLowerCase().match(/[\p{L}\p{N}][\p{L}\p{N}_-]*/gu) ?? [];
 }
 
 const ACTED_ON_STOPWORDS = new Set([


### PR DESCRIPTION
## Problem

`words()` (save_quality) and `slugify()` both matched `[a-z0-9]` only, so
non-Latin content was silently mishandled:

- **Tokenizer:** a `recall_when` trigger in any non-Latin script tokenized
  to ≤1 word → tripped the "too short/generic" penalty (up to −55). Every
  Cyrillic/CJK author landed in the `low` band no matter how specific their
  triggers were.
- **Slugify:** a title with no Latin letters collapsed to `""` and threw
  `cannot slugify` — the save was blocked outright.

The umlaut transliteration in `slugify` (`ä→ae`, …) shows the intent was
already "handle more than ASCII" — it just stopped at one neighbouring
alphabet.

## Fix

Widen both to `\p{L}\p{N}` with the `u` flag — letters of any script.
ASCII behaviour unchanged (umlaut transliteration still runs first); the
specificity gate still fires on genuinely one-word triggers.

## Test

`save-quality-cyrillic.test.ts` covers both paths: multi-word Cyrillic is
no longer flagged, a one-word trigger still is, and a Cyrillic-only title
slugifies instead of throwing. Verified across Latin/Cyrillic/CJK/Arabic/
Greek/Hangul.
