### PR TITLE
feat(map): impact + spill animation, slider-timed first bolt, sequential cascade

### DIFF
--- a/packages/daemon/scripts/verify-impact-wiring.mjs
+++ b/packages/daemon/scripts/verify-impact-wiring.mjs
@@ -1,0 +1,178 @@
+/**
+ * End-to-end check of the impact wiring, by DIFFERENCE.
+ *
+ * Two renderers over the same graph and the same clock; one gets a flash, the
+ * other stays quiet. Everything the flashing one draws beyond the quiet one is,
+ * by construction, the discharge — no guessing which arc is a node and which is
+ * a ring. That mattered: a first attempt keyed on radius and happily "passed"
+ * while measuring node circles.
+ */
+const REPO = new URL("../webui/js", import.meta.url).href;
+
+let clock = 1000;
+globalThis.performance = { now: () => clock };
+globalThis.localStorage = {
+  _d: new Map(),
+  getItem(k) { return this._d.has(k) ? this._d.get(k) : null; },
+  setItem(k, v) { this._d.set(k, String(v)); },
+};
+globalThis.devicePixelRatio = 1;
+
+let sink = [];
+function makeCtx() {
+  let alpha = 1;
+  const rec = (op, extra = {}) => sink.push({ op, alpha, ...extra });
+  return {
+    canvas: { width: 1200, height: 800 },
+    get globalAlpha() { return alpha; },
+    set globalAlpha(v) { alpha = v; },
+    lineWidth: 1, strokeStyle: "", fillStyle: "", font: "", textAlign: "",
+    lineJoin: "", lineCap: "", globalCompositeOperation: "",
+    save() {}, restore() {}, translate() {}, scale() {}, setLineDash() {},
+    beginPath() {}, closePath() {},
+    moveTo() {}, lineTo() {}, quadraticCurveTo() {}, bezierCurveTo() {},
+    arc(x, y, r) { rec("arc", { x, y, r }); },
+    stroke() { rec("stroke"); },
+    fill() {},
+    fillRect() {}, clearRect() {}, strokeRect() {},
+    fillText() {}, strokeText() {},
+    measureText: () => ({ width: 10 }),
+    drawImage(_s, x, y, w) { rec("drawImage", { x, y, w }); },
+    createRadialGradient: () => ({ addColorStop() {} }),
+    createLinearGradient: () => ({ addColorStop() {} }),
+  };
+}
+const canvasEl = {
+  width: 1200, height: 800, clientWidth: 1200, clientHeight: 800, style: {},
+  getContext: () => makeCtx(),
+  getBoundingClientRect: () => ({ width: 1200, height: 800, left: 0, top: 0 }),
+  addEventListener() {},
+};
+globalThis.document = {
+  createElement: () => ({ width: 0, height: 0, getContext: () => makeCtx(), style: {} }),
+  documentElement: { classList: { contains: () => false }, style: {}, dataset: {} },
+  body: { classList: { contains: () => false } },
+  addEventListener() {}, querySelector: () => null,
+};
+globalThis.window = { addEventListener() {}, matchMedia: () => ({ matches: false, addEventListener() {} }) };
+globalThis.getComputedStyle = () => ({ getPropertyValue: () => "#888888" });
+
+const ok = (name, cond, detail = "") => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  — " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+};
+
+const { createRenderer } = await import(`${REPO}/renderer.js`);
+
+function buildSim() {
+  const nodes = [];
+  const mk = (id, x, y) => {
+    const n = { id, x, y, idx: nodes.length, cluster: "c", kind: "memory", label: id };
+    nodes.push(n);
+    return n;
+  };
+  const hub = mk("hub", 0, 0);
+  const ring1 = [...Array(6).keys()].map((i) => mk(`n${i}`, Math.cos(i) * 300, Math.sin(i) * 300));
+  const ring2 = ring1.flatMap((p, i) =>
+    [...Array(3).keys()].map((j) => mk(`f${i}_${j}`, p.x + 60 + j * 40, p.y + 60 + j * 40)),
+  );
+  const edges = [
+    ...ring1.map((n) => ({ s: hub, t: n })),
+    ...ring2.map((n, k) => ({ s: ring1[Math.floor(k / 3)], t: n })),
+  ];
+  return {
+    sim: { nodes, edges, byId: new Map(nodes.map((n) => [n.id, n])), centers: new Map(), alpha: 0 },
+    hub, ring1, ring2,
+  };
+}
+
+const hues = new Map([["c", 200]]);
+const A = buildSim(); // flashes
+const B = buildSim(); // stays quiet — the control
+const rA = createRenderer(canvasEl, A.sim, hues);
+const rB = createRenderer(canvasEl, B.sim, hues);
+
+// draw() takes the clock as an argument — calling it bare makes every
+// time-dependent branch NaN and silently draws nothing.
+const capture = (r) => { sink = []; r.draw(clock); return sink; };
+const near = (o, n) => o.x !== undefined && Math.hypot(o.x - n.x, o.y - n.y) < 1e-6;
+
+rA.flashNode("hub", "#ff0000", 3000);
+
+/** Ops the flashing renderer draws that the quiet one does not, per frame. */
+function extraOps(t) {
+  clock = 1000 + t;
+  const a = capture(rA);
+  const b = capture(rB);
+  return { a, b, extra: a.length - b.length };
+}
+
+// ── 1. the discharge produces marks at all ─────────────────────────────────
+const timeline = [...Array(80).keys()].map((i) => ({ t: i * 15, ...extraOps(i * 15) }));
+const peak = timeline.reduce((x, y) => (y.extra > x.extra ? y : x));
+ok("a flash draws more than the same graph at rest", peak.extra > 0,
+   `+${peak.extra} ops at +${peak.t}ms`);
+
+// ── 2. impacts land ON the first-level neighbours ──────────────────────────
+// Counted as: arcs at a neighbour's exact position that the quiet renderer
+// does NOT draw at that same instant.
+const struck = new Set();
+const impactAlpha = [];
+for (const fr of timeline) {
+  for (const n of A.ring1) {
+    const inA = fr.a.filter((o) => o.op === "arc" && near(o, n));
+    const inB = fr.b.filter((o) => o.op === "arc" && near(o, B.sim.byId.get(n.id)));
+    if (inA.length > inB.length) {
+      struck.add(n.id);
+      // the surplus arcs are the impact rings
+      for (const o of inA.slice(inB.length)) impactAlpha.push(o.alpha);
+    }
+  }
+}
+ok("the discharge strikes its neighbours", struck.size > 0, `${struck.size}/6 struck`);
+ok("every first-level neighbour is struck", struck.size === A.ring1.length,
+   `[${[...struck].sort().join(", ")}]`);
+
+// ── 3. the strike stays under the origin's own flare ───────────────────────
+const originAlpha = [];
+for (const fr of timeline) {
+  const inA = fr.a.filter((o) => (o.op === "arc" || o.op === "drawImage") && near(o, A.hub));
+  const inB = fr.b.filter((o) => (o.op === "arc" || o.op === "drawImage") && near(o, B.hub));
+  for (const o of inA.slice(inB.length)) originAlpha.push(o.alpha);
+}
+const iMax = impactAlpha.length ? Math.max(...impactAlpha) : 0;
+const oMax = originAlpha.length ? Math.max(...originAlpha) : 0;
+ok("impact rings stay dimmer than the origin flare", iMax > 0 && oMax > 0 && iMax < oMax,
+   `impact ${iMax.toFixed(2)} vs origin ${oMax.toFixed(2)}`);
+
+// ── 4. the spill reaches strands beyond the chain ──────────────────────────
+// Second-level nodes are not struck at hop 1, but strands leaving a struck
+// neighbour toward them should glow faintly. Detected as extra strokes while
+// no extra arc sits on those far nodes.
+const extraStrokes = timeline.map((f) =>
+  f.a.filter((o) => o.op === "stroke").length - f.b.filter((o) => o.op === "stroke").length);
+ok("strands light up around the impact", Math.max(...extraStrokes) > A.ring1.length,
+   `${Math.max(...extraStrokes)} extra strokes vs ${A.ring1.length} chain legs`);
+
+// ── 5. it ends ──────────────────────────────────────────────────────────────
+const late = extraOps(9000);
+ok("nothing keeps glowing after the flash", late.extra === 0, `+${late.extra} ops at +9s`);
+
+// ── 6. "off" silences the arrival too ──────────────────────────────────────
+localStorage.setItem("bastra-vault-map-bolt-style", "off");
+const C = buildSim();
+const rC = createRenderer(canvasEl, C.sim, hues);
+const D = buildSim();
+const rD = createRenderer(canvasEl, D.sim, hues);
+rC.flashNode("hub", "#ff0000", 3000);
+let offStruck = 0;
+for (let i = 0; i < 80; i++) {
+  clock = 1000 + i * 15;
+  const a = capture(rC), b = capture(rD);
+  for (const n of C.ring1) {
+    const inA = a.filter((o) => o.op === "arc" && near(o, n)).length;
+    const inB = b.filter((o) => o.op === "arc" && near(o, D.sim.byId.get(n.id))).length;
+    if (inA > inB) offStruck++;
+  }
+}
+ok("style 'off' leaves the neighbours untouched", offStruck === 0, `${offStruck} strikes while off`);

--- a/packages/daemon/scripts/verify-impact-wiring.mjs
+++ b/packages/daemon/scripts/verify-impact-wiring.mjs
@@ -176,3 +176,37 @@ for (let i = 0; i < 80; i++) {
   }
 }
 ok("style 'off' leaves the neighbours untouched", offStruck === 0, `${offStruck} strikes while off`);
+
+// ── 7. the afterglow exists at every slider position ───────────────────────
+// Daniel's report: "geringere Zeit kommt das Nachleuchten nicht durch".
+//
+// Two things could not be measured well here and are deliberately left to
+// verify-impact.mjs, which knows the windows exactly: how LONG the glow lasts
+// (the origin halo lives for the whole flash and swamps any duration measured
+// from the canvas) and the ordering. What this checks is the part that only an
+// end-to-end run can show: that spill strokes are actually emitted at every
+// slider position, not just at the comfortable ones.
+localStorage.setItem("bastra-vault-map-bolt-style", "bolt");
+const spillSeen = {};
+for (const ms of [300, 420, 1000, 2000, 4000]) {
+  localStorage.setItem("bastra-vault-map-bolt-ms", String(ms));
+  const P = buildSim(), Q = buildSim();
+  const rP = createRenderer(canvasEl, P.sim, hues);
+  const rQ = createRenderer(canvasEl, Q.sim, hues);
+  rP.flashNode("hub", "#ff0000", ms * 4 + 2000);
+  let best = 0;
+  for (let k = 0; k * 16 < ms * 4 + 1500; k++) {
+    clock = 1000 + k * 16;
+    const a = capture(rP), b = capture(rQ);
+    // more lit strands than the chain has legs ⇒ spill is on screen
+    const extra = a.filter((o) => o.op === "stroke").length - b.filter((o) => o.op === "stroke").length;
+    best = Math.max(best, extra - P.ring1.length);
+  }
+  spillSeen[ms] = best;
+}
+console.log("   surplus lit strands beyond the chain:", JSON.stringify(spillSeen));
+ok("spill strands appear at every slider position",
+   Object.values(spillSeen).every((v) => v > 0), JSON.stringify(spillSeen));
+ok("the shortest duration is not the poorest",
+   spillSeen[300] >= Math.max(...Object.values(spillSeen)) * 0.5,
+   `300ms: ${spillSeen[300]} vs best ${Math.max(...Object.values(spillSeen))}`);

--- a/packages/daemon/scripts/verify-impact.mjs
+++ b/packages/daemon/scripts/verify-impact.mjs
@@ -19,7 +19,13 @@ import {
   IMPACT_SPILL_MAX,
   IMPACT_SPILL_ALPHA,
 } from "../webui/js/impact.js";
-import { boltRnd } from "../webui/js/bolt-styles.js";
+import {
+  boltRnd,
+  legDurationFor,
+  hopDelayFor,
+  CHAIN_MIN_LEG_MS,
+  CHAIN_MIN_HOP_DELAY_MS,
+} from "../webui/js/bolt-styles.js";
 
 const ok = (name, cond, detail = "") => {
   console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  — " + detail : ""}`);
@@ -100,6 +106,31 @@ for (const ms of SLIDER) {
                         spillWindow(ms).start + spillWindow(ms).dur) - ms;
   ok(`tail budget covers the overhang at ${ms}ms`, tailMs(ms) >= Math.max(0, need) - 1e-9,
      `tail ${Math.round(tailMs(ms))}ms vs needed ${Math.round(Math.max(0, need))}ms`);
+}
+
+
+// ── 1d. the slider times the BOLT; what fires after gets its own time ───────
+// "die zeit der animation muss gemessen werden für die blitze, die anderen
+// verbindungen die dann feuern brauchen extra ihre zeit". Deriving the onward
+// chain from the slider means that at 300ms three levels arrive within 380ms
+// of each other, each lasting 300ms — not a chain travelling outward.
+const RATIO = 180 / 420;
+for (const ms of [300, 420, 1000, 2000, 4000]) {
+  ok(`level 1 obeys the slider exactly at ${ms}ms`, legDurationFor(1, ms) === ms);
+  ok(`following levels get room at ${ms}ms`, legDurationFor(2, ms) >= CHAIN_MIN_LEG_MS,
+     `${legDurationFor(2, ms)}ms`);
+  ok(`levels stay apart at ${ms}ms`, hopDelayFor(ms, RATIO) >= CHAIN_MIN_HOP_DELAY_MS,
+     `${Math.round(hopDelayFor(ms, RATIO))}ms between levels`);
+}
+// the long end must be pure slider — no floor may touch the signed-off look
+for (const ms of [1000, 2000, 4000]) {
+  ok(`no floor bites at ${ms}ms`,
+     legDurationFor(2, ms) === ms && Math.abs(hopDelayFor(ms, RATIO) - ms * RATIO) < 1e-9,
+     `leg ${legDurationFor(2, ms)}ms, gap ${Math.round(hopDelayFor(ms, RATIO))}ms`);
+}
+// a following level must never be SHORTER than the bolt that spawned it
+for (const ms of [300, 420, 1000, 2000, 4000]) {
+  ok(`level 2 is never shorter than level 1 at ${ms}ms`, legDurationFor(2, ms) >= legDurationFor(1, ms));
 }
 
 // ── 2. the impact stays under the origin flare ──────────────────────────────

--- a/packages/daemon/scripts/verify-impact.mjs
+++ b/packages/daemon/scripts/verify-impact.mjs
@@ -8,23 +8,20 @@ import {
   drawImpact,
   drawSpill,
   spillEdgesFor,
-  IMPACT_AT,
-  IMPACT_SPILL_AT,
   spillPhase,
-  impactWindow,
-  spillWindow,
   tailMs,
-  IMPACT_MIN_MS,
-  SPILL_MIN_MS,
+  IMPACT_LEAD_MS,
+  IMPACT_MS,
+  SPILL_GAP_MS,
+  SPILL_MS,
   IMPACT_SPILL_MAX,
   IMPACT_SPILL_ALPHA,
 } from "../webui/js/impact.js";
 import {
   boltRnd,
   legDurationFor,
-  hopDelayFor,
+  levelStartOffset,
   CHAIN_LEG_MS,
-  CHAIN_HOP_DELAY_MS,
 } from "../webui/js/bolt-styles.js";
 
 const ok = (name, cond, detail = "") => {
@@ -51,62 +48,61 @@ function recorder() {
 }
 const glowSprite = () => ({ sprite: true });
 
-// ── 1. phase curve ──────────────────────────────────────────────────────────
-const REF = 420; // the shipped default duration
-ok("phase is 0 while the bolt is still travelling", impactPhase(0, REF) === 0 && impactPhase(IMPACT_AT * REF, REF) === 0);
-ok("phase is 0 once its own window is over", impactPhase(impactWindow(REF).start + impactWindow(REF).dur, REF) === 0);
-const peak = [...Array(101).keys()].map((i) => ({ t: i / 100, p: impactPhase((i / 100) * REF, REF) }))
+// ── 1. the post-bolt clock: measured from the bolt's arrival, in fixed ms ────
+// legMs is time since the bolt started; legDur is how long the bolt travelled.
+// A leg of 420ms and a leg of 4000ms must produce the SAME strike/spill once
+// the bolt has arrived — that is the whole rule.
+// the strike fires IMPACT_LEAD_MS before the bolt ends — a fixed lead, not the
+// bolt's end and not a fraction of its length
+const arrival = (legDur) => legDur - IMPACT_LEAD_MS;
+ok("nothing strikes before the fixed lead point", impactPhase(arrival(420) - 5, 420) === 0);
+ok("the strike is lit at the lead point", impactPhase(arrival(420) + 5, 420) > 0);
+ok("the strike fires exactly IMPACT_LEAD_MS before the bolt ends", (() => {
+  for (const legDur of [300, 420, 1000, 2000, 4000]) {
+    let first = null;
+    for (let legMs = 0; legMs <= legDur + 100; legMs += 1) if (impactPhase(legMs, legDur) > 0) { first = legMs; break; }
+    if (Math.abs(legDur - first - IMPACT_LEAD_MS) > 1.5) return false;
+  }
+  return true;
+})(), `${IMPACT_LEAD_MS}ms before the end, every slider`);
+// peak brightness sits inside the fixed strike window, near its front
+const strikePeak = [...Array(200).keys()]
+  .map((i) => ({ since: (i / 200) * IMPACT_MS, p: impactPhase(arrival(1000) + (i / 200) * IMPACT_MS, 1000) }))
   .reduce((a, b) => (b.p > a.p ? b : a));
-ok("phase peaks inside the arrival window", peak.p > 0.9 && peak.t > IMPACT_AT && peak.t < 1,
-   `peak ${peak.p.toFixed(2)} at t=${peak.t}`);
-// rises faster than it falls — a strike, not a breath
-const rise = peak.t - IMPACT_AT, fall = 1 - peak.t;
-ok("rises fast, decays slow", fall > rise * 1.5, `rise ${rise.toFixed(3)} vs fall ${fall.toFixed(3)}`);
+ok("strike peaks near 1, early in its window", strikePeak.p > 0.9 && strikePeak.since < IMPACT_MS * 0.4,
+   `peak ${strikePeak.p.toFixed(2)} at +${Math.round(strikePeak.since)}ms`);
+ok("both fade to nothing eventually", impactPhase(99999, 420) === 0 && spillPhase(99999, 420) === 0);
 
 // ── 1b. cause before consequence ────────────────────────────────────────────
-// The strike lands first, the neighbourhood answers after. Sharing one phase
-// (which is how it started) flattens the two into a single event.
-ok("the spill starts after the strike", IMPACT_SPILL_AT > IMPACT_AT,
-   `spill ${IMPACT_SPILL_AT} > impact ${IMPACT_AT}`);
-const firstImpact = [...Array(200).keys()].map((i) => i / 200).find((t) => impactPhase(t * REF, REF) > 0);
-const firstSpill = [...Array(200).keys()].map((i) => i / 200).find((t) => spillPhase(t * REF, REF) > 0);
-ok("nothing spills before the strike is visible", firstSpill > firstImpact,
-   `impact from t=${firstImpact.toFixed(3)}, spill from t=${firstSpill.toFixed(3)}`);
-ok("both fade to nothing eventually", impactPhase(9999, REF) === 0 && spillPhase(9999, REF) === 0);
-// and the strike itself must not sit at the very end of the travel
-ok("the strike is not late in the leg", IMPACT_AT < 0.5, `IMPACT_AT ${IMPACT_AT}`);
+// Strike first, then — after it has PLAYED OUT, not during — the neighbourhood.
+const iStart = [...Array(600).keys()].map((k) => k * 5).find((s) => impactPhase(1000 + s, 1000) > 0);
+const iEnd = [...Array(600).keys()].map((k) => k * 5).reverse().find((s) => impactPhase(1000 + s, 1000) > 0);
+const sStart = [...Array(600).keys()].map((k) => k * 5).find((s) => spillPhase(1000 + s, 1000) > 0);
+ok("the follow-up starts after the strike has finished", sStart >= iEnd,
+   `strike +${iStart}..${iEnd}ms, follow-up from +${sStart}ms`);
+ok("the gap between them matches SPILL_GAP_MS", Math.abs(sStart - iEnd - SPILL_GAP_MS) < 20,
+   `gap ~${sStart - iEnd}ms vs ${SPILL_GAP_MS}ms`);
 
-
-// ── 1c. the slider must not be able to hide the afterglow ───────────────────
-// The bug this pins: every window used to be a FRACTION of the discharge, so
-// at 300ms the afterglow got 102ms — geometrically correct, perceptually gone,
-// while the same design read perfectly at 2s.
+// ── 1c. THE RULE: the slider touches the first bolt and nothing else ─────────
+// The strike and the follow-up, measured from arrival, are byte-for-byte the
+// same at every slider position. If they weren't, the slider would be changing
+// an animation that is not the first bolt — the exact thing Daniel ruled out.
 const SLIDER = [300, 420, 700, 1000, 2000, 4000];
-const PERCEPTIBLE_MS = 250;
-for (const ms of SLIDER) {
-  const s = spillWindow(ms), i = impactWindow(ms);
-  ok(`afterglow stays perceptible at ${ms}ms`, s.dur >= PERCEPTIBLE_MS,
-     `${Math.round(s.dur)}ms`);
-  ok(`strike stays perceptible at ${ms}ms`, i.dur >= PERCEPTIBLE_MS, `${Math.round(i.dur)}ms`);
-}
-// the 2s look is the reference — it must be untouched by the floors
-const ref2s = { i: impactWindow(2000), s: spillWindow(2000) };
-ok("the 2s reference is purely proportional (floors do not bite)",
-   Math.abs(ref2s.i.dur - 0.78 * 2000) < 1 && Math.abs(ref2s.s.dur - 0.34 * 2000) < 1,
-   `impact ${Math.round(ref2s.i.dur)}ms, spill ${Math.round(ref2s.s.dur)}ms`);
-// and the ordering survives everywhere
-for (const ms of SLIDER) {
-  const fi = [...Array(400).keys()].map((k) => (k / 400) * ms * 2).find((x) => impactPhase(x, ms) > 0);
-  const fs = [...Array(400).keys()].map((k) => (k / 400) * ms * 2).find((x) => spillPhase(x, ms) > 0);
-  ok(`strike still precedes afterglow at ${ms}ms`, fs > fi, `${Math.round(fi)}ms → ${Math.round(fs)}ms`);
-}
-// legs must be kept alive long enough for the tail
-for (const ms of SLIDER) {
-  const need = Math.max(impactWindow(ms).start + impactWindow(ms).dur,
-                        spillWindow(ms).start + spillWindow(ms).dur) - ms;
-  ok(`tail budget covers the overhang at ${ms}ms`, tailMs(ms) >= Math.max(0, need) - 1e-9,
-     `tail ${Math.round(tailMs(ms))}ms vs needed ${Math.round(Math.max(0, need))}ms`);
-}
+const profile = (fn, legDur) => [...Array(400).keys()].map((k) => fn(legDur + k * 6, legDur) > 0.001 ? 1 : 0).join("");
+const strikeProfiles = SLIDER.map((ms) => profile(impactPhase, ms));
+const spillProfiles = SLIDER.map((ms) => profile(spillPhase, ms));
+ok("the strike is identical at every slider position (arrival-relative)",
+   strikeProfiles.every((p) => p === strikeProfiles[0]), `${new Set(strikeProfiles).size} distinct profiles`);
+ok("the follow-up is identical at every slider position (arrival-relative)",
+   spillProfiles.every((p) => p === spillProfiles[0]), `${new Set(spillProfiles).size} distinct profiles`);
+// the follow-up has to be a comfortable length — it was "zu schnell" before
+ok("the follow-up is a calm, perceptible length", SPILL_MS >= 900, `${SPILL_MS}ms`);
+// the strike and follow-up each have their own length; neither is derived from
+// the other, so their relative order is a free choice, not an invariant.
+// the keep-alive tail is a constant with no slider term (the sequence ends
+// IMPACT_LEAD_MS earlier because it also starts that much before the bolt end)
+ok("tailMs carries the whole fixed sequence and no slider term",
+   tailMs() === IMPACT_MS + SPILL_GAP_MS + SPILL_MS - IMPACT_LEAD_MS, `${tailMs()}ms`);
 
 
 // ── 1d. the slider times level 1 ONLY — everything after is decoupled ───────
@@ -121,15 +117,28 @@ for (const ms of S1) {
 const legFollow = S1.map((ms) => legDurationFor(2, ms));
 ok("a following level's duration never depends on the slider",
    legFollow.every((v) => v === CHAIN_LEG_MS), `[${legFollow.join(", ")}]`);
-const delays = S1.map(() => hopDelayFor());
-ok("the gap between levels never depends on the slider",
-   delays.every((v) => v === CHAIN_HOP_DELAY_MS), `[${delays.join(", ")}]`);
-// hop 3 is timed the same way as hop 2 — both are followers
 ok("all following levels share one fixed duration",
    legDurationFor(2, 300) === legDurationFor(3, 4000));
-// and a follower is a real, perceptible length regardless of a tiny slider
-ok("followers stay perceptible even at the shortest slider",
-   legDurationFor(2, 300) >= 250, `${legDurationFor(2, 300)}ms`);
+
+// ── 1e. the levels QUEUE: each starts only after the previous strike ────────
+// "Nach diesen 2 Sekunden müssen dann die anderen Sachen zünden." Level N+1
+// must not overlap level N's strike — it starts once that strike has run out.
+for (const ms of S1) {
+  ok(`level 1 starts at 0 at ${ms}ms`, levelStartOffset(1, ms) === 0);
+  // level 2 begins exactly when level 1's strike ends: (boltMs - LEAD) + IMPACT_MS
+  const l1StrikeEnd = ms - IMPACT_LEAD_MS + IMPACT_MS;
+  ok(`level 2 starts as level 1's strike ends at ${ms}ms`,
+     Math.abs(levelStartOffset(2, ms) - l1StrikeEnd) < 1e-9,
+     `start ${levelStartOffset(2, ms)}ms vs strike-end ${l1StrikeEnd}ms`);
+  // level 3 begins after level 2's strike, which is a fixed length (no slider)
+  const l2StrikeEnd = levelStartOffset(2, ms) + CHAIN_LEG_MS - IMPACT_LEAD_MS + IMPACT_MS;
+  ok(`level 3 starts as level 2's strike ends at ${ms}ms`,
+     Math.abs(levelStartOffset(3, ms) - l2StrikeEnd) < 1e-9);
+  // the offset between level 2 and 3 is slider-independent (both are followers)
+}
+const l23Gap = S1.map((ms) => levelStartOffset(3, ms) - levelStartOffset(2, ms));
+ok("the gap between two following levels never depends on the slider",
+   l23Gap.every((g) => Math.abs(g - l23Gap[0]) < 1e-9), `[${l23Gap.map(Math.round).join(", ")}]`);
 
 // ── 2. the impact stays under the origin flare ──────────────────────────────
 // origin supernova: ring alpha 0.75, halo up to 0.9, ring reach 80px
@@ -145,13 +154,14 @@ ok("impact ring stays well inside the supernova's reach", ring.r < 45, `reach ${
 // The bug this pins: sizing the ring off `phase` (which rises then falls) makes
 // it start wide, collapse inward while the strike brightens, and only then
 // expand. Radius must follow progress, which is monotonic.
+const LEG = 420;
 const radii = [];
 for (let i = 0; i <= 40; i++) {
-  const t = IMPACT_AT + ((1 - IMPACT_AT) * i) / 40;
+  const legMs = LEG + (IMPACT_MS * i) / 40; // step across the strike window, from arrival
   const r = recorder();
   drawImpact({
     ctx: r.ctx, x: 0, y: 0, r: 4, phase: 1 /* forced: isolate geometry */,
-    progress: impactProgress(t * REF, REF), strength: 1, color: "#fff", camScale: 1, glowSprite,
+    progress: impactProgress(legMs, LEG), strength: 1, color: "#fff", camScale: 1, glowSprite,
   });
   const arc = r.calls.find((c) => c.op === "arc");
   if (arc) radii.push(arc.r);
@@ -162,8 +172,8 @@ ok("impact ring never contracts", monotonic,
 ok("impact ring actually travels", radii[radii.length - 1] > radii[0] * 2);
 ok("progress is monotonic across the window",
    [...Array(50).keys()].every((i) => {
-     const t0 = (i / 49) * REF, t1 = ((i + 1) / 49) * REF;
-     return impactProgress(t1, REF) >= impactProgress(t0, REF);
+     const t0 = LEG + (i / 49) * IMPACT_MS, t1 = LEG + ((i + 1) / 49) * IMPACT_MS;
+     return impactProgress(t1, LEG) >= impactProgress(t0, LEG);
    }));
 
 // ── 3. hop falloff carries into the impact ──────────────────────────────────

--- a/packages/daemon/scripts/verify-impact.mjs
+++ b/packages/daemon/scripts/verify-impact.mjs
@@ -1,0 +1,133 @@
+/**
+ * Verifies the impact/spill animation without a browser: the canvas is a
+ * recording proxy, so every stroke, arc and alpha becomes inspectable data.
+ */
+import {
+  impactPhase,
+  impactProgress,
+  drawImpact,
+  drawSpill,
+  spillEdgesFor,
+  IMPACT_AT,
+  IMPACT_SPILL_MAX,
+  IMPACT_SPILL_ALPHA,
+} from "../webui/js/impact.js";
+import { boltRnd } from "../webui/js/bolt-styles.js";
+
+const ok = (name, cond, detail = "") => {
+  console.log(`${cond ? "PASS" : "FAIL"}  ${name}${detail ? "  — " + detail : ""}`);
+  if (!cond) process.exitCode = 1;
+};
+
+// ── recording canvas ────────────────────────────────────────────────────────
+function recorder() {
+  const calls = [];
+  let alpha = 1;
+  const ctx = {
+    get globalAlpha() { return alpha; },
+    set globalAlpha(v) { alpha = v; },
+    lineWidth: 1,
+    strokeStyle: "",
+    beginPath: () => calls.push({ op: "beginPath" }),
+    arc: (x, y, r) => calls.push({ op: "arc", x, y, r, alpha }),
+    stroke: () => calls.push({ op: "stroke", alpha }),
+    drawImage: (_s, x, y, w) => calls.push({ op: "drawImage", x, y, w, alpha }),
+    moveTo: () => {}, lineTo: () => {},
+  };
+  return { ctx, calls };
+}
+const glowSprite = () => ({ sprite: true });
+
+// ── 1. phase curve ──────────────────────────────────────────────────────────
+ok("phase is 0 while the bolt is still travelling", impactPhase(0) === 0 && impactPhase(IMPACT_AT) === 0);
+ok("phase is 0 once the leg is over", impactPhase(1) === 0 && impactPhase(1.2) === 0);
+const peak = [...Array(101).keys()].map((i) => ({ t: i / 100, p: impactPhase(i / 100) }))
+  .reduce((a, b) => (b.p > a.p ? b : a));
+ok("phase peaks inside the arrival window", peak.p > 0.9 && peak.t > IMPACT_AT && peak.t < 1,
+   `peak ${peak.p.toFixed(2)} at t=${peak.t}`);
+// rises faster than it falls — a strike, not a breath
+const rise = peak.t - IMPACT_AT, fall = 1 - peak.t;
+ok("rises fast, decays slow", fall > rise * 1.5, `rise ${rise.toFixed(3)} vs fall ${fall.toFixed(3)}`);
+
+// ── 2. the impact stays under the origin flare ──────────────────────────────
+// origin supernova: ring alpha 0.75, halo up to 0.9, ring reach 80px
+const { ctx, calls } = recorder();
+drawImpact({ ctx, x: 0, y: 0, r: 4, phase: 1, strength: 1, color: "#fff", camScale: 1, glowSprite });
+const alphasOf = (cs) => cs.filter((c) => typeof c.alpha === "number").map((c) => c.alpha);
+const maxAlpha = Math.max(...alphasOf(calls));
+ok("impact never outshines the origin flare", maxAlpha <= 0.65, `max alpha ${maxAlpha.toFixed(2)}`);
+const ring = calls.find((c) => c.op === "arc");
+ok("impact ring stays well inside the supernova's reach", ring.r < 45, `reach ${ring.r.toFixed(1)}px vs 80px`);
+
+// ── 2b. the ring only ever travels OUTWARD ──────────────────────────────────
+// The bug this pins: sizing the ring off `phase` (which rises then falls) makes
+// it start wide, collapse inward while the strike brightens, and only then
+// expand. Radius must follow progress, which is monotonic.
+const radii = [];
+for (let i = 0; i <= 40; i++) {
+  const t = IMPACT_AT + ((1 - IMPACT_AT) * i) / 40;
+  const r = recorder();
+  drawImpact({
+    ctx: r.ctx, x: 0, y: 0, r: 4, phase: 1 /* forced: isolate geometry */,
+    progress: impactProgress(t), strength: 1, color: "#fff", camScale: 1, glowSprite,
+  });
+  const arc = r.calls.find((c) => c.op === "arc");
+  if (arc) radii.push(arc.r);
+}
+const monotonic = radii.every((v, i) => i === 0 || v >= radii[i - 1] - 1e-9);
+ok("impact ring never contracts", monotonic,
+   `${radii[0].toFixed(1)}px → ${radii[radii.length - 1].toFixed(1)}px`);
+ok("impact ring actually travels", radii[radii.length - 1] > radii[0] * 2);
+ok("progress is monotonic across the window",
+   [...Array(50).keys()].every((i, _, a) => {
+     const t0 = i / 49, t1 = (i + 1) / 49;
+     return impactProgress(t1) >= impactProgress(t0);
+   }));
+
+// ── 3. hop falloff carries into the impact ──────────────────────────────────
+const at = (strength) => {
+  const r = recorder();
+  drawImpact({ ctx: r.ctx, x: 0, y: 0, r: 4, phase: 1, strength, color: "#fff", camScale: 1, glowSprite });
+  return Math.max(0, ...alphasOf(r.calls));
+};
+const [a1, a2, a3] = [at(1), at(0.22), at(0.22 ** 2)];
+ok("deeper hops strike dimmer", a1 > a2 && a2 > a3, `${a1.toFixed(2)} > ${a2.toFixed(2)} > ${a3.toFixed(2)}`);
+ok("third-level impact is nearly gone", a3 < 0.06, `${a3.toFixed(3)}`);
+ok("a vanishing impact draws nothing at all", at(0.001) === 0);
+
+// ── 4. spill is faint and finite ────────────────────────────────────────────
+const spillCalls = [];
+const strokeEdge = (e) => spillCalls.push({ e, alpha: sctx.globalAlpha });
+const sRec = recorder(); const sctx = sRec.ctx;
+drawSpill({ ctx: sctx, e: { id: "e1" }, phase: 1, strength: 1, color: "#fff", camScale: 1, strokeEdge });
+ok("spill peaks at the configured whisper", Math.abs(spillCalls[0].alpha - IMPACT_SPILL_ALPHA) < 1e-9,
+   `${spillCalls[0].alpha}`);
+ok("spill is far below the impact that causes it", IMPACT_SPILL_ALPHA < maxAlpha / 2.5);
+spillCalls.length = 0;
+drawSpill({ ctx: sctx, e: { id: "e2" }, phase: 0.01, strength: 0.05, color: "#fff", camScale: 1, strokeEdge });
+ok("an invisible spill is skipped, not drawn", spillCalls.length === 0);
+
+// ── 5. selection: deterministic, bounded, never the chain's own strands ─────
+const node = (id) => ({ id, ringHidden: false });
+const nodes = [...Array(40).keys()].map((i) => node("n" + i));
+const hub = node("hub");
+const edges = nodes.map((n) => ({ s: hub, t: n }));
+const used = new Set([edges[0], edges[1]]);
+const seedFor = (id) => { let h = 0; for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) % 100000; return h; };
+
+const pick1 = spillEdgesFor("hub", edges, used, boltRnd, seedFor("hub"));
+const pick2 = spillEdgesFor("hub", edges, used, boltRnd, seedFor("hub"));
+ok("same node picks the same strands every flare", JSON.stringify(pick1) === JSON.stringify(pick2));
+ok("spill is capped", pick1.length <= IMPACT_SPILL_MAX, `${pick1.length} ≤ ${IMPACT_SPILL_MAX}`);
+ok("spill never re-uses a strand the chain is already using",
+   pick1.every((e) => !used.has(e)));
+const other = spillEdgesFor("hub", edges, used, boltRnd, seedFor("different-memory"));
+ok("a different identity picks a different fan", JSON.stringify(other) !== JSON.stringify(pick1));
+
+// hidden neighbours are skipped
+const hidden = edges.map((e, i) => (i % 2 ? { ...e, t: { ...e.t, ringHidden: true } } : e));
+const pickH = spillEdgesFor("hub", hidden, new Set(), boltRnd, seedFor("hub"));
+ok("drilled-away neighbours are never lit", pickH.every((e) => !e.t.ringHidden && !e.s.ringHidden));
+
+// a node with no free strands spills nothing
+ok("no free strand → no spill", spillEdgesFor("hub", edges, new Set(edges), boltRnd, 1).length === 0);

--- a/packages/daemon/scripts/verify-impact.mjs
+++ b/packages/daemon/scripts/verify-impact.mjs
@@ -23,8 +23,8 @@ import {
   boltRnd,
   legDurationFor,
   hopDelayFor,
-  CHAIN_MIN_LEG_MS,
-  CHAIN_MIN_HOP_DELAY_MS,
+  CHAIN_LEG_MS,
+  CHAIN_HOP_DELAY_MS,
 } from "../webui/js/bolt-styles.js";
 
 const ok = (name, cond, detail = "") => {
@@ -109,29 +109,27 @@ for (const ms of SLIDER) {
 }
 
 
-// ── 1d. the slider times the BOLT; what fires after gets its own time ───────
-// "die zeit der animation muss gemessen werden für die blitze, die anderen
-// verbindungen die dann feuern brauchen extra ihre zeit". Deriving the onward
-// chain from the slider means that at 300ms three levels arrive within 380ms
-// of each other, each lasting 300ms — not a chain travelling outward.
-const RATIO = 180 / 420;
-for (const ms of [300, 420, 1000, 2000, 4000]) {
+// ── 1d. the slider times level 1 ONLY — everything after is decoupled ───────
+// "Die Zeit am Regler ist einzig und allein die Zeit, in der der erste Blitz
+// auf erster Linie angezeigt wird. Die Folgeblitze dürfen nicht mit dieser
+// Zeit zusammenhängen." So the invariant is not a floor — it is INDEPENDENCE:
+// a following level's timing is byte-for-byte the same at 300ms and at 4s.
+const S1 = [300, 420, 1000, 2000, 4000];
+for (const ms of S1) {
   ok(`level 1 obeys the slider exactly at ${ms}ms`, legDurationFor(1, ms) === ms);
-  ok(`following levels get room at ${ms}ms`, legDurationFor(2, ms) >= CHAIN_MIN_LEG_MS,
-     `${legDurationFor(2, ms)}ms`);
-  ok(`levels stay apart at ${ms}ms`, hopDelayFor(ms, RATIO) >= CHAIN_MIN_HOP_DELAY_MS,
-     `${Math.round(hopDelayFor(ms, RATIO))}ms between levels`);
 }
-// the long end must be pure slider — no floor may touch the signed-off look
-for (const ms of [1000, 2000, 4000]) {
-  ok(`no floor bites at ${ms}ms`,
-     legDurationFor(2, ms) === ms && Math.abs(hopDelayFor(ms, RATIO) - ms * RATIO) < 1e-9,
-     `leg ${legDurationFor(2, ms)}ms, gap ${Math.round(hopDelayFor(ms, RATIO))}ms`);
-}
-// a following level must never be SHORTER than the bolt that spawned it
-for (const ms of [300, 420, 1000, 2000, 4000]) {
-  ok(`level 2 is never shorter than level 1 at ${ms}ms`, legDurationFor(2, ms) >= legDurationFor(1, ms));
-}
+const legFollow = S1.map((ms) => legDurationFor(2, ms));
+ok("a following level's duration never depends on the slider",
+   legFollow.every((v) => v === CHAIN_LEG_MS), `[${legFollow.join(", ")}]`);
+const delays = S1.map(() => hopDelayFor());
+ok("the gap between levels never depends on the slider",
+   delays.every((v) => v === CHAIN_HOP_DELAY_MS), `[${delays.join(", ")}]`);
+// hop 3 is timed the same way as hop 2 — both are followers
+ok("all following levels share one fixed duration",
+   legDurationFor(2, 300) === legDurationFor(3, 4000));
+// and a follower is a real, perceptible length regardless of a tiny slider
+ok("followers stay perceptible even at the shortest slider",
+   legDurationFor(2, 300) >= 250, `${legDurationFor(2, 300)}ms`);
 
 // ── 2. the impact stays under the origin flare ──────────────────────────────
 // origin supernova: ring alpha 0.75, halo up to 0.9, ring reach 80px

--- a/packages/daemon/scripts/verify-impact.mjs
+++ b/packages/daemon/scripts/verify-impact.mjs
@@ -11,6 +11,11 @@ import {
   IMPACT_AT,
   IMPACT_SPILL_AT,
   spillPhase,
+  impactWindow,
+  spillWindow,
+  tailMs,
+  IMPACT_MIN_MS,
+  SPILL_MIN_MS,
   IMPACT_SPILL_MAX,
   IMPACT_SPILL_ALPHA,
 } from "../webui/js/impact.js";
@@ -41,9 +46,10 @@ function recorder() {
 const glowSprite = () => ({ sprite: true });
 
 // ── 1. phase curve ──────────────────────────────────────────────────────────
-ok("phase is 0 while the bolt is still travelling", impactPhase(0) === 0 && impactPhase(IMPACT_AT) === 0);
-ok("phase is 0 once the leg is over", impactPhase(1) === 0 && impactPhase(1.2) === 0);
-const peak = [...Array(101).keys()].map((i) => ({ t: i / 100, p: impactPhase(i / 100) }))
+const REF = 420; // the shipped default duration
+ok("phase is 0 while the bolt is still travelling", impactPhase(0, REF) === 0 && impactPhase(IMPACT_AT * REF, REF) === 0);
+ok("phase is 0 once its own window is over", impactPhase(impactWindow(REF).start + impactWindow(REF).dur, REF) === 0);
+const peak = [...Array(101).keys()].map((i) => ({ t: i / 100, p: impactPhase((i / 100) * REF, REF) }))
   .reduce((a, b) => (b.p > a.p ? b : a));
 ok("phase peaks inside the arrival window", peak.p > 0.9 && peak.t > IMPACT_AT && peak.t < 1,
    `peak ${peak.p.toFixed(2)} at t=${peak.t}`);
@@ -56,13 +62,45 @@ ok("rises fast, decays slow", fall > rise * 1.5, `rise ${rise.toFixed(3)} vs fal
 // (which is how it started) flattens the two into a single event.
 ok("the spill starts after the strike", IMPACT_SPILL_AT > IMPACT_AT,
    `spill ${IMPACT_SPILL_AT} > impact ${IMPACT_AT}`);
-const firstImpact = [...Array(200).keys()].map((i) => i / 200).find((t) => impactPhase(t) > 0);
-const firstSpill = [...Array(200).keys()].map((i) => i / 200).find((t) => spillPhase(t) > 0);
+const firstImpact = [...Array(200).keys()].map((i) => i / 200).find((t) => impactPhase(t * REF, REF) > 0);
+const firstSpill = [...Array(200).keys()].map((i) => i / 200).find((t) => spillPhase(t * REF, REF) > 0);
 ok("nothing spills before the strike is visible", firstSpill > firstImpact,
    `impact from t=${firstImpact.toFixed(3)}, spill from t=${firstSpill.toFixed(3)}`);
-ok("both are done by the end of the leg", impactPhase(0.999) >= 0 && spillPhase(1) === 0);
+ok("both fade to nothing eventually", impactPhase(9999, REF) === 0 && spillPhase(9999, REF) === 0);
 // and the strike itself must not sit at the very end of the travel
 ok("the strike is not late in the leg", IMPACT_AT < 0.5, `IMPACT_AT ${IMPACT_AT}`);
+
+
+// ── 1c. the slider must not be able to hide the afterglow ───────────────────
+// The bug this pins: every window used to be a FRACTION of the discharge, so
+// at 300ms the afterglow got 102ms — geometrically correct, perceptually gone,
+// while the same design read perfectly at 2s.
+const SLIDER = [300, 420, 700, 1000, 2000, 4000];
+const PERCEPTIBLE_MS = 250;
+for (const ms of SLIDER) {
+  const s = spillWindow(ms), i = impactWindow(ms);
+  ok(`afterglow stays perceptible at ${ms}ms`, s.dur >= PERCEPTIBLE_MS,
+     `${Math.round(s.dur)}ms`);
+  ok(`strike stays perceptible at ${ms}ms`, i.dur >= PERCEPTIBLE_MS, `${Math.round(i.dur)}ms`);
+}
+// the 2s look is the reference — it must be untouched by the floors
+const ref2s = { i: impactWindow(2000), s: spillWindow(2000) };
+ok("the 2s reference is purely proportional (floors do not bite)",
+   Math.abs(ref2s.i.dur - 0.78 * 2000) < 1 && Math.abs(ref2s.s.dur - 0.34 * 2000) < 1,
+   `impact ${Math.round(ref2s.i.dur)}ms, spill ${Math.round(ref2s.s.dur)}ms`);
+// and the ordering survives everywhere
+for (const ms of SLIDER) {
+  const fi = [...Array(400).keys()].map((k) => (k / 400) * ms * 2).find((x) => impactPhase(x, ms) > 0);
+  const fs = [...Array(400).keys()].map((k) => (k / 400) * ms * 2).find((x) => spillPhase(x, ms) > 0);
+  ok(`strike still precedes afterglow at ${ms}ms`, fs > fi, `${Math.round(fi)}ms → ${Math.round(fs)}ms`);
+}
+// legs must be kept alive long enough for the tail
+for (const ms of SLIDER) {
+  const need = Math.max(impactWindow(ms).start + impactWindow(ms).dur,
+                        spillWindow(ms).start + spillWindow(ms).dur) - ms;
+  ok(`tail budget covers the overhang at ${ms}ms`, tailMs(ms) >= Math.max(0, need) - 1e-9,
+     `tail ${Math.round(tailMs(ms))}ms vs needed ${Math.round(Math.max(0, need))}ms`);
+}
 
 // ── 2. the impact stays under the origin flare ──────────────────────────────
 // origin supernova: ring alpha 0.75, halo up to 0.9, ring reach 80px
@@ -84,7 +122,7 @@ for (let i = 0; i <= 40; i++) {
   const r = recorder();
   drawImpact({
     ctx: r.ctx, x: 0, y: 0, r: 4, phase: 1 /* forced: isolate geometry */,
-    progress: impactProgress(t), strength: 1, color: "#fff", camScale: 1, glowSprite,
+    progress: impactProgress(t * REF, REF), strength: 1, color: "#fff", camScale: 1, glowSprite,
   });
   const arc = r.calls.find((c) => c.op === "arc");
   if (arc) radii.push(arc.r);
@@ -94,9 +132,9 @@ ok("impact ring never contracts", monotonic,
    `${radii[0].toFixed(1)}px → ${radii[radii.length - 1].toFixed(1)}px`);
 ok("impact ring actually travels", radii[radii.length - 1] > radii[0] * 2);
 ok("progress is monotonic across the window",
-   [...Array(50).keys()].every((i, _, a) => {
-     const t0 = i / 49, t1 = (i + 1) / 49;
-     return impactProgress(t1) >= impactProgress(t0);
+   [...Array(50).keys()].every((i) => {
+     const t0 = (i / 49) * REF, t1 = ((i + 1) / 49) * REF;
+     return impactProgress(t1, REF) >= impactProgress(t0, REF);
    }));
 
 // ── 3. hop falloff carries into the impact ──────────────────────────────────

--- a/packages/daemon/scripts/verify-impact.mjs
+++ b/packages/daemon/scripts/verify-impact.mjs
@@ -9,6 +9,8 @@ import {
   drawSpill,
   spillEdgesFor,
   IMPACT_AT,
+  IMPACT_SPILL_AT,
+  spillPhase,
   IMPACT_SPILL_MAX,
   IMPACT_SPILL_ALPHA,
 } from "../webui/js/impact.js";
@@ -48,6 +50,19 @@ ok("phase peaks inside the arrival window", peak.p > 0.9 && peak.t > IMPACT_AT &
 // rises faster than it falls — a strike, not a breath
 const rise = peak.t - IMPACT_AT, fall = 1 - peak.t;
 ok("rises fast, decays slow", fall > rise * 1.5, `rise ${rise.toFixed(3)} vs fall ${fall.toFixed(3)}`);
+
+// ── 1b. cause before consequence ────────────────────────────────────────────
+// The strike lands first, the neighbourhood answers after. Sharing one phase
+// (which is how it started) flattens the two into a single event.
+ok("the spill starts after the strike", IMPACT_SPILL_AT > IMPACT_AT,
+   `spill ${IMPACT_SPILL_AT} > impact ${IMPACT_AT}`);
+const firstImpact = [...Array(200).keys()].map((i) => i / 200).find((t) => impactPhase(t) > 0);
+const firstSpill = [...Array(200).keys()].map((i) => i / 200).find((t) => spillPhase(t) > 0);
+ok("nothing spills before the strike is visible", firstSpill > firstImpact,
+   `impact from t=${firstImpact.toFixed(3)}, spill from t=${firstSpill.toFixed(3)}`);
+ok("both are done by the end of the leg", impactPhase(0.999) >= 0 && spillPhase(1) === 0);
+// and the strike itself must not sit at the very end of the travel
+ok("the strike is not late in the leg", IMPACT_AT < 0.5, `IMPACT_AT ${IMPACT_AT}`);
 
 // ── 2. the impact stays under the origin flare ──────────────────────────────
 // origin supernova: ring alpha 0.75, halo up to 0.9, ring reach 80px

--- a/packages/daemon/webui/js/bolt-styles.js
+++ b/packages/daemon/webui/js/bolt-styles.js
@@ -23,6 +23,32 @@ export const BOLT_SPREAD_KEY = "bastra-vault-map-bolt-spread";
 export const BOLT_SPREAD_DEFAULT = 1;
 export const BOLT_SEGMENTS = 7; // zigzag points per bolt
 
+/** What the duration slider actually governs, and what it does not.
+ *
+ *  The slider sets the time for THE BOLT — the first-level discharge, the thing
+ *  the eye follows. The strands that fire afterwards are a separate event and
+ *  need their own room: deriving their duration from the slider means that at
+ *  300ms the onward chain gets 300ms per level and 128ms between levels, which
+ *  is not a chain travelling outward but three near-simultaneous twitches.
+ *
+ *  So levels beyond the first have a floor of their own, in real milliseconds.
+ *  Above ~520ms the slider is already more generous and nothing changes — the
+ *  long end of the range, including the 2s look, is untouched. */
+export const CHAIN_MIN_LEG_MS = 520; // a following level's own travel time
+export const CHAIN_MIN_HOP_DELAY_MS = 190; // and the gap before it starts
+
+/** Stagger between chain levels: a fraction of the discharge, but never so
+ *  small that the levels collapse into each other. */
+export function hopDelayFor(boltMs, ratio) {
+  return Math.max(CHAIN_MIN_HOP_DELAY_MS, boltMs * ratio);
+}
+
+/** How long one leg of the chain travels. Level 1 is the bolt itself and obeys
+ *  the slider exactly; later levels get their own minimum. */
+export function legDurationFor(hop, boltMs) {
+  return hop === 1 ? boltMs : Math.max(CHAIN_MIN_LEG_MS, boltMs);
+}
+
 /** Deterministic 0..1 value. */
 export function boltRnd(seed) {
   const x = Math.sin(seed * 12.9898) * 43758.5453;

--- a/packages/daemon/webui/js/bolt-styles.js
+++ b/packages/daemon/webui/js/bolt-styles.js
@@ -23,30 +23,32 @@ export const BOLT_SPREAD_KEY = "bastra-vault-map-bolt-spread";
 export const BOLT_SPREAD_DEFAULT = 1;
 export const BOLT_SEGMENTS = 7; // zigzag points per bolt
 
-/** What the duration slider actually governs, and what it does not.
+/** What the duration slider governs, and what it does NOT.
  *
- *  The slider sets the time for THE BOLT — the first-level discharge, the thing
- *  the eye follows. The strands that fire afterwards are a separate event and
- *  need their own room: deriving their duration from the slider means that at
- *  300ms the onward chain gets 300ms per level and 128ms between levels, which
- *  is not a chain travelling outward but three near-simultaneous twitches.
+ *  The slider is the time of the FIRST bolt — level 1, the discharge the eye
+ *  follows — and nothing else. Everything that fires afterwards (the onward
+ *  chain and its impacts) has its own fixed time, in real milliseconds,
+ *  completely decoupled from the slider.
  *
- *  So levels beyond the first have a floor of their own, in real milliseconds.
- *  Above ~520ms the slider is already more generous and nothing changes — the
- *  long end of the range, including the 2s look, is untouched. */
-export const CHAIN_MIN_LEG_MS = 520; // a following level's own travel time
-export const CHAIN_MIN_HOP_DELAY_MS = 190; // and the gap before it starts
+ *  This is the third attempt at it, so it is worth being blunt about why the
+ *  first two were wrong. Deriving a following level from the slider (`boltMs`
+ *  or `max(floor, boltMs)`) couples them back together at one end or the other:
+ *  at 300ms the whole chain fires inside a few hundred ms, at 2s the followers
+ *  balloon to 2s each. Both are "the followers depend on the slider", which is
+ *  exactly what must not happen. A constant is the only shape that does not. */
+export const CHAIN_LEG_MS = 680; // a following level's own travel time — fixed
+export const CHAIN_HOP_DELAY_MS = 300; // gap before the next level starts — fixed
 
-/** Stagger between chain levels: a fraction of the discharge, but never so
- *  small that the levels collapse into each other. */
-export function hopDelayFor(boltMs, ratio) {
-  return Math.max(CHAIN_MIN_HOP_DELAY_MS, boltMs * ratio);
+/** Start-to-start gap between chain levels. Constant: a following level's
+ *  timing has nothing to do with how long the first bolt is on screen. */
+export function hopDelayFor() {
+  return CHAIN_HOP_DELAY_MS;
 }
 
-/** How long one leg of the chain travels. Level 1 is the bolt itself and obeys
- *  the slider exactly; later levels get their own minimum. */
+/** How long one leg travels. Level 1 IS the bolt and obeys the slider; every
+ *  later level runs for the fixed CHAIN_LEG_MS regardless of the slider. */
 export function legDurationFor(hop, boltMs) {
-  return hop === 1 ? boltMs : Math.max(CHAIN_MIN_LEG_MS, boltMs);
+  return hop === 1 ? boltMs : CHAIN_LEG_MS;
 }
 
 /** Deterministic 0..1 value. */

--- a/packages/daemon/webui/js/bolt-styles.js
+++ b/packages/daemon/webui/js/bolt-styles.js
@@ -11,6 +11,8 @@
  *  large file (file-size convention).
  */
 
+import { IMPACT_LEAD_MS, IMPACT_MS } from "./impact.js";
+
 export const BOLT_STYLE_KEY = "bastra-vault-map-bolt-style";
 export const BOLT_MS_KEY = "bastra-vault-map-bolt-ms";
 export const BOLT_MS_DEFAULT = 420;
@@ -37,18 +39,28 @@ export const BOLT_SEGMENTS = 7; // zigzag points per bolt
  *  balloon to 2s each. Both are "the followers depend on the slider", which is
  *  exactly what must not happen. A constant is the only shape that does not. */
 export const CHAIN_LEG_MS = 680; // a following level's own travel time — fixed
-export const CHAIN_HOP_DELAY_MS = 300; // gap before the next level starts — fixed
-
-/** Start-to-start gap between chain levels. Constant: a following level's
- *  timing has nothing to do with how long the first bolt is on screen. */
-export function hopDelayFor() {
-  return CHAIN_HOP_DELAY_MS;
-}
 
 /** How long one leg travels. Level 1 IS the bolt and obeys the slider; every
  *  later level runs for the fixed CHAIN_LEG_MS regardless of the slider. */
 export function legDurationFor(hop, boltMs) {
   return hop === 1 ? boltMs : CHAIN_LEG_MS;
+}
+
+/** When level `hop` starts, in ms since the flash began.
+ *
+ *  The whole point (Daniel): each level fires only AFTER the previous level's
+ *  strike has fully played out — not gestured at with a fixed hop-delay while
+ *  the strike is still running. So level 1 is the bolt (slider-timed), and
+ *  every later level waits out the level before it: that level's own travel,
+ *  minus the strike's lead, plus the strike's full run. Each animation keeps
+ *  its own duration; they simply queue up, so nothing lands on top of anything
+ *  else and nothing gets cut off. */
+export function levelStartOffset(hop, boltMs) {
+  let off = 0;
+  for (let h = 1; h < hop; h++) {
+    off += legDurationFor(h, boltMs) - IMPACT_LEAD_MS + IMPACT_MS; // through h's strike
+  }
+  return off;
 }
 
 /** Deterministic 0..1 value. */

--- a/packages/daemon/webui/js/impact.js
+++ b/packages/daemon/webui/js/impact.js
@@ -19,19 +19,20 @@
 
 /** When on a leg's own 0..1 timeline the discharge counts as arrived.
  *
- *  Tuned down from 0.62: keying it to `pulse`, whose head only reaches the far
- *  end at t ≈ 0.87, made the strike feel like it came after the event rather
- *  than being it. The default style `bolt` puts its zigzag across the whole
- *  strand immediately, so the eye is already at the far node long before the
- *  slowest style gets there. */
-export const IMPACT_AT = 0.38;
+ *  Walked down 0.62 → 0.38 → 0.22 by eye. The first value was keyed to `pulse`,
+ *  whose head only reaches the far end at t ≈ 0.87; but the default style puts
+ *  its zigzag across the whole strand at once, so the eye is at the far node
+ *  almost immediately and anything later reads as lag. The strike is now near
+ *  the front of the leg — it IS the event, not a report of it. */
+export const IMPACT_AT = 0.22;
 
 /** When the spilled strands pick up, on the same 0..1 leg timeline.
  *
- *  Deliberately after IMPACT_AT: the strike lands, and only then does the
- *  neighbourhood answer. Firing both on one phase — which is what it did at
- *  first — collapses cause and consequence into a single flat event. */
-export const IMPACT_SPILL_AT = 0.56;
+ *  Deliberately well after IMPACT_AT: the strike lands, and the neighbourhood
+ *  answers a beat later. Firing both on one phase — which is what it did at
+ *  first — collapses cause and consequence into a single flat event. Widening
+ *  this gap is what "Einschlag früher, Rest später" means in numbers. */
+export const IMPACT_SPILL_AT = 0.66;
 
 /** How many of the target's other strands glow along. Three is the most that
  *  still reads as "a couple"; beyond that a hub turns into a starburst. */

--- a/packages/daemon/webui/js/impact.js
+++ b/packages/daemon/webui/js/impact.js
@@ -18,9 +18,20 @@
  */
 
 /** When on a leg's own 0..1 timeline the discharge counts as arrived.
- *  Matches `pulse`, whose head reaches the far end at t ≈ 0.87 — the strike
- *  starts just before the fastest style gets there, so no style lands late. */
-export const IMPACT_AT = 0.62;
+ *
+ *  Tuned down from 0.62: keying it to `pulse`, whose head only reaches the far
+ *  end at t ≈ 0.87, made the strike feel like it came after the event rather
+ *  than being it. The default style `bolt` puts its zigzag across the whole
+ *  strand immediately, so the eye is already at the far node long before the
+ *  slowest style gets there. */
+export const IMPACT_AT = 0.38;
+
+/** When the spilled strands pick up, on the same 0..1 leg timeline.
+ *
+ *  Deliberately after IMPACT_AT: the strike lands, and only then does the
+ *  neighbourhood answer. Firing both on one phase — which is what it did at
+ *  first — collapses cause and consequence into a single flat event. */
+export const IMPACT_SPILL_AT = 0.56;
 
 /** How many of the target's other strands glow along. Three is the most that
  *  still reads as "a couple"; beyond that a hub turns into a starburst. */
@@ -63,6 +74,14 @@ export function impactProgress(t) {
   if (t <= IMPACT_AT) return 0;
   if (t >= 1) return 1;
   return (t - IMPACT_AT) / (1 - IMPACT_AT);
+}
+
+/** Brightness of the spilled strands — same shape as impactPhase, but starting
+ *  later, so the glow trails the strike instead of sharing its instant. */
+export function spillPhase(t) {
+  if (t <= IMPACT_SPILL_AT || t >= 1) return 0;
+  const u = (t - IMPACT_SPILL_AT) / (1 - IMPACT_SPILL_AT);
+  return (Math.min(u / IMPACT_RISE, 1) * (1 - u)) / (1 - IMPACT_RISE);
 }
 
 /** The strike itself: a tight ring that opens once, plus a small core glow.

--- a/packages/daemon/webui/js/impact.js
+++ b/packages/daemon/webui/js/impact.js
@@ -17,23 +17,6 @@
  *  reading a large file (file-size convention).
  */
 
-/** When on a leg's own 0..1 timeline the discharge counts as arrived.
- *
- *  Walked down 0.62 → 0.38 → 0.22 by eye. The first value was keyed to `pulse`,
- *  whose head only reaches the far end at t ≈ 0.87; but the default style puts
- *  its zigzag across the whole strand at once, so the eye is at the far node
- *  almost immediately and anything later reads as lag. The strike is now near
- *  the front of the leg — it IS the event, not a report of it. */
-export const IMPACT_AT = 0.22;
-
-/** When the spilled strands pick up, on the same 0..1 leg timeline.
- *
- *  Deliberately well after IMPACT_AT: the strike lands, and the neighbourhood
- *  answers a beat later. Firing both on one phase — which is what it did at
- *  first — collapses cause and consequence into a single flat event. Widening
- *  this gap is what "Einschlag früher, Rest später" means in numbers. */
-export const IMPACT_SPILL_AT = 0.66;
-
 /** How many of the target's other strands glow along. Three is the most that
  *  still reads as "a couple"; beyond that a hub turns into a starburst. */
 export const IMPACT_SPILL_MAX = 3;
@@ -46,88 +29,72 @@ export const IMPACT_SPILL_ALPHA = 0.17;
  *  turn a single flare into hundreds of extra strokes per frame. */
 export const IMPACT_SPILL_BUDGET = 18;
 
-/** Floors in REAL milliseconds — the reason this module stopped working in
- *  normalised leg-time.
+/** Everything AFTER the bolt, in FIXED milliseconds.
  *
- *  Everything here used to be a fraction of the discharge duration, which is a
- *  slider running 300ms…4s. That scales the geometry correctly and the
- *  PERCEPTION not at all: at 2s the afterglow ran 680ms and read beautifully;
- *  at 300ms the same fraction gave it 102ms, which is below the threshold where
- *  a faint stroke registers as anything but a flicker. Same design, invisible.
+ *  THE RULE (Daniel, repeatedly, finally understood): the slider — `boltMs` —
+ *  is the display time of the FIRST bolt and NOTHING else. It must not appear
+ *  in any other animation, not as a duration and not as a start offset. Every
+ *  attempt that put `boltMs` (or `IMPACT_AT · boltMs`, or `max(floor, boltMs)`)
+ *  into the strike or the follow-up was wrong for the same reason: it let the
+ *  slider change an animation that is not the first bolt.
  *
- *  So the strike and the afterglow have a minimum lifetime in wall-clock time.
- *  Above roughly a second the proportional value already exceeds these and
- *  nothing changes — the 2s look Daniel signed off on is untouched. Below it,
- *  they stop shrinking and simply outlast the bolt, which is what an afterglow
- *  is entitled to do. */
-export const IMPACT_MIN_MS = 260;
-export const SPILL_MIN_MS = 420;
+ *  So the strike and the follow-up run on their OWN clock, measured from the
+ *  moment the bolt reaches the target (its travel end). That hand-off point is
+ *  the only place the bolt's length enters — as "when did the bolt finish", not
+ *  as a duration of anything downstream. Change these to retune; none of them
+ *  touches the slider. */
+export const IMPACT_LEAD_MS = 250; // strike fires this long BEFORE the bolt's travel ends
+export const IMPACT_MS = 2000; // strike animation length
+export const SPILL_GAP_MS = 90; // pause between strike and follow-up
+export const SPILL_MS = 1000; // follow-up animation length on the onward strands
 
-/** How long the strike lives, and when it starts, for a given discharge. */
-export function impactWindow(boltMs) {
-  return {
-    start: IMPACT_AT * boltMs,
-    dur: Math.max(IMPACT_MIN_MS, (1 - IMPACT_AT) * boltMs),
-  };
-}
-
-/** Same for the afterglow on the neighbouring strands. */
-export function spillWindow(boltMs) {
-  return {
-    start: IMPACT_SPILL_AT * boltMs,
-    dur: Math.max(SPILL_MIN_MS, (1 - IMPACT_SPILL_AT) * boltMs),
-  };
-}
-
-/** How long a leg needs to be kept alive after its own travel is over, so a
- *  strike or an afterglow with a floor is never cut off mid-fade. */
-export function tailMs(boltMs) {
-  const i = impactWindow(boltMs);
-  const s = spillWindow(boltMs);
-  return Math.max(0, i.start + i.dur - boltMs, s.start + s.dur - boltMs);
-}
-
-/** Where the rise finishes and the decay takes over, on the window's own 0..1
- *  axis. The quarter is what makes it read as a strike rather than a breath. */
+/** Rise/decay split of the 0→1→0 brightness curve. A quarter up, three
+ *  quarters down, so it reads as a strike and not a breath. */
 const IMPACT_RISE = 0.25;
 
-/** 0 → 1 → 0 over the arrival window: rises fast, falls slow. Returns 0 before
- *  the discharge has arrived, which is what keeps the strike off the origin.
- *
- *  Normalised so the peak really is 1: without the divisor the curve tops out
- *  at 1 - IMPACT_RISE, and every brightness downstream would silently inherit
- *  that factor — the strike would be dimmer than the constants claim, for no
- *  reason anyone could find later. */
+/** 0 → 1 → 0 over a window, normalised so the peak is a true 1. */
 function shape(u) {
   if (u <= 0 || u >= 1) return 0;
   return (Math.min(u / IMPACT_RISE, 1) * (1 - u)) / (1 - IMPACT_RISE);
 }
 
-/** Strike brightness at `ms` into the leg, for a discharge of `boltMs`. */
-export function impactPhase(ms, boltMs) {
-  const { start, dur } = impactWindow(boltMs);
-  return shape((ms - start) / dur);
-}
-
-/** Linear 0..1 across the same window — how FAR along the strike is, as
- *  opposed to how bright.
+/** Milliseconds since the strike fired.
  *
- *  These have to be two different numbers. Brightness rises and then falls, so
- *  anything geometric driven by it runs backwards for the first quarter: a ring
- *  sized off the phase starts wide, collapses inward as the strike brightens,
- *  and only then expands. An impact that implodes first is not a subtle bug —
- *  it is the opposite of the gesture. */
-export function impactProgress(ms, boltMs) {
-  const { start, dur } = impactWindow(boltMs);
-  return Math.max(0, Math.min(1, (ms - start) / dur));
+ *  The strike fires a FIXED IMPACT_LEAD_MS before the bolt finishes travelling
+ *  — the head reaches the target shortly before the tail burns out, and that is
+ *  when the hit should register. A constant lead, never a fraction of the
+ *  length: shorten the bolt and the end moves in, but the strike stays exactly
+ *  IMPACT_LEAD_MS ahead of it, at the same on-screen distance every time. This
+ *  `legDur` is the ONLY use of the bolt's length past the bolt itself. */
+function sinceArrival(legMs, legDur) {
+  return legMs - (legDur - IMPACT_LEAD_MS);
 }
 
-/** Brightness of the spilled strands — same shape as impactPhase, but starting
- *  later and living longer, so the glow trails the strike instead of sharing
- *  its instant and survives a short discharge. */
-export function spillPhase(ms, boltMs) {
-  const { start, dur } = spillWindow(boltMs);
-  return shape((ms - start) / dur);
+/** Strike brightness. Fixed IMPACT_MS window opening at the bolt's arrival. */
+export function impactPhase(legMs, legDur) {
+  return shape(sinceArrival(legMs, legDur) / IMPACT_MS);
+}
+
+/** How FAR along the strike is (linear 0..1), for the ring radius. Separate
+ *  from brightness: brightness rises then falls, and a radius driven by it
+ *  would implode before it expands. */
+export function impactProgress(legMs, legDur) {
+  return Math.max(0, Math.min(1, sinceArrival(legMs, legDur) / IMPACT_MS));
+}
+
+/** Follow-up brightness on the onward strands. Its own fixed SPILL_MS window,
+ *  opening after the strike has played out (IMPACT_MS + SPILL_GAP_MS past
+ *  arrival) — "nachdem die Einschlagsanimation gespielt hat". */
+export function spillPhase(legMs, legDur) {
+  return shape((sinceArrival(legMs, legDur) - IMPACT_MS - SPILL_GAP_MS) / SPILL_MS);
+}
+
+/** How long a leg must stay alive past its bolt so the whole fixed sequence
+ *  (strike → gap → follow-up) can finish. The strike opens IMPACT_LEAD_MS
+ *  before the bolt ends, so the sequence's end sits that much earlier too.
+ *  Constant — no slider term. */
+export function tailMs() {
+  return IMPACT_MS + SPILL_GAP_MS + SPILL_MS - IMPACT_LEAD_MS;
 }
 
 /** The strike itself: a tight ring that opens once, plus a small core glow.

--- a/packages/daemon/webui/js/impact.js
+++ b/packages/daemon/webui/js/impact.js
@@ -1,0 +1,137 @@
+/** What happens where a discharge LANDS (#216).
+ *
+ *  Until now only the origin flared: the memory that was touched got the ring
+ *  and the halo, and the strands carried light outward — but the far end of a
+ *  strand stayed dark. The light arrived nowhere. This module gives the arrival
+ *  its moment: a small strike at the node the bolt reaches, and a faint spill
+ *  of that node's OTHER strands, so the neighbourhood registers the hit without
+ *  competing with it.
+ *
+ *  The whole point is restraint. The origin is the event; an impact is the
+ *  consequence of an event, and a consequence that shouts as loud as its cause
+ *  reads as a second event. Every constant here is chosen to stay under the
+ *  origin flare, and the spill is deliberately at the edge of visibility —
+ *  "ein paar Stränge weiter leuchten, aber nicht so doll".
+ *
+ *  Split out of renderer.js, which is near the size where a small change means
+ *  reading a large file (file-size convention).
+ */
+
+/** When on a leg's own 0..1 timeline the discharge counts as arrived.
+ *  Matches `pulse`, whose head reaches the far end at t ≈ 0.87 — the strike
+ *  starts just before the fastest style gets there, so no style lands late. */
+export const IMPACT_AT = 0.62;
+
+/** How many of the target's other strands glow along. Three is the most that
+ *  still reads as "a couple"; beyond that a hub turns into a starburst. */
+export const IMPACT_SPILL_MAX = 3;
+
+/** Peak opacity of a spilled strand. Low on purpose — this is the quietest
+ *  mark on the map, and it should stay that way. */
+export const IMPACT_SPILL_ALPHA = 0.17;
+
+/** Ceiling for the spill selection across one chain, so a dense galaxy cannot
+ *  turn a single flare into hundreds of extra strokes per frame. */
+export const IMPACT_SPILL_BUDGET = 18;
+
+/** Where the rise finishes and the decay takes over, on the window's own 0..1
+ *  axis. The quarter is what makes it read as a strike rather than a breath. */
+const IMPACT_RISE = 0.25;
+
+/** 0 → 1 → 0 over the arrival window: rises fast, falls slow. Returns 0 before
+ *  the discharge has arrived, which is what keeps the strike off the origin.
+ *
+ *  Normalised so the peak really is 1: without the divisor the curve tops out
+ *  at 1 - IMPACT_RISE, and every brightness downstream would silently inherit
+ *  that factor — the strike would be dimmer than the constants claim, for no
+ *  reason anyone could find later. */
+export function impactPhase(t) {
+  if (t <= IMPACT_AT || t >= 1) return 0;
+  const u = (t - IMPACT_AT) / (1 - IMPACT_AT);
+  return (Math.min(u / IMPACT_RISE, 1) * (1 - u)) / (1 - IMPACT_RISE);
+}
+
+/** Linear 0..1 across the same window — how FAR along the strike is, as
+ *  opposed to how bright.
+ *
+ *  These have to be two different numbers. Brightness rises and then falls, so
+ *  anything geometric driven by it runs backwards for the first quarter: a ring
+ *  sized off the phase starts wide, collapses inward as the strike brightens,
+ *  and only then expands. An impact that implodes first is not a subtle bug —
+ *  it is the opposite of the gesture. */
+export function impactProgress(t) {
+  if (t <= IMPACT_AT) return 0;
+  if (t >= 1) return 1;
+  return (t - IMPACT_AT) / (1 - IMPACT_AT);
+}
+
+/** The strike itself: a tight ring that opens once, plus a small core glow.
+ *
+ *  `strength` already carries the chain's hop falloff, so a third-level impact
+ *  is a sixth of a first-level one without this function knowing about hops.
+ */
+export function drawImpact(s) {
+  const { ctx, x, y, r, phase, progress, strength, color, camScale, glowSprite } = s;
+  if (phase <= 0) return;
+  const amp = phase * strength;
+  if (amp < 0.02) return; // below this it is a wasted draw call, not a subtlety
+
+  // Ring: opens from the node and thins as it goes — driven by progress, so it
+  // only ever travels outward. Half the reach of the origin's supernova ring
+  // (80px): an arrival, not an announcement.
+  const ringR = r + (2 + (progress ?? 0) * 34) / camScale;
+  ctx.globalAlpha = Math.min(0.5, 0.62 * amp);
+  ctx.lineWidth = (1.6 * phase) / camScale;
+  ctx.strokeStyle = color;
+  ctx.beginPath();
+  ctx.arc(x, y, ringR, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Core: brief brightening of the node itself, so the hit is legible even
+  // when the ring has already left the node behind.
+  const gr = Math.max(r * 2.1, 13 / camScale);
+  ctx.globalAlpha = Math.min(0.62, 0.7 * amp);
+  ctx.drawImage(glowSprite(color), x - gr, y - gr, gr * 2, gr * 2);
+  ctx.globalAlpha = 1;
+}
+
+/** The spill: strands leaving the struck node that the chain does NOT use.
+ *
+ *  Selection is derived from the node's identity, never from the clock — the
+ *  same rule the chain itself follows. A lit strand claims two memories belong
+ *  together; that claim has to hold still between two flares, or the map is
+ *  just twinkling at people.
+ *
+ *  `rnd` is the shared deterministic hash so this file needs no clock and no
+ *  RNG of its own; `usedEdges` is the chain's own set, kept out so the spill
+ *  cannot double-draw a strand that is already carrying the discharge.
+ */
+export function spillEdgesFor(nodeId, edges, usedEdges, rnd, seed) {
+  const out = [];
+  for (const e of edges) {
+    if (out.length >= IMPACT_SPILL_MAX) break;
+    if (usedEdges.has(e)) continue;
+    const other = e.s?.id === nodeId ? e.t : e.t?.id === nodeId ? e.s : null;
+    if (!other || other.ringHidden) continue;
+    // Thin the candidates deterministically: taking simply "the first three"
+    // would always pick the same corner of a hub's fan.
+    if (rnd(seed + out.length * 53.7 + edges.indexOf(e) * 0.017) > 0.62) continue;
+    out.push(e);
+  }
+  return out;
+}
+
+/** Draw one spilled strand: the connection itself, barely lit, fading with the
+ *  same phase as the strike that caused it. No zigzag, no travelling head —
+ *  anything with motion of its own would read as a discharge rather than as
+ *  the glow around one. */
+export function drawSpill(s) {
+  const { ctx, e, phase, strength, color, camScale, strokeEdge } = s;
+  const amp = phase * strength;
+  if (amp < 0.015) return;
+  ctx.globalAlpha = IMPACT_SPILL_ALPHA * amp;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1 / camScale;
+  strokeEdge(e);
+  ctx.globalAlpha = 1;
+}

--- a/packages/daemon/webui/js/impact.js
+++ b/packages/daemon/webui/js/impact.js
@@ -46,6 +46,47 @@ export const IMPACT_SPILL_ALPHA = 0.17;
  *  turn a single flare into hundreds of extra strokes per frame. */
 export const IMPACT_SPILL_BUDGET = 18;
 
+/** Floors in REAL milliseconds — the reason this module stopped working in
+ *  normalised leg-time.
+ *
+ *  Everything here used to be a fraction of the discharge duration, which is a
+ *  slider running 300ms…4s. That scales the geometry correctly and the
+ *  PERCEPTION not at all: at 2s the afterglow ran 680ms and read beautifully;
+ *  at 300ms the same fraction gave it 102ms, which is below the threshold where
+ *  a faint stroke registers as anything but a flicker. Same design, invisible.
+ *
+ *  So the strike and the afterglow have a minimum lifetime in wall-clock time.
+ *  Above roughly a second the proportional value already exceeds these and
+ *  nothing changes — the 2s look Daniel signed off on is untouched. Below it,
+ *  they stop shrinking and simply outlast the bolt, which is what an afterglow
+ *  is entitled to do. */
+export const IMPACT_MIN_MS = 260;
+export const SPILL_MIN_MS = 420;
+
+/** How long the strike lives, and when it starts, for a given discharge. */
+export function impactWindow(boltMs) {
+  return {
+    start: IMPACT_AT * boltMs,
+    dur: Math.max(IMPACT_MIN_MS, (1 - IMPACT_AT) * boltMs),
+  };
+}
+
+/** Same for the afterglow on the neighbouring strands. */
+export function spillWindow(boltMs) {
+  return {
+    start: IMPACT_SPILL_AT * boltMs,
+    dur: Math.max(SPILL_MIN_MS, (1 - IMPACT_SPILL_AT) * boltMs),
+  };
+}
+
+/** How long a leg needs to be kept alive after its own travel is over, so a
+ *  strike or an afterglow with a floor is never cut off mid-fade. */
+export function tailMs(boltMs) {
+  const i = impactWindow(boltMs);
+  const s = spillWindow(boltMs);
+  return Math.max(0, i.start + i.dur - boltMs, s.start + s.dur - boltMs);
+}
+
 /** Where the rise finishes and the decay takes over, on the window's own 0..1
  *  axis. The quarter is what makes it read as a strike rather than a breath. */
 const IMPACT_RISE = 0.25;
@@ -57,10 +98,15 @@ const IMPACT_RISE = 0.25;
  *  at 1 - IMPACT_RISE, and every brightness downstream would silently inherit
  *  that factor — the strike would be dimmer than the constants claim, for no
  *  reason anyone could find later. */
-export function impactPhase(t) {
-  if (t <= IMPACT_AT || t >= 1) return 0;
-  const u = (t - IMPACT_AT) / (1 - IMPACT_AT);
+function shape(u) {
+  if (u <= 0 || u >= 1) return 0;
   return (Math.min(u / IMPACT_RISE, 1) * (1 - u)) / (1 - IMPACT_RISE);
+}
+
+/** Strike brightness at `ms` into the leg, for a discharge of `boltMs`. */
+export function impactPhase(ms, boltMs) {
+  const { start, dur } = impactWindow(boltMs);
+  return shape((ms - start) / dur);
 }
 
 /** Linear 0..1 across the same window — how FAR along the strike is, as
@@ -71,18 +117,17 @@ export function impactPhase(t) {
  *  sized off the phase starts wide, collapses inward as the strike brightens,
  *  and only then expands. An impact that implodes first is not a subtle bug —
  *  it is the opposite of the gesture. */
-export function impactProgress(t) {
-  if (t <= IMPACT_AT) return 0;
-  if (t >= 1) return 1;
-  return (t - IMPACT_AT) / (1 - IMPACT_AT);
+export function impactProgress(ms, boltMs) {
+  const { start, dur } = impactWindow(boltMs);
+  return Math.max(0, Math.min(1, (ms - start) / dur));
 }
 
 /** Brightness of the spilled strands — same shape as impactPhase, but starting
- *  later, so the glow trails the strike instead of sharing its instant. */
-export function spillPhase(t) {
-  if (t <= IMPACT_SPILL_AT || t >= 1) return 0;
-  const u = (t - IMPACT_SPILL_AT) / (1 - IMPACT_SPILL_AT);
-  return (Math.min(u / IMPACT_RISE, 1) * (1 - u)) / (1 - IMPACT_RISE);
+ *  later and living longer, so the glow trails the strike instead of sharing
+ *  its instant and survives a short discharge. */
+export function spillPhase(ms, boltMs) {
+  const { start, dur } = spillWindow(boltMs);
+  return shape((ms - start) / dur);
 }
 
 /** The strike itself: a tight ring that opens once, plus a small core glow.

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -16,6 +16,14 @@ import {
   BOLT_MS_MAX,
   BOLT_SPREAD_KEY,
 } from "./bolt-styles.js";
+import {
+  IMPACT_SPILL_BUDGET,
+  impactPhase,
+  impactProgress,
+  drawImpact,
+  drawSpill,
+  spillEdgesFor,
+} from "./impact.js";
 
 // Activity bolts (#217): a flaring node discharges along its connections.
 //
@@ -105,7 +113,10 @@ export function createRenderer(canvas, sim, initialHues) {
           const other = e.s?.id === from ? e.t : e.t?.id === from ? e.s : null;
           if (!other || other.ringHidden || seen.has(other.id)) continue;
           seen.add(other.id);
-          legs.push({ e, hop });
+          // `to` is the END the discharge travels toward — the edge alone does
+          // not say which of its two nodes gets struck, and the impact needs
+          // exactly that.
+          legs.push({ e, hop, to: other.id });
           next.push(other.id);
           taken++;
         }
@@ -113,6 +124,29 @@ export function createRenderer(canvas, sim, initialHues) {
       frontier = next;
     }
     return legs;
+  }
+
+  /** Which strands glow faintly around each struck node (impact.js).
+   *
+   *  Resolved once with the chain and kept on the flash, for the same reason
+   *  the chain is: the selection must not change between two flares of the
+   *  same memory. Only first-level impacts spill — deeper in the chain the
+   *  legs are already echoes, and an echo of an echo is noise.
+   */
+  function spillOf(legs) {
+    const used = new Set(legs.map((l) => l.e));
+    const byNode = new Map();
+    let budget = IMPACT_SPILL_BUDGET;
+    for (const leg of legs) {
+      if (budget <= 0) break;
+      if (leg.hop !== 1) continue;
+      const picked = spillEdgesFor(leg.to, sim.edges, used, boltRnd, idSeed(leg.to)).slice(0, budget);
+      if (!picked.length) continue;
+      for (const e of picked) used.add(e); // never spill the same strand twice
+      byNode.set(leg.to, picked);
+      budget -= picked.length;
+    }
+    return byNode;
   }
   let highlightLabelKey = null; // cloud label to keep bright while hovering
   let filterFn = null; // active sidebar filter — non-matching nodes dim
@@ -497,6 +531,39 @@ export function createRenderer(canvas, sim, initialHues) {
             spread: boltSpread,
             strokeEdge,
           });
+
+          // …and where it lands. The spill goes first so the struck node's
+          // own light sits on top of the strands it lit, not under them.
+          const phase = impactPhase(t);
+          if (phase <= 0) return;
+          const hit = sim.byId.get(leg.to);
+          if (!hit || hit.ringHidden) return;
+          const hop1 = BOLT_HOP_FALLOFF ** (leg.hop - 1);
+          for (const se of f.spill.get(leg.to) ?? []) {
+            if (se.s.ringHidden || se.t.ringHidden) continue;
+            drawSpill({
+              ctx,
+              e: se,
+              phase,
+              strength: hop1,
+              color: f.color,
+              camScale: camera.scale,
+              strokeEdge,
+            });
+          }
+          ctx.strokeStyle = f.color; // drawSpill/drawImpact reset alpha, not stroke
+          drawImpact({
+            ctx,
+            x: hit.x,
+            y: hit.y,
+            r: drawRadius(hit),
+            phase,
+            progress: impactProgress(t),
+            strength: hop1,
+            color: f.color,
+            camScale: camera.scale,
+            glowSprite,
+          });
         });
       }
       const ringT = Math.min((now - f.born) / 900, 1);
@@ -676,7 +743,8 @@ export function createRenderer(canvas, sim, initialHues) {
         prev.boltAt = now;
         return;
       }
-      flashes.set(id, { color, born: now, life: lifeMs, boltAt: now, links: boltChainOf(id) });
+      const links = boltChainOf(id);
+      flashes.set(id, { color, born: now, life: lifeMs, boltAt: now, links, spill: spillOf(links) });
     },
     setHover: (n) => (hover = n),
     setFocus: (n) => {

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -55,12 +55,9 @@ const BOLT_HOP_FALLOFF = 0.22; // visibility per level beyond the first
 // ("longer, parallel, rather than a short blast"), hence a slider instead of a
 // second hardcoded number.
 const BOLT_MS_DEFAULT = 420;
-// Stagger between levels as a FRACTION of the duration, not a fixed number of
-// ms: the chain has to keep its rhythm when the whole thing is stretched to 4s,
-// and a fraction below 1 also guarantees the levels overlap, so it never breaks
-// apart. Widened from 110/420 on Daniel's "Einschlag früher, Rest später" — the
-// onward chain now waits noticeably longer after the strike it follows.
-const BOLT_HOP_DELAY_RATIO = 180 / 420;
+// The stagger between levels is a fixed number of ms now (bolt-styles.js:
+// hopDelayFor) — a follower's timing is deliberately independent of the
+// slider, so there is no ratio here any more.
 const BOLT_TICK_MS = 55; // re-rolling the zigzag: below ~40ms it turns to noise
 const FLASH_LIFE_MAX = 20000; // ceiling, so constant access can't flare forever
 
@@ -507,15 +504,16 @@ export function createRenderer(canvas, sim, initialHues) {
       // flaring node stays the hero and the edges merely hint at where the
       // activity radiates.
       const chainAge = now - f.boltAt;
-      const hopDelay = hopDelayFor(boltMs, BOLT_HOP_DELAY_RATIO);
+      const hopDelay = hopDelayFor(); // fixed — a follower's start is not slider-timed
       const style = BOLT_STYLES[boltStyle] ?? null; // "off" resolves to nothing on purpose
-      // The window has to outlast the LONGEST leg plus its tail: later levels
-      // have their own floor (legDurationFor) and the impact/afterglow have
-      // theirs, and anything cut off here is cut off mid-fade — which is
-      // exactly how the afterglow went missing below ~1s while looking right
-      // at 2s.
-      const slowestLeg = legDurationFor(2, boltMs);
-      if (style && chainAge < slowestLeg + BOLT_HOPS * hopDelay + tailMs(slowestLeg) && f.links.length) {
+      // The window must outlast whichever finishes last: level 1 ends at
+      // boltMs (+tail), while the final follower starts at (HOPS-1)*hopDelay
+      // and runs CHAIN_LEG_MS (+tail). At a long slider level 1 wins; at a
+      // short one the followers do. Anything cut off here is cut off mid-fade.
+      const lvl1End = boltMs + tailMs(boltMs);
+      const followEnd =
+        (BOLT_HOPS - 1) * hopDelay + legDurationFor(2, boltMs) + tailMs(legDurationFor(2, boltMs));
+      if (style && chainAge < Math.max(lvl1End, followEnd) && f.links.length) {
         const tick = Math.floor(now / BOLT_TICK_MS);
         ctx.strokeStyle = f.color;
         ctx.lineJoin = "round";

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -15,6 +15,8 @@ import {
   BOLT_MS_MIN,
   BOLT_MS_MAX,
   BOLT_SPREAD_KEY,
+  hopDelayFor,
+  legDurationFor,
 } from "./bolt-styles.js";
 import {
   IMPACT_SPILL_BUDGET,
@@ -505,14 +507,15 @@ export function createRenderer(canvas, sim, initialHues) {
       // flaring node stays the hero and the edges merely hint at where the
       // activity radiates.
       const chainAge = now - f.boltAt;
-      const hopDelay = boltMs * BOLT_HOP_DELAY_RATIO;
+      const hopDelay = hopDelayFor(boltMs, BOLT_HOP_DELAY_RATIO);
       const style = BOLT_STYLES[boltStyle] ?? null; // "off" resolves to nothing on purpose
-      // The window has to outlast the bolt by the impact/afterglow tail: at
-      // short durations those have a millisecond floor and would otherwise be
-      // cut off mid-fade — which is exactly how the afterglow went missing
-      // below ~1s while looking right at 2s.
-      const tail = tailMs(boltMs);
-      if (style && chainAge < boltMs + BOLT_HOPS * hopDelay + tail && f.links.length) {
+      // The window has to outlast the LONGEST leg plus its tail: later levels
+      // have their own floor (legDurationFor) and the impact/afterglow have
+      // theirs, and anything cut off here is cut off mid-fade — which is
+      // exactly how the afterglow went missing below ~1s while looking right
+      // at 2s.
+      const slowestLeg = legDurationFor(2, boltMs);
+      if (style && chainAge < slowestLeg + BOLT_HOPS * hopDelay + tailMs(slowestLeg) && f.links.length) {
         const tick = Math.floor(now / BOLT_TICK_MS);
         ctx.strokeStyle = f.color;
         ctx.lineJoin = "round";
@@ -521,9 +524,13 @@ export function createRenderer(canvas, sim, initialHues) {
           if (e.s.ringHidden || e.t.ringHidden) return;
           // each level starts a little later, so the discharge visibly runs on
           // instead of every leg lighting up at once
+          // The slider times the BOLT; a level that fires afterwards gets its
+          // own travel time, or a short discharge would compress the whole
+          // chain into one twitch.
+          const legDur = legDurationFor(leg.hop, boltMs);
           const legMs = chainAge - (leg.hop - 1) * hopDelay;
-          const t = legMs / boltMs;
-          if (legMs <= 0 || t >= 1 + tail / boltMs) return;
+          const t = legMs / legDur;
+          if (legMs <= 0 || legMs >= legDur + tailMs(legDur)) return;
           // fast in, slow out — activity strikes and then burns down
           const strength = Math.min(t * 6, 1) * (1 - t) * BOLT_HOP_FALLOFF ** (leg.hop - 1);
           // WHICH strands and HOW STRONG is settled here; WHAT is painted on
@@ -548,8 +555,8 @@ export function createRenderer(canvas, sim, initialHues) {
 
           // …and where it lands. The spill goes first so the struck node's
           // own light sits on top of the strands it lit, not under them.
-          const phase = impactPhase(legMs, boltMs);
-          const sPhase = spillPhase(legMs, boltMs); // trails the strike, see impact.js
+          const phase = impactPhase(legMs, legDur);
+          const sPhase = spillPhase(legMs, legDur); // trails the strike, see impact.js
           if (phase <= 0 && sPhase <= 0) return;
           const hit = sim.byId.get(leg.to);
           if (!hit || hit.ringHidden) return;
@@ -573,7 +580,7 @@ export function createRenderer(canvas, sim, initialHues) {
             y: hit.y,
             r: drawRadius(hit),
             phase,
-            progress: impactProgress(legMs, boltMs),
+            progress: impactProgress(legMs, legDur),
             strength: hop1,
             color: f.color,
             camScale: camera.scale,

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -21,6 +21,7 @@ import {
   impactPhase,
   impactProgress,
   spillPhase,
+  tailMs,
   drawImpact,
   drawSpill,
   spillEdgesFor,
@@ -506,7 +507,12 @@ export function createRenderer(canvas, sim, initialHues) {
       const chainAge = now - f.boltAt;
       const hopDelay = boltMs * BOLT_HOP_DELAY_RATIO;
       const style = BOLT_STYLES[boltStyle] ?? null; // "off" resolves to nothing on purpose
-      if (style && chainAge < boltMs + BOLT_HOPS * hopDelay && f.links.length) {
+      // The window has to outlast the bolt by the impact/afterglow tail: at
+      // short durations those have a millisecond floor and would otherwise be
+      // cut off mid-fade — which is exactly how the afterglow went missing
+      // below ~1s while looking right at 2s.
+      const tail = tailMs(boltMs);
+      if (style && chainAge < boltMs + BOLT_HOPS * hopDelay + tail && f.links.length) {
         const tick = Math.floor(now / BOLT_TICK_MS);
         ctx.strokeStyle = f.color;
         ctx.lineJoin = "round";
@@ -515,34 +521,39 @@ export function createRenderer(canvas, sim, initialHues) {
           if (e.s.ringHidden || e.t.ringHidden) return;
           // each level starts a little later, so the discharge visibly runs on
           // instead of every leg lighting up at once
-          const t = (chainAge - (leg.hop - 1) * hopDelay) / boltMs;
-          if (t <= 0 || t >= 1) return;
+          const legMs = chainAge - (leg.hop - 1) * hopDelay;
+          const t = legMs / boltMs;
+          if (legMs <= 0 || t >= 1 + tail / boltMs) return;
           // fast in, slow out — activity strikes and then burns down
           const strength = Math.min(t * 6, 1) * (1 - t) * BOLT_HOP_FALLOFF ** (leg.hop - 1);
           // WHICH strands and HOW STRONG is settled here; WHAT is painted on
           // them belongs to the chosen style (bolt-styles.js). Every style
           // draws on the strand's own curve — strokeEdge is handed over so the
           // lit connection is literally the same line the map draws.
-          style.draw({
-            ctx,
-            e,
-            cp: edgeBend(e),
-            t,
-            strength,
-            seed: tick + i * 131,
-            camScale: camera.scale,
-            spread: boltSpread,
-            strokeEdge,
-          });
+          // Only while the bolt is actually travelling: past t=1 the leg is
+          // kept alive purely for the tail, and `strength` has gone negative.
+          if (t < 1) {
+            style.draw({
+              ctx,
+              e,
+              cp: edgeBend(e),
+              t,
+              strength,
+              seed: tick + i * 131,
+              camScale: camera.scale,
+              spread: boltSpread,
+              strokeEdge,
+            });
+          }
 
           // …and where it lands. The spill goes first so the struck node's
           // own light sits on top of the strands it lit, not under them.
-          const phase = impactPhase(t);
-          if (phase <= 0) return;
+          const phase = impactPhase(legMs, boltMs);
+          const sPhase = spillPhase(legMs, boltMs); // trails the strike, see impact.js
+          if (phase <= 0 && sPhase <= 0) return;
           const hit = sim.byId.get(leg.to);
           if (!hit || hit.ringHidden) return;
           const hop1 = BOLT_HOP_FALLOFF ** (leg.hop - 1);
-          const sPhase = spillPhase(t); // trails the strike, see impact.js
           for (const se of f.spill.get(leg.to) ?? []) {
             if (se.s.ringHidden || se.t.ringHidden) continue;
             drawSpill({
@@ -562,7 +573,7 @@ export function createRenderer(canvas, sim, initialHues) {
             y: hit.y,
             r: drawRadius(hit),
             phase,
-            progress: impactProgress(t),
+            progress: impactProgress(legMs, boltMs),
             strength: hop1,
             color: f.color,
             camScale: camera.scale,

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -15,7 +15,7 @@ import {
   BOLT_MS_MIN,
   BOLT_MS_MAX,
   BOLT_SPREAD_KEY,
-  hopDelayFor,
+  levelStartOffset,
   legDurationFor,
 } from "./bolt-styles.js";
 import {
@@ -55,9 +55,9 @@ const BOLT_HOP_FALLOFF = 0.22; // visibility per level beyond the first
 // ("longer, parallel, rather than a short blast"), hence a slider instead of a
 // second hardcoded number.
 const BOLT_MS_DEFAULT = 420;
-// The stagger between levels is a fixed number of ms now (bolt-styles.js:
-// hopDelayFor) — a follower's timing is deliberately independent of the
-// slider, so there is no ratio here any more.
+// When each level starts is decided by levelStartOffset (bolt-styles.js): a
+// level fires only after the previous level's strike has finished, so there is
+// no per-level delay constant here any more.
 const BOLT_TICK_MS = 55; // re-rolling the zigzag: below ~40ms it turns to noise
 const FLASH_LIFE_MAX = 20000; // ceiling, so constant access can't flare forever
 
@@ -494,8 +494,23 @@ export function createRenderer(canvas, sim, initialHues) {
         flashes.delete(id);
         continue;
       }
-      const t = (now - f.born) / f.life;
-      if (t >= 1) {
+      const chainAge = now - f.boltAt;
+      // The cascade — bolt, strike, and the follow-up on the onward strands —
+      // runs on its OWN summed clock, not the notice's `life`. Each level fires
+      // only after the previous level's strike has played out (levelStartOffset),
+      // each animation keeps its own fixed duration, and the whole thing simply
+      // takes as long as it takes. NOTHING may be cut off, so the flash lives
+      // until BOTH the halo's life has elapsed AND the last level's sequence has
+      // finished — never the shorter of the two.
+      let cascadeEnd = 0;
+      for (let hop = 1; hop <= BOLT_HOPS; hop++) {
+        cascadeEnd = Math.max(
+          cascadeEnd,
+          levelStartOffset(hop, boltMs) + legDurationFor(hop, boltMs) + tailMs(),
+        );
+      }
+      const haloT = (now - f.born) / f.life;
+      if (haloT >= 1 && chainAge >= cascadeEnd) {
         flashes.delete(id);
         continue;
       }
@@ -503,17 +518,8 @@ export function createRenderer(canvas, sim, initialHues) {
       // Activity bolts FIRST: they run underneath the ring and the halo, so the
       // flaring node stays the hero and the edges merely hint at where the
       // activity radiates.
-      const chainAge = now - f.boltAt;
-      const hopDelay = hopDelayFor(); // fixed — a follower's start is not slider-timed
       const style = BOLT_STYLES[boltStyle] ?? null; // "off" resolves to nothing on purpose
-      // The window must outlast whichever finishes last: level 1 ends at
-      // boltMs (+tail), while the final follower starts at (HOPS-1)*hopDelay
-      // and runs CHAIN_LEG_MS (+tail). At a long slider level 1 wins; at a
-      // short one the followers do. Anything cut off here is cut off mid-fade.
-      const lvl1End = boltMs + tailMs(boltMs);
-      const followEnd =
-        (BOLT_HOPS - 1) * hopDelay + legDurationFor(2, boltMs) + tailMs(legDurationFor(2, boltMs));
-      if (style && chainAge < Math.max(lvl1End, followEnd) && f.links.length) {
+      if (style && chainAge < cascadeEnd && f.links.length) {
         const tick = Math.floor(now / BOLT_TICK_MS);
         ctx.strokeStyle = f.color;
         ctx.lineJoin = "round";
@@ -523,12 +529,13 @@ export function createRenderer(canvas, sim, initialHues) {
           // each level starts a little later, so the discharge visibly runs on
           // instead of every leg lighting up at once
           // The slider times the BOLT; a level that fires afterwards gets its
-          // own travel time, or a short discharge would compress the whole
-          // chain into one twitch.
+          // own travel time and starts only once the previous level's strike
+          // has finished (levelStartOffset), so the levels queue instead of
+          // overlapping.
           const legDur = legDurationFor(leg.hop, boltMs);
-          const legMs = chainAge - (leg.hop - 1) * hopDelay;
+          const legMs = chainAge - levelStartOffset(leg.hop, boltMs);
           const t = legMs / legDur;
-          if (legMs <= 0 || legMs >= legDur + tailMs(legDur)) return;
+          if (legMs <= 0 || legMs >= legDur + tailMs()) return;
           // fast in, slow out — activity strikes and then burns down
           const strength = Math.min(t * 6, 1) * (1 - t) * BOLT_HOP_FALLOFF ** (leg.hop - 1);
           // WHICH strands and HOW STRONG is settled here; WHAT is painted on
@@ -596,11 +603,16 @@ export function createRenderer(canvas, sim, initialHues) {
         ctx.arc(n.x, n.y, ringR, 0, Math.PI * 2);
         ctx.stroke();
       }
-      const ease = 1 - t * t;
-      const fr = Math.max(r * 4, 36 / camera.scale) * (1 + 0.15 * Math.sin(now / 160));
-      ctx.globalAlpha = Math.min(1, 0.9 * ease);
-      ctx.drawImage(glowSprite(f.color, theme.label), n.x - fr, n.y - fr, fr * 2, fr * 2);
-      ctx.globalAlpha = 1;
+      // Halo fades over the notice's own life. If the cascade outlasts it, the
+      // halo is simply gone by then while the strands keep animating — the
+      // origin glow was never meant to hold for a multi-second sequence.
+      if (haloT < 1) {
+        const ease = 1 - haloT * haloT;
+        const fr = Math.max(r * 4, 36 / camera.scale) * (1 + 0.15 * Math.sin(now / 160));
+        ctx.globalAlpha = Math.min(1, 0.9 * ease);
+        ctx.drawImage(glowSprite(f.color, theme.label), n.x - fr, n.y - fr, fr * 2, fr * 2);
+        ctx.globalAlpha = 1;
+      }
     }
 
     // ── overlay (live supernovae): after nodes, in every view ──

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -20,6 +20,7 @@ import {
   IMPACT_SPILL_BUDGET,
   impactPhase,
   impactProgress,
+  spillPhase,
   drawImpact,
   drawSpill,
   spillEdgesFor,
@@ -539,12 +540,13 @@ export function createRenderer(canvas, sim, initialHues) {
           const hit = sim.byId.get(leg.to);
           if (!hit || hit.ringHidden) return;
           const hop1 = BOLT_HOP_FALLOFF ** (leg.hop - 1);
+          const sPhase = spillPhase(t); // trails the strike, see impact.js
           for (const se of f.spill.get(leg.to) ?? []) {
             if (se.s.ringHidden || se.t.ringHidden) continue;
             drawSpill({
               ctx,
               e: se,
-              phase,
+              phase: sPhase,
               strength: hop1,
               color: f.color,
               camScale: camera.scale,

--- a/packages/daemon/webui/js/renderer.js
+++ b/packages/daemon/webui/js/renderer.js
@@ -52,10 +52,12 @@ const BOLT_HOP_FALLOFF = 0.22; // visibility per level beyond the first
 // ("longer, parallel, rather than a short blast"), hence a slider instead of a
 // second hardcoded number.
 const BOLT_MS_DEFAULT = 420;
-// Stagger between levels as a FRACTION of the duration, not a fixed 110ms: the
-// chain has to keep its rhythm when the whole thing is stretched to 4s, and a
-// fraction below 1 also guarantees the levels overlap, so it never breaks apart.
-const BOLT_HOP_DELAY_RATIO = 110 / 420;
+// Stagger between levels as a FRACTION of the duration, not a fixed number of
+// ms: the chain has to keep its rhythm when the whole thing is stretched to 4s,
+// and a fraction below 1 also guarantees the levels overlap, so it never breaks
+// apart. Widened from 110/420 on Daniel's "Einschlag früher, Rest später" — the
+// onward chain now waits noticeably longer after the strike it follows.
+const BOLT_HOP_DELAY_RATIO = 180 / 420;
 const BOLT_TICK_MS = 55; // re-rolling the zigzag: below ~40ms it turns to noise
 const FLASH_LIFE_MAX = 20000; // ceiling, so constant access can't flare forever
 


### PR DESCRIPTION
Adds the arrival half of the activity animation on the vault map — the strike where a bolt lands and the follow-up on the target's onward strands — and fixes the timing model so the duration slider governs only the first bolt.

Frontend only (`packages/daemon/webui/js/`). Verified without a browser via a canvas-recording stub (Chrome automation is unavailable here); two scripts under `packages/daemon/scripts/` pin the invariants.

## The rule

The duration slider is the display time of the **first bolt** and nothing else. Every other animation runs on its own fixed-millisecond clock, independent of the slider and of each other. The levels **queue** — each fires only once the previous level's strike has fully played out — so each animation keeps its own length and nothing gets cut off.

## What landed

- **Impact + spill** (`impact.js`): a strike at the struck node, then a faint glow on a couple of its other strands ("ein paar Stränge weiter leuchten, aber nicht so doll"). Both stay under the origin flare; spill selection is deterministic per node id.
- **Strike timing:** fires a fixed `IMPACT_LEAD_MS` before the bolt ends (not a fraction of its length), with its own fixed `IMPACT_MS` duration.
- **Sequential cascade** (`levelStartOffset` in `bolt-styles.js`): level 2 begins exactly as level 1's strike ends, level 3 after level 2's — measured 3750 ms at a 2000 ms slider.
- **Nothing cut off** (`renderer.js`): the flash lives until both the notice's halo life has elapsed **and** the whole cascade has finished, instead of a fixed `life` that guillotined the sequence at 3 s.

## Verification

`scripts/verify-impact.mjs` (51 checks) + `verify-impact-wiring.mjs` (9): strike fires the fixed lead before the end at every slider position; strike/follow-up profiles identical across the whole slider range; each level starts as the previous strike ends; the cascade runs to completion under a short notice-life.

🤖 Generated with [Claude Code](https://claude.com/claude-code)